### PR TITLE
fix: remove vis type filter in OpenFileDialog and filter only LL AOs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^23.6.2",
+        "@dhis2/analytics": "^23.6.3",
         "@dhis2/app-runtime": "^3.4.0",
         "@dhis2/d2-ui-rich-text": "^7.3.3",
         "@dhis2/ui": "^8.1.3",

--- a/src/components/Toolbar/MenuBar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar/MenuBar.js
@@ -13,10 +13,7 @@ import { acSetCurrent } from '../../../actions/current.js'
 import { acSetVisualization } from '../../../actions/visualization.js'
 import { getAlertTypeByStatusCode } from '../../../modules/error.js'
 import history from '../../../modules/history.js'
-import {
-    visTypes,
-    getVisualizationFromCurrent,
-} from '../../../modules/visualization.js'
+import { getVisualizationFromCurrent } from '../../../modules/visualization.js'
 import { sGetCurrent } from '../../../reducers/current.js'
 import { sGetVisualization } from '../../../reducers/visualization.js'
 import { ToolbarDownloadDropdown } from '../../DownloadMenu/index.js'
@@ -222,8 +219,6 @@ const MenuBar = ({
                 currentUser={currentUser}
                 fileType={apiObjectName}
                 fileObject={current}
-                filterVisTypes={visTypes}
-                defaultFilterVisType={VIS_TYPE_LINE_LIST}
                 onOpen={onOpen}
                 onNew={onNew}
                 onRename={onRename}

--- a/src/components/Toolbar/MenuBar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar/MenuBar.js
@@ -219,6 +219,7 @@ const MenuBar = ({
                 currentUser={currentUser}
                 fileType={apiObjectName}
                 fileObject={current}
+                defaultFilterVisType={VIS_TYPE_LINE_LIST}
                 onOpen={onOpen}
                 onNew={onNew}
                 onRename={onRename}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,10 +1951,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^23.6.2":
-  version "23.6.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.6.2.tgz#9aadc4bbc31ca86c33e1611ccc15ea311b3e67f1"
-  integrity sha512-0SNNx/TQMz6uuoNBYpVOa8U0bu1n7dMcKnF2ZsGcpr5PjbyupXN82/qkNpoSoTzmfKGKFn7/0y9J/jsvXXgFTw==
+"@dhis2/analytics@^23.6.3":
+  version "23.6.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.6.3.tgz#6b28c3bfdd2f1587cd4fa83549a21b389892dd76"
+  integrity sha512-wj7yAEUIpuGWNYJwxDOkLFa+uPIVSWv3Ug2jsKdcQXJn9TcFxZzhWxiCBTwjckVteQd0zjP1Ov0pT6Lq4/CCWQ==
   dependencies:
     "@dhis2/d2-ui-translation-dialog" "^7.3.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Related to https://github.com/dhis2/analytics/pull/1176

### Key features

1. Filter only LL AOs
2. Remove the vis type filter in the dialog

---

### Description

We only want to list Line list AOs.

---

### Screenshots

No vis type filter:
<img width="811" alt="Screenshot 2022-03-16 at 12 45 24" src="https://user-images.githubusercontent.com/150978/158583981-dc22c5a8-1280-4f08-b2f4-69728f1ffdb9.png">

Query filter for LL AOs only:
<img width="622" alt="Screenshot 2022-03-16 at 12 45 35" src="https://user-images.githubusercontent.com/150978/158583964-e20c845e-ac77-4fa9-b1e7-acdb578da31e.png">

