### PR TITLE
fix: open correct tab, enable date to be removed (TECH-1044, TECH-1052)

### DIFF
--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -79,7 +79,11 @@ export const PeriodDimension = ({ dimension, onClose }) => {
     const selectedIds =
         useSelector((state) => sGetUiItemsByDimension(state, dimension?.id)) ||
         []
-    const [entryMethod, setEntryMethod] = useState(OPTION_PRESETS)
+    const [entryMethod, setEntryMethod] = useState(
+        selectedIds.filter((id) => isStartEndDate(id)).length
+            ? OPTION_START_END_DATES
+            : OPTION_PRESETS
+    )
     const [presets, setPresets] = useState(() =>
         selectedIds
             .filter((id) => !isStartEndDate(id))
@@ -97,9 +101,7 @@ export const PeriodDimension = ({ dimension, onClose }) => {
     }, [presets])
 
     useEffect(() => {
-        if (startEndDate) {
-            updatePeriodDimensionItems([{ id: startEndDate }])
-        }
+        updatePeriodDimensionItems(startEndDate ? [{ id: startEndDate }] : [])
     }, [startEndDate])
 
     const updatePeriodDimensionItems = (items) => {

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -10,9 +10,7 @@ export const StartEndDate = ({ value, setValue }) => {
     const [endDate, setEndDate] = useState(endDateStr)
 
     useEffect(() => {
-        if (startDate && endDate) {
-            setValue(`${startDate}_${endDate}`)
-        }
+        setValue(startDate && endDate ? `${startDate}_${endDate}` : '')
     }, [startDate, endDate])
 
     const onStartDateChange = ({ value }) => {


### PR DESCRIPTION
Implements [TECH-1044](https://dhis2.atlassian.net/browse/TECH-1044)
Implements [TECH-1052](https://dhis2.atlassian.net/browse/TECH-1052)

1. When the period selector is opened, the correct tab is now preselected
2. Enables dates to be removed/cleared