### PR TITLE
Fix/use prefixed sort dimension

### DIFF
--- a/src/actions/current.js
+++ b/src/actions/current.js
@@ -1,5 +1,6 @@
 import { AXIS_ID_COLUMNS } from '@dhis2/analytics'
 import { acSetUiSorting } from '../actions/ui.js'
+import { formatDimensionId } from '../modules/utils.js'
 import { headersMap } from '../modules/visualization.js'
 import {
     SET_CURRENT,
@@ -19,7 +20,9 @@ const acSetCurrent = (value) => ({
 })
 
 export const tSetCurrent = (visualization) => (dispatch) => {
-    const defaultSortField = visualization[AXIS_ID_COLUMNS][0].dimension
+    const defaultSortField = formatDimensionId(
+        visualization[AXIS_ID_COLUMNS][0]
+    )
 
     dispatch(acSetCurrent(visualization))
     dispatch(

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -26,3 +26,8 @@ export const useDidUpdateEffect = (fn, inputs) => {
         }
     }, inputs)
 }
+
+export const formatDimensionId = (dimensionObj) =>
+    dimensionObj.programStage?.id
+        ? `${dimensionObj.programStage.id}.${dimensionObj.dimension}`
+        : dimensionObj.dimension


### PR DESCRIPTION
Implements [TECH-1045](https://dhis2.atlassian.net/browse/TECH-1045)

---

### Key features

1. pass prefixed dimension to `asc`/`desc` for sorting

---

### Description

Dimension with a program stage defined need to be prefixed when passed to the `asc`/`desc` parameter in analytics.

---

### Screenshots

Before:
<img width="420" alt="Screenshot 2022-03-18 at 12 38 36" src="https://user-images.githubusercontent.com/150978/158996580-cf760934-44c0-44e9-97e4-0f1d8834fef5.png">


After:
<img width="413" alt="Screenshot 2022-03-18 at 12 38 12" src="https://user-images.githubusercontent.com/150978/158996533-5033a877-ee0a-433e-aa2d-56d6cc24066c.png">

