### PR TITLE
fix: remove stage index from dimension id used for modal

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -149,7 +149,9 @@ export const Visualization = ({
 
     const formatCellHeader = (header) => {
         let headerName = header.column
-        let dimensionId = header.name
+        let dimensionId = header?.stageOffset
+            ? header.name.replace(/\[-?\d+\]/, '')
+            : header.name
 
         const reverseLookupDimensionId = Object.keys(headersMap).find(
             (key) => headersMap[key] === header.name


### PR DESCRIPTION
### Key features

1. fix id used to open dimension modal for dimensions with repeatable events

---

### Description

The key used to open the dimension modal should not contain the repeatable index, only program stage and dimension ids.