### PR TITLE
fix: make layout scrollable and collapsible when expanded and at full height

### DIFF
--- a/src/components/Layout/styles/Layout.module.css
+++ b/src/components/Layout/styles/Layout.module.css
@@ -1,3 +1,9 @@
+:root {
+    --headerbarHeight: 48px;
+    --toolbarHeight: 38px;
+    --expandButtonHeight: 16px;
+}
+
 .container {
     display: flex;
     flex-direction: column;
@@ -14,14 +20,18 @@
 }
 
 .expanded {
-    max-height: 100%;
+    max-height: calc(
+        100vh - var(--headerbarHeight) - var(--toolbarHeight) -
+            var(--expandButtonHeight)
+    );
+    overflow-y: auto;
 }
 
 .button {
     cursor: pointer;
     padding: 0;
     width: 100%;
-    height: 16px;
+    height: var(--expandButtonHeight);
     background-color: var(--colors-grey050);
     border: none;
     border-top: 1px solid var(--colors-grey300);


### PR DESCRIPTION
Implements [TECH-995](https://jira.dhis2.org/browse/TECH-995)

---

### Key features

1. Calculate the available height for the expanded layout correctly, and make it scrollable
---

### Screenshots

Before:

https://user-images.githubusercontent.com/6113918/157390248-e4c88c4a-f9b8-446a-b7ae-8e173c5c624a.mov


After


https://user-images.githubusercontent.com/6113918/157390286-1530635f-0ef6-43b0-9cd9-1722eab35b2c.mov


