### PR TITLE
fix: rename lastUpdated to lastUpdatedDate TECH-1040

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Implements [DHIS2-XXXX](https://jira.dhis2.org/browse/DHIS2-XXXX)
+Implements [DHIS2-XXXX](https://dhis2.atlassian.net/browse/DHIS2-XXXX)
 
 **Requires https://github.com/dhis2/analytics/pull/XXX**
 

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -20,7 +20,7 @@ import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
 import {
     DIMENSION_ID_EVENT_STATUS,
     DIMENSION_ID_PROGRAM_STATUS,
-    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_LAST_UPDATED_DATE,
 } from '../../modules/dimensionConstants.js'
 import { genericServerError, noPeriodError } from '../../modules/error.js'
 import {
@@ -140,7 +140,7 @@ export const Visualization = ({
             return metadata[value]?.name || value
         } else if (header?.valueType === 'DATE') {
             return moment(value).format(
-                header.name === headersMap[DIMENSION_ID_LAST_UPDATED]
+                header.name === headersMap[DIMENSION_ID_LAST_UPDATED_DATE]
                     ? 'yyyy-MM-DD hh:mm'
                     : 'yyyy-MM-DD'
             )

--- a/src/modules/__tests__/timeDimensions.spec.js
+++ b/src/modules/__tests__/timeDimensions.spec.js
@@ -3,7 +3,7 @@ import {
     DIMENSION_ID_ENROLLMENT_DATE,
     DIMENSION_ID_INCIDENT_DATE,
     DIMENSION_ID_SCHEDULED_DATE,
-    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_LAST_UPDATED_DATE,
 } from '../dimensionConstants.js'
 import {
     PROGRAM_TYPE_WITH_REGISTRATION,
@@ -24,7 +24,7 @@ describe('ER > Dimensions > getTimeDimensionName', () => {
     /***** NOT in MVP / 2.38 release *****
     const scheduledDateDimension = timeDimensions[DIMENSION_ID_SCHEDULED_DATE]
     */
-    const lastUpdatedDimension = timeDimensions[DIMENSION_ID_LAST_UPDATED]
+    const lastUpdatedDimension = timeDimensions[DIMENSION_ID_LAST_UPDATED_DATE]
 
     it('uses default names normally', () => {
         const program = {
@@ -200,7 +200,7 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 DIMENSION_ID_ENROLLMENT_DATE,
                 DIMENSION_ID_SCHEDULED_DATE,
                 DIMENSION_ID_INCIDENT_DATE,
-                DIMENSION_ID_LAST_UPDATED,
+                DIMENSION_ID_LAST_UPDATED_DATE,
             ],
         },
         // Hiding the due date
@@ -218,7 +218,7 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 DIMENSION_ID_EVENT_DATE,
                 DIMENSION_ID_ENROLLMENT_DATE,
                 DIMENSION_ID_INCIDENT_DATE,
-                DIMENSION_ID_LAST_UPDATED,
+                DIMENSION_ID_LAST_UPDATED_DATE,
             ],
         },
         // Hiding the incident date
@@ -235,7 +235,7 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
             expected: [
                 DIMENSION_ID_EVENT_DATE,
                 DIMENSION_ID_ENROLLMENT_DATE,
-                DIMENSION_ID_LAST_UPDATED,
+                DIMENSION_ID_LAST_UPDATED_DATE,
             ],
         },
         // input type enrollment
@@ -252,7 +252,7 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
             expected: [
                 DIMENSION_ID_ENROLLMENT_DATE,
                 DIMENSION_ID_INCIDENT_DATE,
-                DIMENSION_ID_LAST_UPDATED,
+                DIMENSION_ID_LAST_UPDATED_DATE,
             ],
         },
         // Event program
@@ -266,7 +266,7 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 id: '1',
                 hideDueDate: false,
             },
-            expected: [DIMENSION_ID_EVENT_DATE, DIMENSION_ID_LAST_UPDATED],
+            expected: [DIMENSION_ID_EVENT_DATE, DIMENSION_ID_LAST_UPDATED_DATE],
         },
     ])(
         'returns expected IDs for inputType $inputType, programType $program.programType with displayIncidentDate $program.displayIncidentDate and stage.hideDueDate $stage.hideDueDate',

--- a/src/modules/dimensionConstants.js
+++ b/src/modules/dimensionConstants.js
@@ -45,14 +45,14 @@ export const DIMENSION_ID_EVENT_DATE = 'eventDate'
 export const DIMENSION_ID_ENROLLMENT_DATE = 'enrollmentDate'
 export const DIMENSION_ID_INCIDENT_DATE = 'incidentDate'
 export const DIMENSION_ID_SCHEDULED_DATE = 'scheduledDate'
-export const DIMENSION_ID_LAST_UPDATED = 'lastUpdated'
+export const DIMENSION_ID_LAST_UPDATED_DATE = 'lastUpdatedDate'
 
 export const DIMENSION_IDS_TIME = new Set([
     DIMENSION_ID_EVENT_DATE,
     DIMENSION_ID_ENROLLMENT_DATE,
     DIMENSION_ID_INCIDENT_DATE,
     DIMENSION_ID_SCHEDULED_DATE,
-    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_LAST_UPDATED_DATE,
 ])
 
 export const getUiDimensionType = ({ dimensionId, dimensionType }) => {

--- a/src/modules/timeDimensions.js
+++ b/src/modules/timeDimensions.js
@@ -5,7 +5,7 @@ import {
     DIMENSION_ID_ENROLLMENT_DATE,
     DIMENSION_ID_INCIDENT_DATE,
     DIMENSION_ID_SCHEDULED_DATE,
-    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_LAST_UPDATED_DATE,
 } from './dimensionConstants.js'
 import { PROGRAM_TYPE_WITH_REGISTRATION } from './programTypes.js'
 import { OUTPUT_TYPE_EVENT, OUTPUT_TYPE_ENROLLMENT } from './visualization.js'
@@ -44,8 +44,8 @@ export const getTimeDimensions = () => ({
         nameProperty: 'displayDueDateLabel',
     },
     */
-    [DIMENSION_ID_LAST_UPDATED]: {
-        id: DIMENSION_ID_LAST_UPDATED,
+    [DIMENSION_ID_LAST_UPDATED_DATE]: {
+        id: DIMENSION_ID_LAST_UPDATED_DATE,
         dimensionType: DIMENSION_TYPE_PERIOD,
         name: i18n.t('Last updated on'),
     },
@@ -91,7 +91,7 @@ export const getEnabledTimeDimensionIds = (inputType, program, stage) => {
         }
 
         if (isEvent || isEnrollment || withRegistration) {
-            enabledDimensionIds.add(DIMENSION_ID_LAST_UPDATED)
+            enabledDimensionIds.add(DIMENSION_ID_LAST_UPDATED_DATE)
         }
     }
     return enabledDimensionIds

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -19,7 +19,7 @@ import {
     DIMENSION_ID_ENROLLMENT_DATE,
     DIMENSION_ID_INCIDENT_DATE,
     DIMENSION_ID_SCHEDULED_DATE,
-    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_LAST_UPDATED_DATE,
     DIMENSION_ID_LAST_UPDATED_BY,
     DIMENSION_ID_PROGRAM_STATUS,
 } from './dimensionConstants.js'
@@ -48,7 +48,7 @@ export const headersMap = {
     [DIMENSION_ID_ENROLLMENT_DATE]: 'enrollmentdate',
     [DIMENSION_ID_INCIDENT_DATE]: 'incidentdate',
     [DIMENSION_ID_SCHEDULED_DATE]: 'scheduleddate',
-    [DIMENSION_ID_LAST_UPDATED]: 'lastupdated',
+    [DIMENSION_ID_LAST_UPDATED_DATE]: 'lastupdated',
 }
 
 export const outputTypeTimeDimensionMap = {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -11,7 +11,7 @@ import {
     DIMENSION_ID_ENROLLMENT_DATE,
     DIMENSION_ID_INCIDENT_DATE,
     // DIMENSION_ID_SCHEDULED_DATE,
-    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_LAST_UPDATED_DATE,
     DIMENSION_ID_EVENT_STATUS,
     DIMENSION_ID_PROGRAM_STATUS,
 } from '../modules/dimensionConstants.js'
@@ -422,7 +422,7 @@ export const useTimeDimensions = () => {
     //     sGetMetadataById(state, DIMENSION_ID_SCHEDULED_DATE)
     // )
     const lastUpdatedDim = useSelector((state) =>
-        sGetMetadataById(state, DIMENSION_ID_LAST_UPDATED)
+        sGetMetadataById(state, DIMENSION_ID_LAST_UPDATED_DATE)
     )
 
     return useMemo(() => {


### PR DESCRIPTION
Implements [TECH-1040](https://dhis2.atlassian.net/browse/TECH-1040)

---

### Key features

1. rename `lastUpdated` to `lastUpdatedDate`

---

### Description

The field has been renamed in the backend, see https://jira.dhis2.org/browse/DHIS2-12856.
The header field name remains `lastupdated`.

---

### Screenshots

Example of saved AO with `lastUpdatedDate` dimension, save and load works as it should:
<img width="974" alt="Screenshot 2022-03-15 at 16 06 38" src="https://user-images.githubusercontent.com/150978/158409192-1a45dd9f-c218-4bff-92a2-9ef008f501f6.png">


