### PR TITLE
fix: pass correct page length to pager

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -290,7 +290,11 @@ export const Visualization = ({
                                         pageSizeSelectText={i18n.t(
                                             'Rows per page'
                                         )}
-                                        pageLength={data.rows.length}
+                                        pageLength={
+                                            fetching && data.isLastPage
+                                                ? pageSize
+                                                : data.rows.length
+                                        }
                                         pageSummaryText={({
                                             firstItem,
                                             lastItem,


### PR DESCRIPTION
The issue only occured when navigating backwards from the last page. The "next" button is disabled when on the last page, so the combination of "fetching" and "isLastPage" covers this. All previous pages will have the same number of items as the page size, so using that to set the correct length.