### PR TITLE
fix: remove core app flag to allow app deployment

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -2,7 +2,6 @@ const config = {
     type: 'app',
     name: 'line-listing',
     title: 'Line Listing',
-    coreApp: true,
 
     entryPoints: {
         app: './src/AppWrapper.js',


### PR DESCRIPTION
### Key features

1. enable app deployment

---

### Description

By removing the `coreApp` flag the app can be deployed any time.