### PR TITLE
fix: chip label with stage name and correct suffix

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-03T11:56:45.782Z\n"
-"PO-Revision-Date: 2022-03-03T11:56:45.782Z\n"
+"POT-Creation-Date: 2022-03-04T06:58:11.681Z\n"
+"PO-Revision-Date: 2022-03-04T06:58:11.681Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -234,6 +234,9 @@ msgstr "Searching for \"{{searchText}}\""
 
 msgid "No results found"
 msgstr "No results found"
+
+msgid "all"
+msgstr "all"
 
 msgid "{{count}} selected"
 msgid_plural "{{count}} selected"

--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -158,6 +158,10 @@ const OuterDndContext = ({ children }) => {
             dimension = metadata[rawDimensionId]
         }
 
+        if (!dimension) {
+            return null
+        }
+
         if (SOURCE_DIMENSIONS.includes(sourceAxis)) {
             return (
                 <div className={cx(styles.overlay, styles.dimensionItem)}>

--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -16,7 +16,6 @@ import {
     acSetUiLayout,
     acSetUiDraggingId,
 } from '../actions/ui.js'
-import { parseConditionsStringToArray } from '../modules/conditions.js'
 import { sGetMetadata } from '../reducers/metadata.js'
 import {
     sGetUiLayout,
@@ -151,32 +150,21 @@ const OuterDndContext = ({ children }) => {
         // is a temporary workaround
         // until the backend is updated to return programStageId.dimensionId
         // in analytics response.metadata.items
-        let name
-        let dimensionType
+        let dimension
         if (metadata[id]) {
-            name = metadata[id].name || ''
-            dimensionType = metadata[id].dimensionType || null
+            dimension = metadata[id]
         } else {
             const [rawDimensionId] = id.split('.').reverse()
-            name = metadata[rawDimensionId]?.name || ''
-            dimensionType = metadata[rawDimensionId]?.dimensionType || null
+            dimension = metadata[rawDimensionId]
         }
 
         if (SOURCE_DIMENSIONS.includes(sourceAxis)) {
             return (
                 <div className={cx(styles.overlay, styles.dimensionItem)}>
-                    <DimensionItemBase
-                        name={name}
-                        dimensionType={dimensionType}
-                        dragging={true}
-                    />
+                    <DimensionItemBase {...dimension} dragging={true} />
                 </div>
             )
         }
-
-        const numberOfConditions =
-            parseConditionsStringToArray(chipConditions.condition).length ||
-            (chipConditions.legendSet ? 1 : 0)
 
         return (
             <div
@@ -188,15 +176,16 @@ const OuterDndContext = ({ children }) => {
                         [chipStyles.chipEmpty]:
                             sourceAxis === AXIS_ID_FILTERS &&
                             !chipItems.length &&
-                            !numberOfConditions,
+                            !chipConditions.condition?.length &&
+                            !chipConditions.legendSet,
                     }
                 )}
             >
                 <ChipBase
-                    dimensionName={name}
-                    dimensionType={dimensionType}
+                    dimension={dimension}
                     items={chipItems}
-                    numberOfConditions={numberOfConditions}
+                    conditions={chipConditions}
+                    metadata
                 />
             </div>
         )

--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -185,7 +185,7 @@ const OuterDndContext = ({ children }) => {
                     dimension={dimension}
                     items={chipItems}
                     conditions={chipConditions}
-                    metadata
+                    metadata={metadata}
                 />
             </div>
         )

--- a/src/components/Layout/ChipBase.js
+++ b/src/components/Layout/ChipBase.js
@@ -12,6 +12,9 @@ import { DIMENSION_TYPE_PERIOD } from '../../modules/dimensionConstants.js'
 import { DimensionIcon } from '../MainSidebar/DimensionItem/DimensionIcon.js'
 import styles from './styles/Chip.module.css'
 
+const VALUE_TYPE_TRUE_ONLY_NUM_OPTIONS = 2
+const VALUE_TYPE_BOOLEAN_NUM_OPTIONS = 3
+
 // Presentational component used by dnd - do not add redux or dnd functionality
 
 const getChipSuffix = ({
@@ -39,8 +42,10 @@ const getChipSuffix = ({
     const conds = getConditions({ conditions, metadata, dimension })
 
     if (
-        (valueType === VALUE_TYPE_TRUE_ONLY && conds.length === 2) ||
-        (valueType === VALUE_TYPE_BOOLEAN && conds.length === 3)
+        (valueType === VALUE_TYPE_TRUE_ONLY &&
+            conds.length === VALUE_TYPE_TRUE_ONLY_NUM_OPTIONS) ||
+        (valueType === VALUE_TYPE_BOOLEAN &&
+            conds.length === VALUE_TYPE_BOOLEAN_NUM_OPTIONS)
     ) {
         return `: ${all}`
     }

--- a/src/components/Layout/ChipBase.js
+++ b/src/components/Layout/ChipBase.js
@@ -67,14 +67,19 @@ const getChipSuffix = ({
 }
 
 export const ChipBase = (props) => {
-    const { name, dimensionType } = props.dimension
+    const { name, dimensionType, stageName } = props.dimension
     return (
         <div className={cx(styles.chipBase)}>
             <div className={styles.leftIcon}>
                 <DimensionIcon dimensionType={dimensionType} />
             </div>
-            <span className={styles.label}>{name}</span>
-            <span className={styles.label}>{getChipSuffix(props)}</span>
+            <span className={styles.label}>
+                <span className={styles.primary}>{name}</span>
+                {stageName && (
+                    <span className={styles.secondary}>{stageName}</span>
+                )}
+            </span>
+            <span className={styles.suffix}>{getChipSuffix(props)}</span>
         </div>
     )
 }

--- a/src/components/Layout/ChipBase.js
+++ b/src/components/Layout/ChipBase.js
@@ -17,62 +17,58 @@ const VALUE_TYPE_BOOLEAN_NUM_OPTIONS = 3
 
 // Presentational component used by dnd - do not add redux or dnd functionality
 
-const getChipSuffix = ({
-    dimension,
-    conditions = {},
-    items = [],
-    metadata,
-}) => {
-    const { id, dimensionType, optionSet, valueType } = dimension
+export const ChipBase = ({ dimension, conditions, items, metadata }) => {
+    const { id, name, dimensionType, optionSet, valueType, stageName } =
+        dimension
 
-    if (
-        (id === DIMENSION_ID_ORGUNIT ||
-            dimensionType === DIMENSION_TYPE_PERIOD) &&
-        !items.length
-    ) {
+    const getChipSuffix = () => {
+        if (
+            (id === DIMENSION_ID_ORGUNIT ||
+                dimensionType === DIMENSION_TYPE_PERIOD) &&
+            !items.length
+        ) {
+            return ''
+        }
+
+        const all = i18n.t('all')
+
+        if (!conditions.condition && !conditions.legendSet && !items.length) {
+            return `: ${all}`
+        }
+
+        const conds = getConditions({ conditions, metadata, dimension })
+
+        if (
+            (valueType === VALUE_TYPE_TRUE_ONLY &&
+                conds.length === VALUE_TYPE_TRUE_ONLY_NUM_OPTIONS) ||
+            (valueType === VALUE_TYPE_BOOLEAN &&
+                conds.length === VALUE_TYPE_BOOLEAN_NUM_OPTIONS)
+        ) {
+            return `: ${all}`
+        }
+
+        const numberOfConditions = conds.length
+
+        if (optionSet || items.length) {
+            const selected = items.length || numberOfConditions
+            const suffix = i18n.t('{{count}} selected', {
+                count: selected,
+                defaultValue: '{{count}} selected',
+                defaultValue_plural: '{{count}} selected',
+            })
+            return `: ${suffix}`
+        } else if (numberOfConditions) {
+            const suffix = i18n.t('{{count}} conditions', {
+                count: numberOfConditions,
+                defaultValue: '{{count}} condition',
+                defaultValue_plural: '{{count}} conditions',
+            })
+            return `: ${suffix}`
+        }
+
         return ''
     }
 
-    const all = i18n.t('all')
-
-    if (!conditions.condition && !conditions.legendSet && !items.length) {
-        return `: ${all}`
-    }
-
-    const conds = getConditions({ conditions, metadata, dimension })
-
-    if (
-        (valueType === VALUE_TYPE_TRUE_ONLY &&
-            conds.length === VALUE_TYPE_TRUE_ONLY_NUM_OPTIONS) ||
-        (valueType === VALUE_TYPE_BOOLEAN &&
-            conds.length === VALUE_TYPE_BOOLEAN_NUM_OPTIONS)
-    ) {
-        return `: ${all}`
-    }
-
-    const numberOfConditions = conds.length
-
-    let suffix = ''
-    if (optionSet || items.length) {
-        const selected = items.length || numberOfConditions
-
-        suffix = i18n.t('{{count}} selected', {
-            count: selected,
-            defaultValue: '{{count}} selected',
-            defaultValue_plural: '{{count}} selected',
-        })
-    } else if (numberOfConditions) {
-        suffix = i18n.t('{{count}} conditions', {
-            count: numberOfConditions,
-            defaultValue: '{{count}} condition',
-            defaultValue_plural: '{{count}} conditions',
-        })
-    }
-    return suffix ? `: ${suffix}` : ''
-}
-
-export const ChipBase = (props) => {
-    const { name, dimensionType, stageName } = props.dimension
     return (
         <div className={cx(styles.chipBase)}>
             <div className={styles.leftIcon}>
@@ -84,11 +80,27 @@ export const ChipBase = (props) => {
                     <span className={styles.secondary}>{stageName}</span>
                 )}
             </span>
-            <span className={styles.suffix}>{getChipSuffix(props)}</span>
+            <span className={styles.suffix}>{getChipSuffix()}</span>
         </div>
     )
 }
 
 ChipBase.propTypes = {
-    dimension: PropTypes.object,
+    conditions: PropTypes.object,
+    dimension: PropTypes.shape({
+        dimensionType: PropTypes.string,
+        id: PropTypes.string,
+        name: PropTypes.string,
+        optionSet: PropTypes.string,
+        stageName: PropTypes.string,
+        valueType: PropTypes.string,
+    }),
+    items: PropTypes.array,
+    metadata: PropTypes.object,
+}
+
+ChipBase.defaultProps = {
+    conditions: {},
+    items: [],
+    metadata: {},
 }

--- a/src/components/Layout/ChipBase.js
+++ b/src/components/Layout/ChipBase.js
@@ -1,48 +1,84 @@
+import { DIMENSION_ID_ORGUNIT } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+import {
+    VALUE_TYPE_BOOLEAN,
+    VALUE_TYPE_TRUE_ONLY,
+    getConditions,
+} from '../../modules/conditions.js'
+import { DIMENSION_TYPE_PERIOD } from '../../modules/dimensionConstants.js'
 import { DimensionIcon } from '../MainSidebar/DimensionItem/DimensionIcon.js'
 import styles from './styles/Chip.module.css'
 
 // Presentational component used by dnd - do not add redux or dnd functionality
 
-const renderChipLabelSuffix = (items, numberOfConditions) => {
-    let itemsLabel = ''
-    if (items.length) {
-        itemsLabel = i18n.t('{{count}} selected', {
-            count: items.length,
+const getChipSuffix = ({
+    dimension,
+    conditions = {},
+    items = [],
+    metadata,
+}) => {
+    const { id, dimensionType, optionSet, valueType } = dimension
+
+    if (
+        (id === DIMENSION_ID_ORGUNIT ||
+            dimensionType === DIMENSION_TYPE_PERIOD) &&
+        !items.length
+    ) {
+        return ''
+    }
+
+    const all = i18n.t('all')
+
+    if (!conditions.condition && !conditions.legendSet && !items.length) {
+        return `: ${all}`
+    }
+
+    const conds = getConditions({ conditions, metadata, dimension })
+
+    if (
+        (valueType === VALUE_TYPE_TRUE_ONLY && conds.length === 2) ||
+        (valueType === VALUE_TYPE_BOOLEAN && conds.length === 3)
+    ) {
+        return `: ${all}`
+    }
+
+    const numberOfConditions = conds.length
+
+    let suffix = ''
+    if (optionSet || items.length) {
+        const selected = items.length || numberOfConditions
+
+        suffix = i18n.t('{{count}} selected', {
+            count: selected,
+            defaultValue: '{{count}} selected',
+            defaultValue_plural: '{{count}} selected',
         })
     } else if (numberOfConditions) {
-        itemsLabel = i18n.t('{{count}} conditions', {
+        suffix = i18n.t('{{count}} conditions', {
             count: numberOfConditions,
             defaultValue: '{{count}} condition',
             defaultValue_plural: '{{count}} conditions',
         })
     }
-    return itemsLabel ? `: ${itemsLabel}` : ''
+    return suffix ? `: ${suffix}` : ''
 }
 
-export const ChipBase = ({
-    dimensionName,
-    dimensionType,
-    items,
-    numberOfConditions,
-}) => (
-    <div className={cx(styles.chipBase)}>
-        <div className={styles.leftIcon}>
-            <DimensionIcon dimensionType={dimensionType} />
+export const ChipBase = (props) => {
+    const { name, dimensionType } = props.dimension
+    return (
+        <div className={cx(styles.chipBase)}>
+            <div className={styles.leftIcon}>
+                <DimensionIcon dimensionType={dimensionType} />
+            </div>
+            <span className={styles.label}>{name}</span>
+            <span className={styles.label}>{getChipSuffix(props)}</span>
         </div>
-        <span className={styles.label}>{dimensionName}</span>
-        <span className={styles.label}>
-            {renderChipLabelSuffix(items, numberOfConditions)}
-        </span>
-    </div>
-)
+    )
+}
 
 ChipBase.propTypes = {
-    dimensionName: PropTypes.string,
-    dimensionType: PropTypes.string,
-    items: PropTypes.array,
-    numberOfConditions: PropTypes.number,
+    dimension: PropTypes.object,
 }

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -11,7 +11,7 @@ import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
 import { sGetMetadata, sGetMetadataById } from '../../../reducers/metadata.js'
 import {
     sGetUiDraggingId,
-    sGetUiDimensionIdsForLayoutAxis,
+    sGetUiDimensionIdsByAxisId,
     sGetUiInputType,
     sGetUiProgramId,
     renderChipsSelector,
@@ -83,7 +83,7 @@ const DefaultAxis = ({ axisId, className }) => {
 
     const dispatch = useDispatch()
     const dimensionIds = useSelector((state) =>
-        sGetUiDimensionIdsForLayoutAxis(state, axisId)
+        sGetUiDimensionIdsByAxisId(state, axisId)
     )
     const renderChips = useSelector(renderChipsSelector)
     const draggingId = useSelector(sGetUiDraggingId)

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -2,48 +2,113 @@ import { useDroppable } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React from 'react'
-import { connect, useSelector } from 'react-redux'
+import React, { useMemo } from 'react'
+import { connect, useSelector, useDispatch } from 'react-redux'
 import { createSelector } from 'reselect'
 import { acSetUiOpenDimensionModal } from '../../../actions/ui.js'
 import { getAxisName } from '../../../modules/axis.js'
-import { sGetMetadata } from '../../../reducers/metadata.js'
-import { sGetUiDraggingId, sGetUiLayout } from '../../../reducers/ui.js'
-import DimensionMenu from '../../DimensionMenu/DimensionMenu.js'
+import { DIMENSION_TYPE_DATA_ELEMENT } from '../../../modules/dimensionConstants.js'
+import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
+import { sGetMetadata, sGetMetadataById } from '../../../reducers/metadata.js'
+import {
+    sGetUiDraggingId,
+    sGetUiLayout,
+    sGetUiDimensionIdsForLayoutAxis,
+    sGetUiInputType,
+    sGetUiProgramId,
+} from '../../../reducers/ui.js'
 import { LAST, getDropzoneId } from '../../DndContext.js'
 import Chip from '../Chip.js'
 import { DropZone } from './DropZone.js'
 import styles from './styles/DefaultAxis.module.css'
 
-const DefaultAxis = ({
-    axis,
-    axisId,
-    getOpenHandler,
-    className,
-    renderChips,
+const getDimensionsWithStageName = ({
+    dimensionIds = [],
+    inputType,
+    programStageNames = [],
+    metadata = {},
 }) => {
-    const lastDropZoneId = getDropzoneId(axisId, LAST)
-    const { over, setNodeRef } = useDroppable({
-        id: lastDropZoneId,
-    })
-    const draggingId = useSelector(sGetUiDraggingId)
-    const metadata = useSelector(sGetMetadata)
+    let hasDuplicates = false
+    const dataElements = new Map()
 
-    // TODO - using the rawDimensionId instead of dimensionId
-    // is a temporary workaround
-    // until the backend is updated to return programStageId.dimensionId
-    // in analytics response.metadata.items
-    const getDimension = (id) => {
-        let dimension
+    const dimensions = dimensionIds.map((id) => {
+        let dimension = {}
         if (metadata[id]?.name) {
             dimension = metadata[id]
         } else {
             const [rawDimensionId] = id.split('.').reverse()
             dimension = metadata[rawDimensionId]
         }
+        return dimension
+    })
 
-        return dimension || {}
+    if (inputType === OUTPUT_TYPE_ENROLLMENT) {
+        dimensions.forEach((dimension) => {
+            const dataElementId = dimension.id.split('.')[1]
+            if (
+                dimension.dimensionType === DIMENSION_TYPE_DATA_ELEMENT &&
+                dataElementId
+            ) {
+                const dataElementCount = dataElements.get(dataElementId)
+
+                if (dataElementCount) {
+                    dataElements.set(dataElementId, dataElementCount + 1)
+                    hasDuplicates = true
+                } else {
+                    dataElements.set(dataElementId, 1)
+                }
+            }
+        })
+
+        return hasDuplicates
+            ? dimensions.map((dimension) => {
+                  const [programStageId, dataElementId] =
+                      dimension.id.split('.')
+                  if (dataElementId && dataElements.get(dataElementId) > 1) {
+                      dimension.stageName =
+                          programStageNames?.get(programStageId)
+                  }
+                  return dimension
+              })
+            : dimensions
     }
+
+    return dimensions
+}
+
+const DefaultAxis = ({ axisId, className, renderChips }) => {
+    const lastDropZoneId = getDropzoneId(axisId, LAST)
+    const { over, setNodeRef } = useDroppable({
+        id: lastDropZoneId,
+    })
+
+    const dispatch = useDispatch()
+    const axis = useSelector((state) =>
+        sGetUiDimensionIdsForLayoutAxis(state, axisId)
+    )
+    const draggingId = useSelector(sGetUiDraggingId)
+    const metadata = useSelector(sGetMetadata)
+    const inputType = useSelector(sGetUiInputType)
+    const selectedProgramId = useSelector(sGetUiProgramId)
+    const program = useSelector((state) =>
+        sGetMetadataById(state, selectedProgramId)
+    )
+
+    const programStageNames = useMemo(
+        () =>
+            program?.programStages?.reduce((acc, stage) => {
+                acc.set(stage.id, stage.name)
+                return acc
+            }, new Map()),
+        [program]
+    )
+
+    const dimensions = getDimensionsWithStageName({
+        dimensionIds: axis,
+        inputType,
+        programStageNames,
+        metadata,
+    })
 
     const activeIndex = draggingId ? axis.indexOf(draggingId) : -1
 
@@ -65,11 +130,17 @@ const DefaultAxis = ({
                             overLastDropZone={overLastDropZone}
                         />
                         {renderChips &&
-                            axis.map((id, i) => (
+                            dimensions.map((dimension, i) => (
                                 <Chip
-                                    key={`${axisId}-${id}`}
-                                    onClick={getOpenHandler(id)}
-                                    dimension={getDimension(id)}
+                                    key={`${axisId}-${dimension.id}`}
+                                    onClick={() =>
+                                        dispatch(
+                                            acSetUiOpenDimensionModal(
+                                                dimension.id
+                                            )
+                                        )
+                                    }
+                                    dimension={dimension}
                                     axisId={axisId}
                                     isLast={i === axis.length - 1}
                                     overLastDropZone={overLastDropZone}
@@ -84,10 +155,8 @@ const DefaultAxis = ({
 }
 
 DefaultAxis.propTypes = {
-    axis: PropTypes.array,
     axisId: PropTypes.string,
     className: PropTypes.string,
-    getOpenHandler: PropTypes.func,
     renderChips: PropTypes.bool,
 }
 
@@ -105,24 +174,7 @@ export const renderChipsSelector = createSelector(
 )
 
 const mapStateToProps = (state) => ({
-    layout: sGetUiLayout(state),
     renderChips: renderChipsSelector(state),
 })
 
-const mapDispatchToProps = (dispatch) => ({
-    getOpenHandler: (dimensionId) => () =>
-        dispatch(acSetUiOpenDimensionModal(dimensionId)),
-})
-
-const mergeProps = (stateProps, dispatchProps, ownProps) => ({
-    ...stateProps,
-    ...dispatchProps,
-    ...ownProps,
-    axis: stateProps.layout[ownProps.axisId],
-})
-
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-)(DefaultAxis)
+export default connect(mapStateToProps)(DefaultAxis)

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -32,7 +32,7 @@ const getDimensionsWithStageName = ({
 
     const dimensions = dimensionIds.map((id) => {
         let dimension = {}
-        if (metadata[id]?.name) {
+        if (metadata[id]) {
             dimension = metadata[id]
         } else {
             const [rawDimensionId] = id.split('.').reverse()

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -82,7 +82,7 @@ const DefaultAxis = ({ axisId, className }) => {
     })
 
     const dispatch = useDispatch()
-    const axis = useSelector((state) =>
+    const dimensionIds = useSelector((state) =>
         sGetUiDimensionIdsForLayoutAxis(state, axisId)
     )
     const renderChips = useSelector(renderChipsSelector)
@@ -104,13 +104,13 @@ const DefaultAxis = ({ axisId, className }) => {
     )
 
     const dimensions = getDimensionsWithStageName({
-        dimensionIds: axis,
+        dimensionIds,
         inputType,
         programStageNames,
         metadata,
     })
 
-    const activeIndex = draggingId ? axis.indexOf(draggingId) : -1
+    const activeIndex = draggingId ? dimensionIds.indexOf(draggingId) : -1
 
     const overLastDropZone = over?.id === lastDropZoneId
 
@@ -122,11 +122,11 @@ const DefaultAxis = ({ axisId, className }) => {
                 className={cx(styles.axisContainer, className)}
             >
                 <div className={styles.label}>{getAxisName(axisId)}</div>
-                <SortableContext id={axisId} items={axis}>
+                <SortableContext id={axisId} items={dimensionIds}>
                     <div className={styles.content}>
                         <DropZone
                             axisId={axisId}
-                            firstElementId={axis[0]}
+                            firstElementId={dimensionIds[0]}
                             overLastDropZone={overLastDropZone}
                         />
                         {renderChips &&
@@ -142,7 +142,7 @@ const DefaultAxis = ({ axisId, className }) => {
                                     }
                                     dimension={dimension}
                                     axisId={axisId}
-                                    isLast={i === axis.length - 1}
+                                    isLast={i === dimensionIds.length - 1}
                                     overLastDropZone={overLastDropZone}
                                     activeIndex={activeIndex}
                                 />

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -3,8 +3,7 @@ import { SortableContext } from '@dnd-kit/sortable'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
-import { connect, useSelector, useDispatch } from 'react-redux'
-import { createSelector } from 'reselect'
+import { useSelector, useDispatch } from 'react-redux'
 import { acSetUiOpenDimensionModal } from '../../../actions/ui.js'
 import { getAxisName } from '../../../modules/axis.js'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../../modules/dimensionConstants.js'
@@ -12,10 +11,10 @@ import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
 import { sGetMetadata, sGetMetadataById } from '../../../reducers/metadata.js'
 import {
     sGetUiDraggingId,
-    sGetUiLayout,
     sGetUiDimensionIdsForLayoutAxis,
     sGetUiInputType,
     sGetUiProgramId,
+    renderChipsSelector,
 } from '../../../reducers/ui.js'
 import { LAST, getDropzoneId } from '../../DndContext.js'
 import Chip from '../Chip.js'
@@ -76,7 +75,7 @@ const getDimensionsWithStageName = ({
     return dimensions
 }
 
-const DefaultAxis = ({ axisId, className, renderChips }) => {
+const DefaultAxis = ({ axisId, className }) => {
     const lastDropZoneId = getDropzoneId(axisId, LAST)
     const { over, setNodeRef } = useDroppable({
         id: lastDropZoneId,
@@ -86,6 +85,7 @@ const DefaultAxis = ({ axisId, className, renderChips }) => {
     const axis = useSelector((state) =>
         sGetUiDimensionIdsForLayoutAxis(state, axisId)
     )
+    const renderChips = useSelector(renderChipsSelector)
     const draggingId = useSelector(sGetUiDraggingId)
     const metadata = useSelector(sGetMetadata)
     const inputType = useSelector(sGetUiInputType)
@@ -157,24 +157,6 @@ const DefaultAxis = ({ axisId, className, renderChips }) => {
 DefaultAxis.propTypes = {
     axisId: PropTypes.string,
     className: PropTypes.string,
-    renderChips: PropTypes.bool,
 }
 
-export const renderChipsSelector = createSelector(
-    // only render chips when all have names (from metadata) available
-    [sGetUiLayout, sGetMetadata],
-    (layout, metadata) => {
-        const layoutItems = Object.values(layout || {}).flat()
-        const dataObjects = [...Object.values(metadata || {})] // TODO: Refactor to not use the whole metadata list
-
-        return layoutItems.every((item) =>
-            dataObjects.some((data) => data.id === item)
-        )
-    }
-)
-
-const mapStateToProps = (state) => ({
-    renderChips: renderChipsSelector(state),
-})
-
-export default connect(mapStateToProps)(DefaultAxis)
+export default DefaultAxis

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -73,12 +73,6 @@ const DefaultAxis = ({
                                     axisId={axisId}
                                     isLast={i === axis.length - 1}
                                     overLastDropZone={overLastDropZone}
-                                    contextMenu={
-                                        <DimensionMenu
-                                            dimensionId={id}
-                                            currentAxisId={axisId}
-                                        />
-                                    }
                                     activeIndex={activeIndex}
                                 />
                             ))}

--- a/src/components/Layout/TooltipContent.js
+++ b/src/components/Layout/TooltipContent.js
@@ -3,37 +3,7 @@ import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
-import {
-    parseConditionsStringToArray,
-    VALUE_TYPE_NUMBER,
-    VALUE_TYPE_UNIT_INTERVAL,
-    VALUE_TYPE_PERCENTAGE,
-    VALUE_TYPE_INTEGER,
-    VALUE_TYPE_INTEGER_POSITIVE,
-    VALUE_TYPE_INTEGER_NEGATIVE,
-    VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE,
-    VALUE_TYPE_TEXT,
-    VALUE_TYPE_LONG_TEXT,
-    VALUE_TYPE_LETTER,
-    VALUE_TYPE_PHONE_NUMBER,
-    VALUE_TYPE_EMAIL,
-    VALUE_TYPE_USERNAME,
-    VALUE_TYPE_URL,
-    VALUE_TYPE_BOOLEAN,
-    VALUE_TYPE_TRUE_ONLY,
-    VALUE_TYPE_DATE,
-    VALUE_TYPE_TIME,
-    VALUE_TYPE_DATETIME,
-    VALUE_TYPE_ORGANISATION_UNIT,
-    NUMERIC_OPERATORS,
-    ALPHA_NUMERIC_OPERATORS,
-    DATE_OPERATORS,
-    unprefixOperator,
-    NULL_VALUE,
-    OPERATOR_IN,
-    BOOLEAN_VALUES,
-    OPERATOR_EQUAL,
-} from '../../modules/conditions.js'
+import { getConditions } from '../../modules/conditions.js'
 import {
     DIMENSION_TYPE_CATEGORY,
     DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET,
@@ -60,34 +30,6 @@ const labels = {
 }
 
 const renderLimit = 5
-
-const getOperatorsByValueType = (valueType) => {
-    switch (valueType) {
-        case VALUE_TYPE_NUMBER:
-        case VALUE_TYPE_UNIT_INTERVAL:
-        case VALUE_TYPE_PERCENTAGE:
-        case VALUE_TYPE_INTEGER:
-        case VALUE_TYPE_INTEGER_POSITIVE:
-        case VALUE_TYPE_INTEGER_NEGATIVE:
-        case VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE:
-        case VALUE_TYPE_PHONE_NUMBER: {
-            return NUMERIC_OPERATORS
-        }
-        case VALUE_TYPE_LETTER:
-        case VALUE_TYPE_TEXT:
-        case VALUE_TYPE_LONG_TEXT:
-        case VALUE_TYPE_EMAIL:
-        case VALUE_TYPE_USERNAME:
-        case VALUE_TYPE_URL: {
-            return ALPHA_NUMERIC_OPERATORS
-        }
-        case VALUE_TYPE_DATE:
-        case VALUE_TYPE_TIME:
-        case VALUE_TYPE_DATETIME: {
-            return DATE_OPERATORS
-        }
-    }
-}
 
 export const TooltipContent = ({
     dimension,
@@ -159,77 +101,8 @@ export const TooltipContent = ({
         return itemsToRender
     }
 
-    const renderConditions = () => {
-        const conditionsList = parseConditionsStringToArray(
-            conditions.condition
-        )
-
-        if (conditions.legendSet) {
-            if (!conditionsList?.length) {
-                return renderItems([metadata[conditions.legendSet]?.name])
-            } else {
-                const legends = conditionsList[0].split(':').pop().split(';')
-                const allLegends = metadata[conditions.legendSet]?.legends
-                const legendNames = legends.map(
-                    (legend) => allLegends.find((l) => l.id === legend).name
-                )
-                return renderItems(legendNames)
-            }
-        }
-
-        if (dimension.optionSet && conditionsList[0]?.startsWith(OPERATOR_IN)) {
-            const items = conditionsList[0].split(':').pop().split(';')
-            const itemNames = items.map(
-                (code) =>
-                    Object.values(metadata).find((item) => item.code === code)
-                        .name
-            )
-            return renderItems(itemNames)
-        }
-
-        if (
-            [VALUE_TYPE_BOOLEAN, VALUE_TYPE_TRUE_ONLY].includes(
-                dimension.valueType
-            ) &&
-            conditionsList[0]?.startsWith(OPERATOR_IN)
-        ) {
-            const values = conditionsList[0].split(':').pop().split(';')
-            const valueNames = values.map((value) => BOOLEAN_VALUES[value])
-            return renderItems(valueNames)
-        }
-
-        if (
-            dimension.valueType === VALUE_TYPE_ORGANISATION_UNIT &&
-            conditionsList[0]?.startsWith(OPERATOR_EQUAL)
-        ) {
-            const ous = conditionsList[0].split(':').pop().split(';')
-            const ouNames = ous.map((ou) => metadata[ou]?.name)
-            return renderItems(ouNames)
-        }
-
-        const operators = getOperatorsByValueType(dimension.valueType)
-
-        const parsedConditions = conditionsList.map((condition) => {
-            let operator, value
-
-            if (condition.includes(NULL_VALUE)) {
-                operator = condition
-            } else {
-                const parts = condition.split(':')
-                operator = unprefixOperator(parts[0])
-                value = parts[1]
-            }
-
-            const operatorName = operators[operator]
-            const capitalCaseOperatorName =
-                operatorName[0].toUpperCase() + operatorName.substring(1)
-            return value
-                ? `${capitalCaseOperatorName}: ${value}`
-                : capitalCaseOperatorName
-        })
-
-        return renderItems(parsedConditions)
-    }
+    const renderConditions = () =>
+        renderItems(getConditions({ conditions, metadata, dimension }))
 
     const renderNoItemsLabel = () => (
         <li

--- a/src/components/Layout/styles/Chip.module.css
+++ b/src/components/Layout/styles/Chip.module.css
@@ -14,22 +14,39 @@
     user-select: none;
     width: fit-content;
     align-items: center;
-    padding: 1px 2px 1px 6px;
+    padding: 0 2px 0 6px;
 }
 
 .chipBase {
-    font-size: 14px;
     font-weight: 400;
-    color: var(--colors-grey900);
     display: flex;
     overflow: hidden;
     max-width: 360px;
+    align-items: center;
+    font-size: 14px;
+    line-height: 17px;
+    color: var(--colors-grey900);
 }
 
 .label {
     white-space: nowrap;
+    display: flex;
+    align-items: center;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.secondary {
+    font-size: 13px;
+    line-height: 15px;
+    /* flex: 1; */
+    color: var(--colors-grey700);
+    padding-left: 6px;
+}
+
+.suffix {
+    white-space: nowrap;
+    flex: 1;
 }
 
 .dragging {
@@ -95,8 +112,7 @@
 
 .leftIcon {
     margin-right: 6px;
-    display: flex;
-    align-items: center;
+    line-height: 0;
 }
 
 /* dnd */

--- a/src/components/Layout/styles/Chip.module.css
+++ b/src/components/Layout/styles/Chip.module.css
@@ -20,7 +20,6 @@
 .chipBase {
     font-weight: 400;
     display: flex;
-    overflow: hidden;
     max-width: 360px;
     align-items: center;
     font-size: 14px;
@@ -33,15 +32,24 @@
     display: flex;
     align-items: center;
     overflow: hidden;
+}
+
+.primary {
+    flex: 2 1 auto;
+    overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .secondary {
     font-size: 13px;
     line-height: 15px;
-    /* flex: 1; */
+    flex: 1 2.3 auto;
     color: var(--colors-grey700);
     padding-left: 6px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .suffix {

--- a/src/modules/conditions.js
+++ b/src/modules/conditions.js
@@ -125,3 +125,107 @@ export const checkIsCaseSensitive = (operator) => {
         return operator[0] !== CASE_INSENSITIVE_PREFIX
     }
 }
+
+const getOperatorsByValueType = (valueType) => {
+    switch (valueType) {
+        case VALUE_TYPE_NUMBER:
+        case VALUE_TYPE_UNIT_INTERVAL:
+        case VALUE_TYPE_PERCENTAGE:
+        case VALUE_TYPE_INTEGER:
+        case VALUE_TYPE_INTEGER_POSITIVE:
+        case VALUE_TYPE_INTEGER_NEGATIVE:
+        case VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE:
+        case VALUE_TYPE_PHONE_NUMBER: {
+            return NUMERIC_OPERATORS
+        }
+        case VALUE_TYPE_LETTER:
+        case VALUE_TYPE_TEXT:
+        case VALUE_TYPE_LONG_TEXT:
+        case VALUE_TYPE_EMAIL:
+        case VALUE_TYPE_USERNAME:
+        case VALUE_TYPE_URL: {
+            return ALPHA_NUMERIC_OPERATORS
+        }
+        case VALUE_TYPE_DATE:
+        case VALUE_TYPE_TIME:
+        case VALUE_TYPE_DATETIME: {
+            return DATE_OPERATORS
+        }
+    }
+}
+
+const parseCondition = (conditionItem) =>
+    conditionItem.split(':').pop().split(';')
+
+export const getConditions = ({
+    conditions = {},
+    metadata = {},
+    dimension = {},
+}) => {
+    const conditionsList = parseConditionsStringToArray(conditions.condition)
+
+    if (conditions.legendSet) {
+        if (!conditionsList?.length) {
+            return [metadata[conditions.legendSet]?.name]
+        } else {
+            const legends = parseCondition(conditionsList[0])
+            const allLegends = metadata[conditions.legendSet]?.legends
+            const legendNames = legends.map(
+                (legend) => allLegends.find((l) => l.id === legend).name
+            )
+            return legendNames
+        }
+    }
+
+    if (dimension.optionSet && conditionsList[0]?.startsWith(OPERATOR_IN)) {
+        const items = parseCondition(conditionsList[0])
+        const itemNames = items.map(
+            (code) =>
+                Object.values(metadata).find((item) => item.code === code).name
+        )
+        return itemNames
+    }
+
+    if (
+        [VALUE_TYPE_BOOLEAN, VALUE_TYPE_TRUE_ONLY].includes(
+            dimension.valueType
+        ) &&
+        conditionsList[0]?.startsWith(OPERATOR_IN)
+    ) {
+        const values = parseCondition(conditionsList[0])
+        const valueNames = values.map((value) => BOOLEAN_VALUES[value])
+        return valueNames
+    }
+
+    if (
+        dimension.valueType === VALUE_TYPE_ORGANISATION_UNIT &&
+        conditionsList[0]?.startsWith(OPERATOR_EQUAL)
+    ) {
+        const ous = parseCondition(conditionsList[0])
+        const ouNames = ous.map((ou) => metadata[ou]?.name)
+        return ouNames
+    }
+
+    const operators = getOperatorsByValueType(dimension.valueType)
+
+    const parsedConditions = conditionsList.map((condition) => {
+        let operator, value
+
+        if (condition.includes(NULL_VALUE)) {
+            operator = condition
+        } else {
+            const parts = condition.split(':')
+            operator = unprefixOperator(parts[0])
+            value = parts[1]
+        }
+
+        const operatorName = operators[operator]
+        const capitalCaseOperatorName =
+            operatorName[0].toUpperCase() + operatorName.substring(1)
+        return value
+            ? `${capitalCaseOperatorName}: ${value}`
+            : capitalCaseOperatorName
+    })
+
+    return parsedConditions
+}

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -361,7 +361,7 @@ export const sGetDimensionIdsFromLayout = (state) =>
         []
     )
 
-export const sGetUiDimensionIdsForLayoutAxis = (state, axisId) =>
+export const sGetUiDimensionIdsByAxisId = (state, axisId) =>
     sGetUiLayout(state)[axisId]
 
 export const sGetUiConditionsByDimension = (state, dimension) =>

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -360,6 +360,9 @@ export const sGetDimensionIdsFromLayout = (state) =>
         []
     )
 
+export const sGetUiDimensionIdsForLayoutAxis = (state, axisId) =>
+    sGetUiLayout(state)[axisId]
+
 export const sGetUiConditionsByDimension = (state, dimension) =>
     sGetUiConditions(state)[dimension]
 

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -5,6 +5,7 @@ import {
 } from '@dhis2/analytics'
 import { useMemo } from 'react'
 import { useStore, useSelector } from 'react-redux'
+import { createSelector } from 'reselect'
 import {
     DIMENSION_ID_EVENT_DATE,
     DIMENSION_ID_ENROLLMENT_DATE,
@@ -23,7 +24,7 @@ import { getOptionsForUi } from '../modules/options.js'
 import { getEnabledTimeDimensionIds } from '../modules/timeDimensions.js'
 import { getAdaptedUiByType, getUiFromVisualization } from '../modules/ui.js'
 import { OUTPUT_TYPE_EVENT } from '../modules/visualization.js'
-import { sGetMetadataById } from './metadata.js'
+import { sGetMetadata, sGetMetadataById } from './metadata.js'
 
 export const SET_UI_DRAGGING_ID = 'SET_UI_DRAGGING_ID'
 export const SET_UI_INPUT = 'SET_UI_INPUT'
@@ -368,6 +369,19 @@ export const sGetUiConditionsByDimension = (state, dimension) =>
 
 export const sGetUiRepetitionByDimension = (state, dimensionId) =>
     sGetUiRepetition(state)[dimensionId]
+
+export const renderChipsSelector = createSelector(
+    // only render chips when all have names (from metadata) available
+    [sGetUiLayout, sGetMetadata],
+    (layout, metadata) => {
+        const layoutItems = Object.values(layout || {}).flat()
+        const dataObjects = [...Object.values(metadata || {})] // TODO: Refactor to not use the whole metadata list
+
+        return layoutItems.every((item) =>
+            dataObjects.some((data) => data.id === item)
+        )
+    }
+)
 
 // Selector based hooks
 export const useMainDimensions = () => {


### PR DESCRIPTION
Implements [TECH-1009](https://jira.dhis2.org/browse/TECH-1009)

---

### Key features

1. Add stageName to the chip label in cases where multiple data elements have the same name. This is the same functionality used by ProgramDimensionsList (code is duplicated for now, but will consider refactoring when adding stageName to modal and the visualization columns)
2. Style the chip such that the suffix showing #selected/conditions always shows in full, and the name-stageName part being truncated with overflow ellipsis.
3. move TooltipContent->renderConditions to function getConditions in modules/conditions. This was so that the functionality could be shared with the chip label component (ChipBase)
4. refactor: switch DefaultAxis to use useSelector/useDispatch instead of connect. This resulted in `renderChipsSelector` being moved to reducers/ui.js

---

### Screenshots

Remember to look at the text on the chip. The tooltip is shown so that you can compare what is on the chip to the actual items/conditions that were chosen

Display stage name on the chip in cases where there are duplicate data element names in the layout:
 
<img width="572" alt="image" src="https://user-images.githubusercontent.com/6113918/157036068-dcbe6199-bae5-4b4b-91e0-d6e58743477d.png">


Number-legend set with 3 selected options
![image](https://user-images.githubusercontent.com/6113918/156764098-23ea67e3-54ff-4aa3-86c3-a7829f6b0954.png)

Regular number field with 2 conditions:
![image](https://user-images.githubusercontent.com/6113918/156764284-dd59ae83-a500-4a9a-a6db-c9fab8cd7ff5.png)


Number -option set with 4 selected options
![image](https://user-images.githubusercontent.com/6113918/156764362-41caf536-8e53-4250-8ba5-36c526372587.png)

Multiple types with nothing selected (take note of "Organisation unit" and "Event date":
![image](https://user-images.githubusercontent.com/6113918/156765232-58229dc5-2a21-464a-a205-60bc678c2cd6.png)


Yes-only with 1 option selected
![image](https://user-images.githubusercontent.com/6113918/156764471-2a4c6f97-729a-41b3-8e90-3d0f09ccae3f.png)

Yes-only with both options selected
![image](https://user-images.githubusercontent.com/6113918/156764772-c2c633f8-d2e4-4997-b832-623cd2f41820.png)

Yes-only with no options selected
![image](https://user-images.githubusercontent.com/6113918/156764819-616fce50-aead-478c-bcf6-fce42a368eb6.png)


Boolean with 2 options selected
![image](https://user-images.githubusercontent.com/6113918/156764938-2fdd2cec-d228-46bc-b417-3286db827d68.png)

Boolean with all options selected
![image](https://user-images.githubusercontent.com/6113918/156764973-3f7aa871-fd02-4fe5-9fbd-24bf1e119fdf.png)

Boolean with no options selected
![image](https://user-images.githubusercontent.com/6113918/156765013-111586e0-7798-4f70-9b1c-2940291e9b36.png)





