### PR TITLE
fix: make URL values in datatable clickable TECH-1054

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -130,6 +130,12 @@ export const Visualization = ({
                     ? 'yyyy-MM-DD hh:mm'
                     : 'yyyy-MM-DD'
             )
+        } else if (header?.valueType === 'URL') {
+            return (
+                <a href={value} target="_blank" rel="noreferrer">
+                    {value}
+                </a>
+            )
         } else {
             return formatValue(value, header?.valueType || 'TEXT', {
                 digitGroupSeparator: visualization.digitGroupSeparator,

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -18,6 +18,11 @@ import { useDispatch, useSelector } from 'react-redux'
 import { acSetLoadError } from '../../actions/loader.js'
 import { acSetUiOpenDimensionModal, acSetUiSorting } from '../../actions/ui.js'
 import {
+    VALUE_TYPE_DATE,
+    VALUE_TYPE_TEXT,
+    VALUE_TYPE_URL,
+} from '../../modules/conditions.js'
+import {
     DIMENSION_ID_EVENT_STATUS,
     DIMENSION_ID_PROGRAM_STATUS,
     DIMENSION_ID_LAST_UPDATED,
@@ -124,20 +129,20 @@ export const Visualization = ({
             ].includes(header?.name)
         ) {
             return metadata[value]?.name || value
-        } else if (header?.valueType === 'DATE') {
+        } else if (header?.valueType === VALUE_TYPE_DATE) {
             return moment(value).format(
                 header.name === headersMap[DIMENSION_ID_LAST_UPDATED]
                     ? 'yyyy-MM-DD hh:mm'
                     : 'yyyy-MM-DD'
             )
-        } else if (header?.valueType === 'URL') {
+        } else if (header?.valueType === VALUE_TYPE_URL) {
             return (
                 <a href={value} target="_blank" rel="noreferrer">
                     {value}
                 </a>
             )
         } else {
-            return formatValue(value, header?.valueType || 'TEXT', {
+            return formatValue(value, header?.valueType || VALUE_TYPE_TEXT, {
                 digitGroupSeparator: visualization.digitGroupSeparator,
                 skipRounding: false, // TODO should there be an option for this?
             })


### PR DESCRIPTION
Implements [TECH-1054](https://dhis2.atlassian.net/browse/TECH-1054)

---

### Key features

1. make URLs clickable in datatable

---

### Description

Row values of `URL` type should be rendered as `<a>` tags to make them clickable and open in a new tab.

---

### Screenshots

<img width="572" alt="Screenshot 2022-03-22 at 10 14 08" src="https://user-images.githubusercontent.com/150978/159447769-973796fd-ad66-4b78-b848-c7b54bb8c0c2.png">

