### PR TITLE
fix: disable Save if no current

### DIFF
--- a/src/components/Toolbar/MenuBar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar/MenuBar.js
@@ -2,6 +2,7 @@ import {
     FileMenu,
     useCachedDataQuery,
     VIS_TYPE_LINE_LIST,
+    visTypeDisplayNames,
 } from '@dhis2/analytics'
 import { useDataMutation, useAlert } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
@@ -12,7 +13,10 @@ import { acSetCurrent } from '../../../actions/current.js'
 import { acSetVisualization } from '../../../actions/visualization.js'
 import { getAlertTypeByStatusCode } from '../../../modules/error.js'
 import history from '../../../modules/history.js'
-import { visTypes } from '../../../modules/visualization.js'
+import {
+    visTypes,
+    getVisualizationFromCurrent,
+} from '../../../modules/visualization.js'
 import { sGetCurrent } from '../../../reducers/current.js'
 import { sGetVisualization } from '../../../reducers/visualization.js'
 import { ToolbarDownloadDropdown } from '../../DownloadMenu/index.js'
@@ -124,7 +128,7 @@ const MenuBar = ({
     }
 
     const onSave = (details = {}, copy = false) => {
-        const visualization = current // TODO getVisualizationFromCurrent
+        const visualization = getVisualizationFromCurrent(current)
 
         visualization.name =
             // name provided in Save dialog
@@ -133,7 +137,7 @@ const MenuBar = ({
             visualization.name ||
             // new visualization with no name provided in Save dialog
             i18n.t('Untitled {{visualizationType}} visualization, {{date}}', {
-                visualizationType: 'TEXT', // TODO Line list/PT?
+                visualizationType: visTypeDisplayNames(VIS_TYPE_LINE_LIST),
                 date: new Date().toLocaleDateString(undefined, {
                     year: 'numeric',
                     month: 'short',
@@ -223,7 +227,7 @@ const MenuBar = ({
                 onOpen={onOpen}
                 onNew={onNew}
                 onRename={onRename}
-                onSave={current?.legacy ? undefined : onSave}
+                onSave={!current || current?.legacy ? undefined : onSave}
                 onSaveAs={(details) => onSave(details, true)}
                 onDelete={onDelete}
                 onError={onError}


### PR DESCRIPTION
### Key features

1. Fixed default untitled name.
2. Use `getVisualizationFromCurrent` for generating the save payload
 (although currently it does not make a difference since all options are
 saveable).

---

### Description

The `Save` button was always enabled allowing to save (or rather attempting to save) an empty AO, ie. right after clicking `New`.
This resulted in this error:
<img width="1023" alt="Screenshot 2022-03-11 at 16 37 29" src="https://user-images.githubusercontent.com/150978/157898882-6e936278-40c1-4dfa-8581-09fdc050912a.png">


After using the `getVisualizationFromCurrent` which initialises `current` as an object with a couple of keys, the Save works but the backend returns a different error because of missing keys. In this case the payload only has the options and the name/description (from the prompt) which of course is not enough for a valid Line list AO.
<img width="625" alt="Screenshot 2022-03-11 at 15 57 01" src="https://user-images.githubusercontent.com/150978/157899203-3dfdd0a8-41a3-4c1a-b71b-8e5c976274c6.png">

To avoid this errors it makes sense to disable the `Save` button when `current` is empty.
