### PR TITLE
fix: prevent scrolling while dragging item from program dimensions panel

### DIFF
--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -29,20 +29,10 @@ import { ChipBase } from './Layout/ChipBase.js'
 import chipStyles from './Layout/styles/Chip.module.css'
 import { DimensionItemBase } from './MainSidebar/DimensionItem/DimensionItemBase.js'
 
-// Names for dnd sources
-export const TIME_DIMENSIONS = 'time'
-export const MAIN_DIMENSIONS = 'main'
-export const YOUR_DIMENSIONS = 'your'
-export const PROGRAM_DIMENSIONS = 'program'
-
 const FIRST_POSITION = 0
 const LAST_POSITION = -1
-const SOURCE_DIMENSIONS = [
-    MAIN_DIMENSIONS,
-    TIME_DIMENSIONS,
-    YOUR_DIMENSIONS,
-    PROGRAM_DIMENSIONS,
-]
+
+const DIMENSION_PANEL_SOURCE = 'Sortable'
 
 export const getDropzoneId = (axisId, position) => `${axisId}-${position}`
 export const FIRST = 'first'
@@ -162,7 +152,7 @@ const OuterDndContext = ({ children }) => {
             dimensionType = metadata[rawDimensionId]?.dimensionType || null
         }
 
-        if (SOURCE_DIMENSIONS.includes(sourceAxis)) {
+        if (sourceAxis === DIMENSION_PANEL_SOURCE) {
             return (
                 <div className={cx(styles.overlay, styles.dimensionItem)}>
                     <DimensionItemBase
@@ -246,7 +236,8 @@ const OuterDndContext = ({ children }) => {
         //TODO: Add onDropWithoutItems
     }
 
-    const onDragStart = ({ active }) => {
+    const onDragStart = (prop) => {
+        const { active } = prop
         const id = getIdFromDraggingId(active.id)
 
         setSourceAxis(active.data.current.sortable.containerId)
@@ -268,14 +259,17 @@ const OuterDndContext = ({ children }) => {
         dispatch(acSetUiDraggingId(null))
     }
 
+    const onDragMove = (props) => {
+        console.log('onDragMove', props)
+    }
+
     const onDragEnd = (result) => {
         const { active, over } = result
 
         if (
             !over?.id ||
-            SOURCE_DIMENSIONS.includes(
-                over?.data?.current?.sortable?.containerId
-            )
+            over?.data?.current?.sortable?.containerId ===
+                DIMENSION_PANEL_SOURCE
         ) {
             // dropped over non-droppable or over dimension panel
             onDragCancel()
@@ -300,7 +294,14 @@ const OuterDndContext = ({ children }) => {
             `${AXIS_ID_FILTERS}-${LAST}`,
         ].includes(over.id)
 
-        if (SOURCE_DIMENSIONS.includes(sourceAxisId)) {
+        console.log(
+            'sourceAxisId',
+            sourceAxisId,
+            destinationAxisId,
+            destinationIndex
+        )
+
+        if (sourceAxisId === DIMENSION_PANEL_SOURCE) {
             if (isDroppingInFirstPosition) {
                 destinationIndex = FIRST_POSITION
             } else if (isDroppingInLastPosition) {
@@ -342,6 +343,7 @@ const OuterDndContext = ({ children }) => {
             collisionDetection={rectIntersectionCustom}
             onDragStart={onDragStart}
             onDragEnd={onDragEnd}
+            // onDragMove={onDragMove}
             onDragCancel={onDragCancel}
             sensors={sensors}
         >

--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -236,8 +236,7 @@ const OuterDndContext = ({ children }) => {
         //TODO: Add onDropWithoutItems
     }
 
-    const onDragStart = (prop) => {
-        const { active } = prop
+    const onDragStart = ({ active }) => {
         const id = getIdFromDraggingId(active.id)
 
         setSourceAxis(active.data.current.sortable.containerId)

--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -331,7 +331,6 @@ const OuterDndContext = ({ children }) => {
             collisionDetection={rectIntersectionCustom}
             onDragStart={onDragStart}
             onDragEnd={onDragEnd}
-            // onDragMove={onDragMove}
             onDragCancel={onDragCancel}
             sensors={sensors}
         >

--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -259,10 +259,6 @@ const OuterDndContext = ({ children }) => {
         dispatch(acSetUiDraggingId(null))
     }
 
-    const onDragMove = (props) => {
-        console.log('onDragMove', props)
-    }
-
     const onDragEnd = (result) => {
         const { active, over } = result
 
@@ -293,13 +289,6 @@ const OuterDndContext = ({ children }) => {
             `${AXIS_ID_COLUMNS}-${LAST}`,
             `${AXIS_ID_FILTERS}-${LAST}`,
         ].includes(over.id)
-
-        console.log(
-            'sourceAxisId',
-            sourceAxisId,
-            destinationAxisId,
-            destinationIndex
-        )
 
         if (sourceAxisId === DIMENSION_PANEL_SOURCE) {
             if (isDroppingInFirstPosition) {

--- a/src/components/MainSidebar/DimensionsList/DimensionsList.js
+++ b/src/components/MainSidebar/DimensionsList/DimensionsList.js
@@ -1,6 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
 import { CircularLoader, NoticeBox } from '@dhis2/ui'
-import { SortableContext } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React, { useRef, useEffect } from 'react'
 import { DimensionItem } from '../DimensionItem/index.js'
@@ -29,7 +28,6 @@ const DimensionsList = ({
     fetching,
     error,
     dimensions,
-    listId,
     programName,
     searchTerm,
     setIsListEndVisible,
@@ -75,24 +73,20 @@ const DimensionsList = ({
     return (
         <div
             className={styles.scrollbox}
-            onScroll={(event) =>
-                setIsListEndVisible(isEndReached(event.target))
-            }
+            onScroll={(event) => {
+                console.log('scrolling', event.target)
+                return setIsListEndVisible(isEndReached(event.target))
+            }}
             ref={scrollBoxRef}
         >
             <div className={styles.list}>
-                <SortableContext
-                    id={listId}
-                    items={dimensions.map((dim) => dim.draggableId)}
-                >
-                    {dimensions.map((dimension) => (
-                        <DimensionItem
-                            key={dimension.id}
-                            {...dimension}
-                            selected={getIsDimensionSelected(dimension.id)}
-                        />
-                    ))}
-                </SortableContext>
+                {dimensions.map((dimension) => (
+                    <DimensionItem
+                        key={dimension.id}
+                        {...dimension}
+                        selected={getIsDimensionSelected(dimension.id)}
+                    />
+                ))}
                 {fetching && (
                     <div className={styles.loadMoreWrap}>
                         <CircularLoader small />
@@ -108,7 +102,6 @@ DimensionsList.propTypes = {
     dimensions: PropTypes.array,
     error: PropTypes.object,
     fetching: PropTypes.bool,
-    listId: PropTypes.string,
     loading: PropTypes.bool,
     programName: PropTypes.string,
     searchTerm: PropTypes.string,

--- a/src/components/MainSidebar/DimensionsList/DimensionsList.js
+++ b/src/components/MainSidebar/DimensionsList/DimensionsList.js
@@ -74,9 +74,9 @@ const DimensionsList = ({
         <div
             className={styles.scrollbox}
             onScroll={(event) => {
-                console.log('scrolling', event.target)
                 return setIsListEndVisible(isEndReached(event.target))
             }}
+            onMouseDown={(event) => event.preventDefault()}
             ref={scrollBoxRef}
         >
             <div className={styles.list}>

--- a/src/components/MainSidebar/MainDimensions.js
+++ b/src/components/MainSidebar/MainDimensions.js
@@ -1,8 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
-import { SortableContext } from '@dnd-kit/sortable'
 import React from 'react'
 import { useMainDimensions } from '../../reducers/ui.js'
-import { MAIN_DIMENSIONS } from '../DndContext.js'
 import { DimensionItem } from './DimensionItem/index.js'
 import { MainSidebarSection } from './MainSidebarSection.js'
 import { useSelectedDimensions } from './SelectedDimensionsContext.js'
@@ -12,24 +10,19 @@ export const MainDimensions = () => {
     const { getIsDimensionSelected } = useSelectedDimensions()
 
     const draggableDimensions = mainDimensions.map((dimension) => ({
-        draggableId: `${MAIN_DIMENSIONS}-${dimension.id}`,
+        draggableId: `main-${dimension.id}`,
         ...dimension,
     }))
 
     return (
         <MainSidebarSection header={i18n.t('Main dimensions')}>
-            <SortableContext
-                id={MAIN_DIMENSIONS}
-                items={draggableDimensions.map((dim) => dim.draggableId)}
-            >
-                {draggableDimensions.map((dimension) => (
-                    <DimensionItem
-                        key={dimension.id}
-                        {...dimension}
-                        selected={getIsDimensionSelected(dimension.id)}
-                    />
-                ))}
-            </SortableContext>
+            {draggableDimensions.map((dimension) => (
+                <DimensionItem
+                    key={dimension.id}
+                    {...dimension}
+                    selected={getIsDimensionSelected(dimension.id)}
+                />
+            ))}
         </MainSidebarSection>
     )
 }

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsList.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsList.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { PROGRAM_DIMENSIONS } from '../../DndContext.js'
 import LoadingMask from '../../LoadingMask/LoadingMask.js'
 import { DimensionsList } from '../DimensionsList/index.js'
 import { useProgramDimensions } from './useProgramDimensions.js'
@@ -26,7 +25,7 @@ const ProgramDimensionsList = ({
     }
 
     const draggableDimensions = dimensions.map((dimension) => ({
-        draggableId: `${PROGRAM_DIMENSIONS}-${dimension.id}`,
+        draggableId: `program-${dimension.id}`,
         ...dimension,
     }))
 
@@ -39,7 +38,6 @@ const ProgramDimensionsList = ({
             loading={loading}
             programName={program.name}
             searchTerm={searchTerm}
-            listId={PROGRAM_DIMENSIONS}
         />
     )
 }

--- a/src/components/MainSidebar/TimeDimensions.js
+++ b/src/components/MainSidebar/TimeDimensions.js
@@ -1,8 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
-import { SortableContext } from '@dnd-kit/sortable'
 import React from 'react'
 import { useTimeDimensions } from '../../reducers/ui.js'
-import { TIME_DIMENSIONS } from '../DndContext.js'
 import { DimensionItem } from './DimensionItem/index.js'
 import { MainSidebarSection } from './MainSidebarSection.js'
 import { useSelectedDimensions } from './SelectedDimensionsContext.js'
@@ -16,24 +14,19 @@ export const TimeDimensions = () => {
     }
 
     const draggableDimensions = timeDimensions.map((dimension) => ({
-        draggableId: `${TIME_DIMENSIONS}-${dimension.id}`,
+        draggableId: `time-${dimension.id}`,
         ...dimension,
     }))
 
     return (
         <MainSidebarSection header={i18n.t('Time dimensions')}>
-            <SortableContext
-                id={TIME_DIMENSIONS}
-                items={draggableDimensions.map((dim) => dim.draggableId)}
-            >
-                {draggableDimensions.map((dimension) => (
-                    <DimensionItem
-                        key={dimension.id}
-                        {...dimension}
-                        selected={getIsDimensionSelected(dimension.id)}
-                    />
-                ))}
-            </SortableContext>
+            {draggableDimensions.map((dimension) => (
+                <DimensionItem
+                    key={dimension.id}
+                    {...dimension}
+                    selected={getIsDimensionSelected(dimension.id)}
+                />
+            ))}
         </MainSidebarSection>
     )
 }

--- a/src/components/MainSidebar/YourDimensionsPanel/YourDimensionsPanel.js
+++ b/src/components/MainSidebar/YourDimensionsPanel/YourDimensionsPanel.js
@@ -3,7 +3,6 @@ import { Input } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useDebounce } from '../../../modules/utils.js'
-import { YOUR_DIMENSIONS } from '../../DndContext.js'
 import { DimensionsList } from '../DimensionsList/index.js'
 import { useYourDimensions } from './useYourDimensions.js'
 import styles from './YourDimensionsPanel.module.css'
@@ -22,7 +21,7 @@ const YourDimensionsPanel = ({ visible }) => {
     }
 
     const draggableDimensions = dimensions.map((dimension) => ({
-        draggableId: `${YOUR_DIMENSIONS}-${dimension.id}`,
+        draggableId: `your-${dimension.id}`,
         ...dimension,
     }))
 
@@ -43,7 +42,6 @@ const YourDimensionsPanel = ({ visible }) => {
                 fetching={fetching}
                 loading={loading}
                 searchTerm={debouncedSearchTerm}
-                listId={YOUR_DIMENSIONS}
             />
         </>
     )


### PR DESCRIPTION
Implements [TECH-1024](https://jira.dhis2.org/browse/TECH-1024)
Potentially improves performance: [TECH-990](https://jira.dhis2.org/browse/TECH-990)

---

### Key features

1. Remove DnD SortableContext from all the dimension panel lists since it isn't needed (those lists are not droppable/sortable)
2. Add preventDefault to the onMouseDown of DimensionLists to prevent scrolling on the list when dragging an item outside of the list. This fix prevents a bunch of scroll events from firing while dragging and so hopefully will improve the dragging performance a little bit.  Note that if you do drag the item upwards to the top of the list, it will still scroll upwards (video below). I'm still looking for a solution to that behaviour.  

---

### Screenshots
Bug behaviour:

https://user-images.githubusercontent.com/6113918/156993533-27c5fbf4-84f2-4d59-85c8-ee76b5803270.mov

Better:

https://user-images.githubusercontent.com/6113918/156993596-cfb40ab6-18b4-42aa-b4af-a24cdaac810f.mov

But it still scrolls if you drag over the top of the list (can be fixed in another PR):

https://user-images.githubusercontent.com/6113918/156993655-5b411c5d-0fe7-4808-9a9c-bd50fc13ebd3.mov


