### PR TITLE
fix: reset page to 1 when a sorting is applied (TECH-1025)

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -125,6 +125,11 @@ export const Visualization = ({
     const fontSizeClass = getFontSizeClass(visualization.fontSize)
     const colSpan = String(Math.max(data.headers.length, 1))
 
+    const sortData = ({ sortField, sortDirection }) => {
+        setSorting({ sortField, sortDirection })
+        setPage(1)
+    }
+
     const formatCellValue = (value, header) => {
         if (
             [
@@ -214,7 +219,7 @@ export const Visualization = ({
                                             name,
                                             direction,
                                         }) =>
-                                            setSorting({
+                                            sortData({
                                                 sortField: name,
                                                 sortDirection: direction,
                                             })


### PR DESCRIPTION
Implements [TECH-1025](https://jira.dhis2.org/browse/TECH-1025)

---

### Key features

1. reset page to 1 when sorting

---

### Description

When sorting on a column, the page should be reset to 1 instead of keeping whatever page is currently selected.
