### PR TITLE
fix: operators for program indicators

### DIFF
--- a/src/components/Layout/TooltipContent.js
+++ b/src/components/Layout/TooltipContent.js
@@ -63,16 +63,6 @@ const renderLimit = 5
 
 const getOperatorsByValueType = (valueType) => {
     switch (valueType) {
-        case VALUE_TYPE_NUMBER:
-        case VALUE_TYPE_UNIT_INTERVAL:
-        case VALUE_TYPE_PERCENTAGE:
-        case VALUE_TYPE_INTEGER:
-        case VALUE_TYPE_INTEGER_POSITIVE:
-        case VALUE_TYPE_INTEGER_NEGATIVE:
-        case VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE:
-        case VALUE_TYPE_PHONE_NUMBER: {
-            return NUMERIC_OPERATORS
-        }
         case VALUE_TYPE_LETTER:
         case VALUE_TYPE_TEXT:
         case VALUE_TYPE_LONG_TEXT:
@@ -85,6 +75,17 @@ const getOperatorsByValueType = (valueType) => {
         case VALUE_TYPE_TIME:
         case VALUE_TYPE_DATETIME: {
             return DATE_OPERATORS
+        }
+        case VALUE_TYPE_NUMBER:
+        case VALUE_TYPE_UNIT_INTERVAL:
+        case VALUE_TYPE_PERCENTAGE:
+        case VALUE_TYPE_INTEGER:
+        case VALUE_TYPE_INTEGER_POSITIVE:
+        case VALUE_TYPE_INTEGER_NEGATIVE:
+        case VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE:
+        case VALUE_TYPE_PHONE_NUMBER:
+        default: {
+            return NUMERIC_OPERATORS
         }
     }
 }


### PR DESCRIPTION
Program indicators don't have value type, so when fetching `getOperatorsByValueType` `undefined` is passed in, resulting in no operators being returned.
This fix defaults the switch/case to the numeric operators, which aligns with the program indicators (all program indicators are numeric, as seen here:
https://github.com/dhis2/line-listing-app/blob/7ce2f2295b085ea7ef44d89328f05e3d48a694f3/src/components/Dialogs/Conditions/ConditionsManager.js#L234