### PR TITLE
fix: prevent extra api request and render of vis table when sorting and updating

### DIFF
--- a/src/actions/current.js
+++ b/src/actions/current.js
@@ -18,7 +18,7 @@ const acSetCurrent = (value) => ({
     value,
 })
 
-export const tSetCurrent = (visualization) => (dispatch, getState) => {
+export const tSetCurrent = (visualization) => (dispatch) => {
     const defaultSortField = visualization[AXIS_ID_COLUMNS][0].dimension
 
     dispatch(acSetCurrent(visualization))

--- a/src/actions/current.js
+++ b/src/actions/current.js
@@ -41,7 +41,7 @@ export const acSetCurrentFromUi = (value) => ({
 })
 
 export const tSetCurrentFromUi = () => async (dispatch, getState) => {
-    const { sortField } = sGetUiSorting(getState())
+    const { sortField, sortDirection } = sGetUiSorting(getState())
     const ui = sGetUi(getState())
 
     const allDimensions = [
@@ -50,16 +50,19 @@ export const tSetCurrentFromUi = () => async (dispatch, getState) => {
         ...ui.layout.filters,
     ].map((d) => headersMap[d] || d)
 
+    const sorting = {
+        sortField,
+        sortDirection,
+        page: FIRST_PAGE,
+    }
+
     if (!sortField || !allDimensions.includes(sortField)) {
         const defaultSortField = ui.layout[AXIS_ID_COLUMNS][0]
-        const sorting = {
-            sortField: headersMap[defaultSortField] || defaultSortField,
-            sortDirection: DEFAULT_SORT_DIRECTION,
-            page: FIRST_PAGE,
-        }
 
-        dispatch(acSetUiSorting(sorting))
+        sorting.sortField = headersMap[defaultSortField] || defaultSortField
+        sorting.sortDirection = DEFAULT_SORT_DIRECTION
     }
 
     dispatch(acSetCurrentFromUi(ui))
+    dispatch(acSetUiSorting(sorting))
 }

--- a/src/actions/current.js
+++ b/src/actions/current.js
@@ -10,6 +10,7 @@ import {
     sGetUi,
     sGetUiSorting,
     DEFAULT_SORT_DIRECTION,
+    FIRST_PAGE,
 } from '../reducers/ui.js'
 
 const acSetCurrent = (value) => ({
@@ -18,9 +19,9 @@ const acSetCurrent = (value) => ({
 })
 
 export const tSetCurrent = (visualization) => (dispatch, getState) => {
-    const { sortField, sortDirection } = sGetUiSorting(getState())
+    const { sortField, sortDirection, page } = sGetUiSorting(getState())
 
-    let sorting = { sortField, sortDirection }
+    let sorting = { sortField, sortDirection, page }
 
     const allDimensions = [
         ...visualization.columns,
@@ -33,6 +34,7 @@ export const tSetCurrent = (visualization) => (dispatch, getState) => {
         sorting = {
             sortField: headersMap[defaultSortField] || defaultSortField,
             sortDirection: DEFAULT_SORT_DIRECTION,
+            page: FIRST_PAGE,
         }
     }
 
@@ -64,6 +66,7 @@ export const tSetCurrentFromUi = () => async (dispatch, getState) => {
         const sorting = {
             sortField: headersMap[defaultSortField] || defaultSortField,
             sortDirection: DEFAULT_SORT_DIRECTION,
+            page: FIRST_PAGE,
         }
 
         dispatch(acSetUiSorting(sorting))

--- a/src/actions/current.js
+++ b/src/actions/current.js
@@ -1,14 +1,44 @@
+import { AXIS_ID_COLUMNS } from '@dhis2/analytics'
+import { acSetUiSorting } from '../actions/ui.js'
+import { headersMap } from '../modules/visualization.js'
 import {
     SET_CURRENT,
     CLEAR_CURRENT,
     SET_CURRENT_FROM_UI,
 } from '../reducers/current.js'
-import { sGetUi } from '../reducers/ui.js'
+import {
+    sGetUi,
+    sGetUiSorting,
+    DEFAULT_SORT_DIRECTION,
+} from '../reducers/ui.js'
 
-export const acSetCurrent = (value) => ({
+const acSetCurrent = (value) => ({
     type: SET_CURRENT,
     value,
 })
+
+export const tSetCurrent = (visualization) => (dispatch, getState) => {
+    const { sortField, sortDirection } = sGetUiSorting(getState())
+
+    let sorting = { sortField, sortDirection }
+
+    const allDimensions = [
+        ...visualization.columns,
+        ...visualization.rows,
+        ...visualization.filters,
+    ].map((f) => headersMap[f.dimension] || f.dimension)
+
+    if (!sortField || !allDimensions.includes(sortField)) {
+        const defaultSortField = visualization[AXIS_ID_COLUMNS][0].dimension
+        sorting = {
+            sortField: headersMap[defaultSortField] || defaultSortField,
+            sortDirection: DEFAULT_SORT_DIRECTION,
+        }
+    }
+
+    dispatch(acSetCurrent(visualization))
+    dispatch(acSetUiSorting(sorting))
+}
 
 export const acClearCurrent = () => ({
     type: CLEAR_CURRENT,
@@ -20,5 +50,24 @@ export const acSetCurrentFromUi = (value) => ({
 })
 
 export const tSetCurrentFromUi = () => async (dispatch, getState) => {
-    dispatch(acSetCurrentFromUi(sGetUi(getState())))
+    const { sortField } = sGetUiSorting(getState())
+    const ui = sGetUi(getState())
+
+    const allDimensions = [
+        ...ui.layout.columns,
+        ...ui.layout.rows,
+        ...ui.layout.filters,
+    ].map((d) => headersMap[d] || d)
+
+    if (!sortField || !allDimensions.includes(sortField)) {
+        const defaultSortField = ui.layout[AXIS_ID_COLUMNS][0]
+        const sorting = {
+            sortField: headersMap[defaultSortField] || defaultSortField,
+            sortDirection: DEFAULT_SORT_DIRECTION,
+        }
+
+        dispatch(acSetUiSorting(sorting))
+    }
+
+    dispatch(acSetCurrentFromUi(ui))
 }

--- a/src/actions/current.js
+++ b/src/actions/current.js
@@ -19,27 +19,16 @@ const acSetCurrent = (value) => ({
 })
 
 export const tSetCurrent = (visualization) => (dispatch, getState) => {
-    const { sortField, sortDirection, page } = sGetUiSorting(getState())
+    const defaultSortField = visualization[AXIS_ID_COLUMNS][0].dimension
 
-    let sorting = { sortField, sortDirection, page }
-
-    const allDimensions = [
-        ...visualization.columns,
-        ...visualization.rows,
-        ...visualization.filters,
-    ].map((f) => headersMap[f.dimension] || f.dimension)
-
-    if (!sortField || !allDimensions.includes(sortField)) {
-        const defaultSortField = visualization[AXIS_ID_COLUMNS][0].dimension
-        sorting = {
+    dispatch(acSetCurrent(visualization))
+    dispatch(
+        acSetUiSorting({
             sortField: headersMap[defaultSortField] || defaultSortField,
             sortDirection: DEFAULT_SORT_DIRECTION,
             page: FIRST_PAGE,
-        }
-    }
-
-    dispatch(acSetCurrent(visualization))
-    dispatch(acSetUiSorting(sorting))
+        })
+    )
 }
 
 export const acClearCurrent = () => ({

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -22,6 +22,7 @@ import {
     SET_UI_LAYOUT,
     SET_UI_OPTION,
     SET_UI_OPTIONS,
+    SET_UI_SORTING,
     SET_UI_FROM_VISUALIZATION,
     CLEAR_UI,
     SET_UI_DETAILS_PANEL_OPEN,
@@ -218,6 +219,11 @@ export const acSetUiDetailsPanelOpen = (value) => ({
 
 export const acSetUiAccessoryPanelOpen = (value) => ({
     type: SET_UI_ACCESSORY_PANEL_OPEN,
+    value,
+})
+
+export const acSetUiSorting = (value) => ({
+    type: SET_UI_SORTING,
     value,
 })
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,7 +5,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect, useRef } from 'react'
 import { connect, useDispatch } from 'react-redux'
-import { acSetCurrent } from '../actions/current.js'
+import { tSetCurrent } from '../actions/current.js'
 import {
     acClearAll,
     acClearLoadError,
@@ -366,7 +366,7 @@ const mapDispatchToProps = {
     addSettings: tAddSettings,
     clearAll: acClearAll,
     clearLoadError: acClearLoadError,
-    setCurrent: acSetCurrent,
+    setCurrent: tSetCurrent,
     setInitMetadata: tSetInitMetadata,
     setVisualization: acSetVisualization,
     setUser: acSetUser,

--- a/src/components/Toolbar/MenuBar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar/MenuBar.js
@@ -9,7 +9,7 @@ import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
-import { acSetCurrent } from '../../../actions/current.js'
+import { tSetCurrent } from '../../../actions/current.js'
 import { acSetVisualization } from '../../../actions/visualization.js'
 import { getAlertTypeByStatusCode } from '../../../modules/error.js'
 import history from '../../../modules/history.js'
@@ -255,7 +255,7 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = {
-    setCurrent: acSetCurrent,
+    setCurrent: tSetCurrent,
     setVisualization: acSetVisualization,
 }
 

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -1,4 +1,4 @@
-import { formatValue, AXIS_ID_COLUMNS } from '@dhis2/analytics'
+import { formatValue } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import {
     DataTable,

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -32,7 +32,7 @@ import {
 } from '../../modules/options.js'
 import { headersMap } from '../../modules/visualization.js'
 import { sGetMetadata } from '../../reducers/metadata.js'
-import { sGetUiSorting } from '../../reducers/ui.js'
+import { sGetUiSorting, FIRST_PAGE } from '../../reducers/ui.js'
 import styles from './styles/Visualization.module.css'
 import { useAnalyticsData } from './useAnalyticsData.js'
 import { useAvailableWidth } from './useAvailableWidth.js'
@@ -67,18 +67,16 @@ export const Visualization = ({
 }) => {
     const dispatch = useDispatch()
     const metadata = useSelector(sGetMetadata)
-    const { sortField, sortDirection } = useSelector(sGetUiSorting)
+    const { sortField, sortDirection, page } = useSelector(sGetUiSorting)
     const isInModal = !!relativePeriodDate
     const { availableOuterWidth, availableInnerWidth } =
         useAvailableWidth(isInModal)
 
-    const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(100)
     const { fetching, error, data } = useAnalyticsData({
         visualization,
         relativePeriodDate,
         onResponseReceived,
-        page,
         pageSize,
     })
 
@@ -106,10 +104,17 @@ export const Visualization = ({
     const fontSizeClass = getFontSizeClass(visualization.fontSize)
     const colSpan = String(Math.max(data.headers.length, 1))
 
-    const sortData = ({ sortField, sortDirection }) => {
-        dispatch(acSetUiSorting({ sortField, sortDirection }))
-        setPage(1)
-    }
+    const sortData = ({ name, direction }) =>
+        dispatch(
+            acSetUiSorting({
+                sortField: name,
+                sortDirection: direction,
+                page: FIRST_PAGE,
+            })
+        )
+
+    const setPage = (pageNum) =>
+        dispatch(acSetUiSorting({ sortField, sortDirection, page: pageNum }))
 
     const formatCellValue = (value, header) => {
         if (
@@ -198,15 +203,7 @@ export const Visualization = ({
                                         top="0"
                                         key={header.name}
                                         name={header.name}
-                                        onSortIconClick={({
-                                            name,
-                                            direction,
-                                        }) =>
-                                            sortData({
-                                                sortField: name,
-                                                sortDirection: direction,
-                                            })
-                                        }
+                                        onSortIconClick={sortData}
                                         sortDirection={
                                             header.name === sortField
                                                 ? sortDirection

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -13,10 +13,10 @@ import {
 import cx from 'classnames'
 import moment from 'moment'
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { acSetLoadError } from '../../actions/loader.js'
-import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
+import { acSetUiOpenDimensionModal, acSetUiSorting } from '../../actions/ui.js'
 import {
     DIMENSION_ID_EVENT_STATUS,
     DIMENSION_ID_PROGRAM_STATUS,
@@ -32,6 +32,7 @@ import {
 } from '../../modules/options.js'
 import { headersMap } from '../../modules/visualization.js'
 import { sGetMetadata } from '../../reducers/metadata.js'
+import { sGetUiSorting } from '../../reducers/ui.js'
 import styles from './styles/Visualization.module.css'
 import { useAnalyticsData } from './useAnalyticsData.js'
 import { useAvailableWidth } from './useAvailableWidth.js'
@@ -66,40 +67,20 @@ export const Visualization = ({
 }) => {
     const dispatch = useDispatch()
     const metadata = useSelector(sGetMetadata)
+    const { sortField, sortDirection } = useSelector(sGetUiSorting)
     const isInModal = !!relativePeriodDate
     const { availableOuterWidth, availableInnerWidth } =
         useAvailableWidth(isInModal)
-    const defaultSortField = visualization[AXIS_ID_COLUMNS][0].dimension
-    const defaultSortDirection = 'asc'
 
-    const [{ sortField, sortDirection }, setSorting] = useState({
-        sortField: headersMap[defaultSortField] || defaultSortField,
-        sortDirection: defaultSortDirection,
-    })
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(100)
     const { fetching, error, data } = useAnalyticsData({
         visualization,
         relativePeriodDate,
         onResponseReceived,
-        sortField,
-        sortDirection,
         page,
         pageSize,
     })
-
-    useEffect(() => {
-        if (visualization) {
-            const sortField = visualization[AXIS_ID_COLUMNS][0].dimension
-
-            setSorting({
-                sortField: headersMap[sortField] || sortField,
-                sortDirection: defaultSortDirection,
-            })
-            setPage(1)
-            setPageSize(100)
-        }
-    }, [visualization])
 
     if (error) {
         let output
@@ -126,7 +107,7 @@ export const Visualization = ({
     const colSpan = String(Math.max(data.headers.length, 1))
 
     const sortData = ({ sortField, sortDirection }) => {
-        setSorting({ sortField, sortDirection })
+        dispatch(acSetUiSorting({ sortField, sortDirection }))
         setPage(1)
     }
 

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -213,12 +213,11 @@ const useAnalyticsData = ({
     visualization,
     relativePeriodDate,
     onResponseReceived,
-    page,
     pageSize,
 }) => {
     const dataEngine = useDataEngine()
     const isGlobalLoading = useSelector(sGetIsVisualizationLoading)
-    const { sortField, sortDirection } = useSelector(sGetUiSorting)
+    const { sortField, sortDirection, page } = useSelector(sGetUiSorting)
     const [analyticsEngine] = useState(() => Analytics.getAnalytics(dataEngine))
     const mounted = useRef(false)
     const [loading, setLoading] = useState(true)

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -26,6 +26,7 @@ import {
     headersMap,
 } from '../../modules/visualization.js'
 import { sGetIsVisualizationLoading } from '../../reducers/loader.js'
+import { sGetUiSorting } from '../../reducers/ui.js'
 
 const analyticsApiEndpointMap = {
     [OUTPUT_TYPE_ENROLLMENT]: 'enrollments',
@@ -212,13 +213,12 @@ const useAnalyticsData = ({
     visualization,
     relativePeriodDate,
     onResponseReceived,
-    sortField,
-    sortDirection,
     page,
     pageSize,
 }) => {
     const dataEngine = useDataEngine()
     const isGlobalLoading = useSelector(sGetIsVisualizationLoading)
+    const { sortField, sortDirection } = useSelector(sGetUiSorting)
     const [analyticsEngine] = useState(() => Analytics.getAnalytics(dataEngine))
     const mounted = useRef(false)
     const [loading, setLoading] = useState(true)

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -34,6 +34,7 @@ export const UPDATE_UI_PROGRAM_ID = 'UPDATE_UI_PROGRAM_ID'
 export const UPDATE_UI_PROGRAM_STAGE_ID = 'UPDATE_UI_PROGRAM_STAGE_ID'
 export const SET_UI_OPTIONS = 'SET_UI_OPTIONS'
 export const SET_UI_OPTION = 'SET_UI_OPTION'
+export const SET_UI_SORTING = 'SET_UI_SORTING'
 export const ADD_UI_LAYOUT_DIMENSIONS = 'ADD_UI_LAYOUT_DIMENSIONS'
 export const REMOVE_UI_LAYOUT_DIMENSIONS = 'REMOVE_UI_LAYOUT_DIMENSIONS'
 export const SET_UI_LAYOUT = 'SET_UI_LAYOUT'
@@ -48,6 +49,8 @@ export const REMOVE_UI_ITEMS = 'REMOVE_UI_ITEMS'
 export const ADD_UI_PARENT_GRAPH_MAP = 'ADD_UI_PARENT_GRAPH_MAP'
 export const SET_UI_CONDITIONS = 'SET_UI_CONDITIONS'
 export const SET_UI_REPETITION = 'SET_UI_REPETITION'
+
+export const DEFAULT_SORT_DIRECTION = 'asc'
 
 const EMPTY_UI = {
     draggingId: null,
@@ -67,6 +70,11 @@ const EMPTY_UI = {
     options: {},
     parentGraphMap: {},
     repetitionByDimension: {},
+    sorting: {
+        sortField: null,
+        sortDirection: DEFAULT_SORT_DIRECTION,
+        page: 1,
+    },
 }
 
 export const DEFAULT_UI = {
@@ -94,6 +102,11 @@ export const DEFAULT_UI = {
     parentGraphMap: {},
     repetitionByDimension: {},
     conditions: {},
+    sorting: {
+        sortField: null,
+        sortDirection: DEFAULT_SORT_DIRECTION,
+        page: 1,
+    },
 }
 
 const getPreselectedUi = (options) => {
@@ -129,6 +142,12 @@ export default (state = EMPTY_UI, action) => {
             return {
                 ...state,
                 input: action.value,
+            }
+        }
+        case SET_UI_SORTING: {
+            return {
+                ...state,
+                sorting: action.value,
             }
         }
         case CLEAR_UI_PROGRAM: {
@@ -344,6 +363,8 @@ export const sGetUiParentGraphMap = (state) => sGetUi(state).parentGraphMap
 export const sGetUiConditions = (state) => sGetUi(state).conditions || {}
 export const sGetUiRepetition = (state) =>
     sGetUi(state).repetitionByDimension || {}
+
+export const sGetUiSorting = (state) => sGetUi(state).sorting
 
 // Selectors level 2
 

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -51,6 +51,7 @@ export const SET_UI_CONDITIONS = 'SET_UI_CONDITIONS'
 export const SET_UI_REPETITION = 'SET_UI_REPETITION'
 
 export const DEFAULT_SORT_DIRECTION = 'asc'
+export const FIRST_PAGE = 1
 
 const EMPTY_UI = {
     draggingId: null,
@@ -73,7 +74,7 @@ const EMPTY_UI = {
     sorting: {
         sortField: null,
         sortDirection: DEFAULT_SORT_DIRECTION,
-        page: 1,
+        page: FIRST_PAGE,
     },
 }
 
@@ -105,7 +106,7 @@ export const DEFAULT_UI = {
     sorting: {
         sortField: null,
         sortDirection: DEFAULT_SORT_DIRECTION,
-        page: 1,
+        page: FIRST_PAGE,
     },
 }
 


### PR DESCRIPTION
Implements [TECH-1033](https://dhis2.atlassian.net/browse/TECH-1033)

### Key features

1. sortField, sortDirection and page number need to be stored in redux store since multiple components change the values (sorting buttons on table, and the Update button). With this change, the sorting and current data in store are coordinated so that the api request  in useAnalyticsData only triggers once.

You could argue that `page` shouldn't be bundled together with the sortField/sortDirection in the same redux property, but they are connected in many cases, so I went ahead and bundled them. Also, I left pageSize in Visualization component state since only the table causes changes to that value or is dependent on that value.

### Screenshots

Sort and then change the column order and then update
https://user-images.githubusercontent.com/6113918/158615528-2544e953-0b58-46fe-a381-696eb3f0ba2b.mov


Sort and then delete sort column and then update
https://user-images.githubusercontent.com/6113918/158615646-59b01a72-e90e-481e-a6f8-6275dbeb2317.mov


Sort and then open different AO containing same sort field
https://user-images.githubusercontent.com/6113918/158615734-8bb18c67-1624-457a-b569-b512dd1eac06.mov

Sort and then page forward and then Update


https://user-images.githubusercontent.com/6113918/158615863-9cd3c3f5-17cf-410d-950d-7495f8a5e558.mov





