### PR TITLE
fix: reduce unnecessary rerenders by not creating new objects and arrays in selectors

### DIFF
--- a/src/components/DimensionMenu/DimensionMenu.js
+++ b/src/components/DimensionMenu/DimensionMenu.js
@@ -2,12 +2,11 @@ import { Layer, Popper, IconMore16 } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState, useRef } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import {
     acAddUiLayoutDimensions,
     acRemoveUiLayoutDimensions,
 } from '../../actions/ui.js'
-import { sGetUiType, sGetUiLayout } from '../../reducers/ui.js'
 import IconButton from '../IconButton/IconButton.js'
 import styles from './DimensionMenu.module.css'
 import MenuItems from './MenuItems.js'
@@ -20,10 +19,14 @@ const getAxisIdForDimension = (dimensionId, layout) => {
     return axisLayout ? axisLayout[0] : undefined
 }
 
-const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
+const DimensionMenu = ({
+    currentAxisId,
+    dimensionId,
+    dimensionMetadata,
+    visType,
+    layout,
+}) => {
     const dispatch = useDispatch()
-    const visType = useSelector(sGetUiType)
-    const layout = useSelector(sGetUiLayout)
 
     const axisId = currentAxisId || getAxisIdForDimension(dimensionId, layout)
 
@@ -85,6 +88,10 @@ DimensionMenu.propTypes = {
     currentAxisId: PropTypes.string,
     dimensionId: PropTypes.string,
     dimensionMetadata: PropTypes.object,
+    layout: PropTypes.object,
+    visType: PropTypes.string,
 }
 
-export default DimensionMenu
+const MemoizedDimensionMenu = React.memo(DimensionMenu)
+
+export default MemoizedDimensionMenu

--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -107,6 +107,12 @@ const getIdFromDraggingId = (draggingId) => {
     return id
 }
 
+const constraint = {
+    activationConstraint: {
+        distance: 15,
+    },
+}
+
 const OuterDndContext = ({ children }) => {
     const [sourceAxis, setSourceAxis] = useState(null)
 
@@ -115,18 +121,14 @@ const OuterDndContext = ({ children }) => {
 
     const layout = useSelector(sGetUiLayout)
     const metadata = useSelector(sGetMetadata)
-    const chipItems =
-        useSelector((state) => sGetUiItemsByDimension(state, id)) || []
+    const chipItems = useSelector((state) => sGetUiItemsByDimension(state, id))
 
-    const chipConditions =
-        useSelector((state) => sGetUiConditionsByDimension(state, id)) || {}
+    const chipConditions = useSelector((state) =>
+        sGetUiConditionsByDimension(state, id)
+    )
 
     // Wait 15px movement before starting drag, so that click event isn't overridden
-    const pointerSensor = useSensor(PointerSensor, {
-        activationConstraint: {
-            distance: 15,
-        },
-    })
+    const pointerSensor = useSensor(PointerSensor, constraint)
     const sensors = useSensors(pointerSensor)
 
     const dispatch = useDispatch()
@@ -230,10 +232,10 @@ const OuterDndContext = ({ children }) => {
     }
 
     const onDragStart = ({ active }) => {
-        const id = getIdFromDraggingId(active.id)
-
         setSourceAxis(active.data.current.sortable.containerId)
         dispatch(acSetUiDraggingId(active.id))
+
+        const id = getIdFromDraggingId(active.id)
         dispatch(
             acAddMetadata({
                 [id]: {
@@ -247,9 +249,7 @@ const OuterDndContext = ({ children }) => {
         )
     }
 
-    const onDragCancel = () => {
-        dispatch(acSetUiDraggingId(null))
-    }
+    const onDragCancel = () => dispatch(acSetUiDraggingId(null))
 
     const onDragEnd = (result) => {
         const { active, over } = result

--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -4,7 +4,7 @@ import {
     DragOverlay,
     useSensor,
     useSensors,
-    MouseSensor,
+    PointerSensor,
 } from '@dnd-kit/core'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -122,12 +122,12 @@ const OuterDndContext = ({ children }) => {
         useSelector((state) => sGetUiConditionsByDimension(state, id)) || {}
 
     // Wait 15px movement before starting drag, so that click event isn't overridden
-    const mouseSensor = useSensor(MouseSensor, {
+    const pointerSensor = useSensor(PointerSensor, {
         activationConstraint: {
             distance: 15,
         },
     })
-    const sensors = useSensors(mouseSensor)
+    const sensors = useSensors(pointerSensor)
 
     const dispatch = useDispatch()
 

--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types'
 import React, { useMemo, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
-import { sGetLoadError } from '../../reducers/loader.js'
 import { sGetMetadata } from '../../reducers/metadata.js'
 import {
     sGetUiItemsByDimension,
@@ -36,8 +35,6 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
         [id, name, dimensionType, valueType, optionSet]
     )
 
-    const metadata = useSelector(sGetMetadata)
-
     const {
         attributes,
         listeners,
@@ -52,12 +49,10 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
         id,
         data: memoizedDimensionMetadata,
     })
-    const globalLoadError = useSelector(sGetLoadError)
-
+    const metadata = useSelector(sGetMetadata)
     const conditions = useSelector((state) =>
         sGetUiConditionsByDimension(state, id)
     )
-
     const items = useSelector((state) => sGetUiItemsByDimension(state, id))
 
     const memoizedOnClick = useCallback(
@@ -99,10 +94,6 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
     const dataTest = `layout-chip-${id}`
 
     const renderTooltipContent = () => <TooltipContent dimension={dimension} />
-
-    if (globalLoadError && !name) {
-        return null
-    }
 
     return (
         <div

--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -114,7 +114,7 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
                         axisId === AXIS_ID_FILTERS &&
                         !items.length &&
                         !conditions?.condition?.length &&
-                        !conditions.legendSet,
+                        !conditions?.legendSet,
                     [styles.active]: isDragging,
                     [styles.insertBefore]: insertPosition === BEFORE,
                     [styles.insertAfter]: insertPosition === AFTER,

--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
 import React, { useMemo, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
+import { sGetLoadError } from '../../reducers/loader.js'
 import { sGetMetadata } from '../../reducers/metadata.js'
 import {
     sGetUiItemsByDimension,
@@ -35,6 +36,8 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
         [id, name, dimensionType, valueType, optionSet]
     )
 
+    const metadata = useSelector(sGetMetadata)
+
     const {
         attributes,
         listeners,
@@ -49,10 +52,12 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
         id,
         data: memoizedDimensionMetadata,
     })
-    const metadata = useSelector(sGetMetadata)
+    const globalLoadError = useSelector(sGetLoadError)
+
     const conditions = useSelector((state) =>
         sGetUiConditionsByDimension(state, id)
     )
+
     const items = useSelector((state) => sGetUiItemsByDimension(state, id))
 
     const memoizedOnClick = useCallback(
@@ -94,6 +99,10 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
     const dataTest = `layout-chip-${id}`
 
     const renderTooltipContent = () => <TooltipContent dimension={dimension} />
+
+    if (globalLoadError && !name) {
+        return null
+    }
 
     return (
         <div

--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -4,8 +4,9 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React from 'react'
-import { useSelector } from 'react-redux'
+import React, { useMemo, useCallback } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
 import { sGetLoadError } from '../../reducers/loader.js'
 import { sGetMetadata } from '../../reducers/metadata.js'
 import {
@@ -20,21 +21,22 @@ import { default as TooltipContent } from './TooltipContent.js'
 const BEFORE = 'BEFORE'
 const AFTER = 'AFTER'
 
-const Chip = ({
-    dimension,
-    axisId,
-    isLast,
-    overLastDropZone,
-    onClick,
-    activeIndex,
-}) => {
-    const {
-        id: dimensionId,
-        name: dimensionName,
-        dimensionType,
-        valueType,
-        optionSet,
-    } = dimension
+const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
+    const dispatch = useDispatch()
+    const { id, name, dimensionType, valueType, optionSet } = dimension
+
+    const memoizedDimensionMetadata = useMemo(
+        () => ({
+            id,
+            name,
+            dimensionType,
+            valueType,
+            optionSet,
+        }),
+        [id, name, dimensionType, valueType, optionSet]
+    )
+
+    const metadata = useSelector(sGetMetadata)
 
     const {
         attributes,
@@ -47,26 +49,24 @@ const Chip = ({
         transform,
         transition,
     } = useSortable({
-        id: dimensionId,
-        data: {
-            name: dimensionName,
-            dimensionType,
-            valueType,
-            optionSet,
-        },
+        id,
+        data: memoizedDimensionMetadata,
     })
     const globalLoadError = useSelector(sGetLoadError)
-    const metadata = useSelector(sGetMetadata)
-    const conditions =
-        useSelector((state) =>
-            sGetUiConditionsByDimension(state, dimension.id)
-        ) || {}
-    const items =
-        useSelector((state) => sGetUiItemsByDimension(state, dimension.id)) ||
-        []
+
+    const conditions = useSelector((state) =>
+        sGetUiConditionsByDimension(state, id)
+    )
+
+    const items = useSelector((state) => sGetUiItemsByDimension(state, id))
+
+    const memoizedOnClick = useCallback(
+        () => dispatch(acSetUiOpenDimensionModal(id)),
+        [dispatch, id]
+    )
 
     let insertPosition = undefined
-    if (over?.id === dimensionId) {
+    if (over?.id === id) {
         // This chip is being hovered over by a dragged item
         if (activeIndex === -1) {
             //This item came from the dimensions panel
@@ -94,13 +94,13 @@ const Chip = ({
           }
         : undefined
 
-    const id = Math.random().toString(36)
+    const randomId = Math.random().toString(36)
 
-    const dataTest = `layout-chip-${dimensionId}`
+    const dataTest = `layout-chip-${id}`
 
     const renderTooltipContent = () => <TooltipContent dimension={dimension} />
 
-    if (globalLoadError && !dimensionName) {
+    if (globalLoadError && !name) {
         return null
     }
 
@@ -117,12 +117,12 @@ const Chip = ({
                     [styles.chipEmpty]:
                         axisId === AXIS_ID_FILTERS &&
                         !items.length &&
-                        !conditions.condition?.length &&
+                        !conditions?.condition?.length &&
                         !conditions.legendSet,
                     [styles.active]: isDragging,
                     [styles.insertBefore]: insertPosition === BEFORE,
                     [styles.insertAfter]: insertPosition === AFTER,
-                    [styles.showBlank]: !dimensionName,
+                    [styles.showBlank]: !name,
                 })}
             >
                 <div className={styles.content}>
@@ -134,8 +134,8 @@ const Chip = ({
                             {({ ref, onMouseOver, onMouseOut }) => (
                                 <div
                                     data-test={dataTest}
-                                    id={id}
-                                    onClick={onClick}
+                                    id={randomId}
+                                    onClick={memoizedOnClick}
                                     ref={ref}
                                     onMouseOver={onMouseOver}
                                     onMouseOut={onMouseOut}
@@ -150,10 +150,7 @@ const Chip = ({
                             )}
                         </Tooltip>
                     }
-                    <DimensionMenu
-                        dimensionId={dimensionId}
-                        currentAxisId={axisId}
-                    />
+                    <DimensionMenu dimensionId={id} currentAxisId={axisId} />
                 </div>
             </div>
         </div>
@@ -162,7 +159,6 @@ const Chip = ({
 
 Chip.propTypes = {
     dimension: PropTypes.object.isRequired,
-    onClick: PropTypes.func.isRequired,
     activeIndex: PropTypes.number,
     axisId: PropTypes.string,
     isLast: PropTypes.bool,

--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -36,8 +36,6 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
         [id, name, dimensionType, valueType, optionSet]
     )
 
-    const metadata = useSelector(sGetMetadata)
-
     const {
         attributes,
         listeners,
@@ -53,13 +51,11 @@ const Chip = ({ dimension, axisId, isLast, overLastDropZone, activeIndex }) => {
         data: memoizedDimensionMetadata,
     })
     const globalLoadError = useSelector(sGetLoadError)
-
+    const metadata = useSelector(sGetMetadata)
     const conditions = useSelector((state) =>
         sGetUiConditionsByDimension(state, id)
     )
-
     const items = useSelector((state) => sGetUiItemsByDimension(state, id))
-
     const memoizedOnClick = useCallback(
         () => dispatch(acSetUiOpenDimensionModal(id)),
         [dispatch, id]

--- a/src/components/Layout/ChipBase.js
+++ b/src/components/Layout/ChipBase.js
@@ -32,7 +32,7 @@ export const ChipBase = ({ dimension, conditions, items, metadata }) => {
 
         const all = i18n.t('all')
 
-        if (!conditions.condition && !conditions.legendSet && !items.length) {
+        if (!conditions?.condition && !conditions?.legendSet && !items.length) {
             return `: ${all}`
         }
 
@@ -97,10 +97,4 @@ ChipBase.propTypes = {
     }),
     items: PropTypes.array,
     metadata: PropTypes.object,
-}
-
-ChipBase.defaultProps = {
-    conditions: {},
-    items: [],
-    metadata: {},
 }

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -3,12 +3,11 @@ import { SortableContext } from '@dnd-kit/sortable'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { getAxisName } from '../../../modules/axis.js'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../../modules/dimensionConstants.js'
 import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
 import { sGetMetadata, sGetMetadataById } from '../../../reducers/metadata.js'
-import { sGetLoadError } from '../../../reducers/loader.js'
 import {
     sGetUiDraggingId,
     sGetUiDimensionIdsByAxisId,
@@ -27,6 +26,7 @@ const DefaultAxis = ({ axisId, className }) => {
         id: lastDropZoneId,
     })
 
+    const dispatch = useDispatch()
     const dimensionIds = useSelector((state) =>
         sGetUiDimensionIdsByAxisId(state, axisId)
     )
@@ -38,8 +38,6 @@ const DefaultAxis = ({ axisId, className }) => {
     const program = useSelector((state) =>
         sGetMetadataById(state, selectedProgramId)
     )
-
-    const globalLoadError = useSelector(sGetLoadError)
 
     const programStageNames = useMemo(
         () =>
@@ -114,32 +112,26 @@ const DefaultAxis = ({ axisId, className }) => {
                 className={cx(styles.axisContainer, className)}
             >
                 <div className={styles.label}>{getAxisName(axisId)}</div>
-                {!globalLoadError && (
-                    <SortableContext id={axisId} items={dimensionIds}>
-                        <div className={styles.content}>
-                            <DropZone
-                                axisId={axisId}
-                                firstElementId={dimensionIds[0]}
-                                overLastDropZone={overLastDropZone}
-                            />
-                            {renderChips &&
-                                getDimensionsWithStageName().map(
-                                    (dimension, i) => (
-                                        <Chip
-                                            key={`${axisId}-${dimension.id}`}
-                                            dimension={dimension}
-                                            axisId={axisId}
-                                            isLast={
-                                                i === dimensionIds.length - 1
-                                            }
-                                            overLastDropZone={overLastDropZone}
-                                            activeIndex={activeIndex}
-                                        />
-                                    )
-                                )}
-                        </div>
-                    </SortableContext>
-                )}
+                <SortableContext id={axisId} items={dimensionIds}>
+                    <div className={styles.content}>
+                        <DropZone
+                            axisId={axisId}
+                            firstElementId={dimensionIds[0]}
+                            overLastDropZone={overLastDropZone}
+                        />
+                        {renderChips &&
+                            getDimensionsWithStageName().map((dimension, i) => (
+                                <Chip
+                                    key={`${axisId}-${dimension.id}`}
+                                    dimension={dimension}
+                                    axisId={axisId}
+                                    isLast={i === dimensionIds.length - 1}
+                                    overLastDropZone={overLastDropZone}
+                                    activeIndex={activeIndex}
+                                />
+                            ))}
+                    </div>
+                </SortableContext>
             </div>
         </div>
     )

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -3,11 +3,12 @@ import { SortableContext } from '@dnd-kit/sortable'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { getAxisName } from '../../../modules/axis.js'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../../modules/dimensionConstants.js'
 import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
 import { sGetMetadata, sGetMetadataById } from '../../../reducers/metadata.js'
+import { sGetLoadError } from '../../../reducers/loader.js'
 import {
     sGetUiDraggingId,
     sGetUiDimensionIdsByAxisId,
@@ -26,7 +27,6 @@ const DefaultAxis = ({ axisId, className }) => {
         id: lastDropZoneId,
     })
 
-    const dispatch = useDispatch()
     const dimensionIds = useSelector((state) =>
         sGetUiDimensionIdsByAxisId(state, axisId)
     )
@@ -38,6 +38,8 @@ const DefaultAxis = ({ axisId, className }) => {
     const program = useSelector((state) =>
         sGetMetadataById(state, selectedProgramId)
     )
+
+    const globalLoadError = useSelector(sGetLoadError)
 
     const programStageNames = useMemo(
         () =>
@@ -112,26 +114,32 @@ const DefaultAxis = ({ axisId, className }) => {
                 className={cx(styles.axisContainer, className)}
             >
                 <div className={styles.label}>{getAxisName(axisId)}</div>
-                <SortableContext id={axisId} items={dimensionIds}>
-                    <div className={styles.content}>
-                        <DropZone
-                            axisId={axisId}
-                            firstElementId={dimensionIds[0]}
-                            overLastDropZone={overLastDropZone}
-                        />
-                        {renderChips &&
-                            getDimensionsWithStageName().map((dimension, i) => (
-                                <Chip
-                                    key={`${axisId}-${dimension.id}`}
-                                    dimension={dimension}
-                                    axisId={axisId}
-                                    isLast={i === dimensionIds.length - 1}
-                                    overLastDropZone={overLastDropZone}
-                                    activeIndex={activeIndex}
-                                />
-                            ))}
-                    </div>
-                </SortableContext>
+                {!globalLoadError && (
+                    <SortableContext id={axisId} items={dimensionIds}>
+                        <div className={styles.content}>
+                            <DropZone
+                                axisId={axisId}
+                                firstElementId={dimensionIds[0]}
+                                overLastDropZone={overLastDropZone}
+                            />
+                            {renderChips &&
+                                getDimensionsWithStageName().map(
+                                    (dimension, i) => (
+                                        <Chip
+                                            key={`${axisId}-${dimension.id}`}
+                                            dimension={dimension}
+                                            axisId={axisId}
+                                            isLast={
+                                                i === dimensionIds.length - 1
+                                            }
+                                            overLastDropZone={overLastDropZone}
+                                            activeIndex={activeIndex}
+                                        />
+                                    )
+                                )}
+                        </div>
+                    </SortableContext>
+                )}
             </div>
         </div>
     )

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -4,7 +4,6 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { acSetUiOpenDimensionModal } from '../../../actions/ui.js'
 import { getAxisName } from '../../../modules/axis.js'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../../modules/dimensionConstants.js'
 import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
@@ -124,13 +123,6 @@ const DefaultAxis = ({ axisId, className }) => {
                             getDimensionsWithStageName().map((dimension, i) => (
                                 <Chip
                                     key={`${axisId}-${dimension.id}`}
-                                    onClick={() =>
-                                        dispatch(
-                                            acSetUiOpenDimensionModal(
-                                                dimension.id
-                                            )
-                                        )
-                                    }
                                     dimension={dimension}
                                     axisId={axisId}
                                     isLast={i === dimensionIds.length - 1}

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -3,7 +3,7 @@ import { SortableContext } from '@dnd-kit/sortable'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { getAxisName } from '../../../modules/axis.js'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../../modules/dimensionConstants.js'
 import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
@@ -26,7 +26,6 @@ const DefaultAxis = ({ axisId, className }) => {
         id: lastDropZoneId,
     })
 
-    const dispatch = useDispatch()
     const dimensionIds = useSelector((state) =>
         sGetUiDimensionIdsByAxisId(state, axisId)
     )
@@ -38,7 +37,6 @@ const DefaultAxis = ({ axisId, className }) => {
     const program = useSelector((state) =>
         sGetMetadataById(state, selectedProgramId)
     )
-
     const programStageNames = useMemo(
         () =>
             program?.programStages?.reduce((acc, stage) => {

--- a/src/components/MainSidebar/DimensionItem/DimensionIcon.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionIcon.js
@@ -46,7 +46,7 @@ const DIMENSION_TYPE_ICONS = {
 
 // Presentational component used by dnd - do not add redux or dnd functionality
 
-const DimensionIcon = ({ dimensionType }) => {
+const InternalDimensionIcon = ({ dimensionType }) => {
     const Icon =
         dimensionType && DIMENSION_TYPE_ICONS[dimensionType]
             ? DIMENSION_TYPE_ICONS[dimensionType]
@@ -55,8 +55,10 @@ const DimensionIcon = ({ dimensionType }) => {
     return <Icon />
 }
 
-DimensionIcon.propTypes = {
+InternalDimensionIcon.propTypes = {
     dimensionType: PropTypes.string,
 }
+
+const DimensionIcon = React.memo(InternalDimensionIcon)
 
 export { DimensionIcon }

--- a/src/components/MainSidebar/DimensionItem/DimensionItem.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionItem.js
@@ -23,8 +23,8 @@ export const DimensionItem = ({
     const visType = useSelector(sGetUiType)
     const layout = useSelector(sGetUiLayout)
 
-    const memoizedDimensionMetadata = useMemo(() => {
-        return {
+    const memoizedDimensionMetadata = useMemo(
+        () => ({
             [id]: {
                 id,
                 name,
@@ -32,8 +32,9 @@ export const DimensionItem = ({
                 valueType,
                 optionSet,
             },
-        }
-    }, [id, name, dimensionType, valueType, optionSet])
+        }),
+        [id, name, dimensionType, valueType, optionSet]
+    )
 
     const onClick = useCallback(
         () =>

--- a/src/components/MainSidebar/DimensionItem/DimensionItemBase.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionItemBase.js
@@ -51,10 +51,4 @@ DimensionItemBase.propTypes = {
     onClick: PropTypes.func,
 }
 
-DimensionItemBase.defaultProps = {
-    conditions: [],
-    items: [],
-    onClick: Function.prototype,
-}
-
 export { DimensionItemBase }

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -24,7 +24,7 @@ import { getOptionsForUi } from '../modules/options.js'
 import { getEnabledTimeDimensionIds } from '../modules/timeDimensions.js'
 import { getAdaptedUiByType, getUiFromVisualization } from '../modules/ui.js'
 import { OUTPUT_TYPE_EVENT } from '../modules/visualization.js'
-import { sGetMetadata, sGetMetadataById } from './metadata.js'
+import { sGetMetadata, sGetMetadataById, DEFAULT_METADATA } from './metadata.js'
 
 export const SET_UI_DRAGGING_ID = 'SET_UI_DRAGGING_ID'
 export const SET_UI_INPUT = 'SET_UI_INPUT'
@@ -402,7 +402,7 @@ export const renderChipsSelector = createSelector(
     [sGetUiLayout, sGetMetadata],
     (layout, metadata) => {
         const layoutItems = Object.values(layout || {}).flat()
-        const dataObjects = [...Object.values(metadata || {})] // TODO: Refactor to not use the whole metadata list
+        const dataObjects = [...Object.values(metadata || DEFAULT_METADATA)] // TODO: Refactor to not use the whole metadata list
 
         return layoutItems.every((item) =>
             dataObjects.some((data) => data.id === item)
@@ -428,7 +428,7 @@ export const useMainDimensions = () => {
                 programType,
             }),
         }))
-    }, [programId, inputType])
+    }, [store, programId, inputType])
 }
 
 export const useTimeDimensions = () => {
@@ -478,6 +478,7 @@ export const useTimeDimensions = () => {
             return null
         }
     }, [
+        store,
         inputType,
         programId,
         programStageId,

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -50,6 +50,8 @@ export const ADD_UI_PARENT_GRAPH_MAP = 'ADD_UI_PARENT_GRAPH_MAP'
 export const SET_UI_CONDITIONS = 'SET_UI_CONDITIONS'
 export const SET_UI_REPETITION = 'SET_UI_REPETITION'
 
+const DEFAULT_CONDITIONS = {}
+const DEFAULT_DIMENSION_ITEMS = []
 export const DEFAULT_SORT_DIRECTION = 'asc'
 export const FIRST_PAGE = 1
 
@@ -71,6 +73,7 @@ const EMPTY_UI = {
     options: {},
     parentGraphMap: {},
     repetitionByDimension: {},
+    conditions: DEFAULT_CONDITIONS,
     sorting: {
         sortField: null,
         sortDirection: DEFAULT_SORT_DIRECTION,
@@ -102,7 +105,7 @@ export const DEFAULT_UI = {
     activeModalDialog: null,
     parentGraphMap: {},
     repetitionByDimension: {},
-    conditions: {},
+    conditions: DEFAULT_CONDITIONS,
     sorting: {
         sortField: null,
         sortDirection: DEFAULT_SORT_DIRECTION,
@@ -361,7 +364,7 @@ export const sGetUiType = (state) => sGetUi(state).type
 export const sGetUiActiveModalDialog = (state) =>
     sGetUi(state).activeModalDialog
 export const sGetUiParentGraphMap = (state) => sGetUi(state).parentGraphMap
-export const sGetUiConditions = (state) => sGetUi(state).conditions || {}
+export const sGetUiConditions = (state) => sGetUi(state).conditions
 export const sGetUiRepetition = (state) =>
     sGetUi(state).repetitionByDimension || {}
 
@@ -375,7 +378,9 @@ export const sGetUiProgramId = (state) => sGetUiProgram(state).id
 export const sGetUiProgramStageId = (state) => sGetUiProgram(state).stageId
 
 export const sGetUiItemsByDimension = (state, dimension) =>
-    sGetUiItems(state)[dimension] || DEFAULT_UI.itemsByDimension[dimension]
+    sGetUiItems(state)[dimension] ||
+    DEFAULT_UI.itemsByDimension[dimension] ||
+    DEFAULT_DIMENSION_ITEMS
 
 export const sGetDimensionIdsFromLayout = (state) =>
     Object.values(sGetUiLayout(state)).reduce(


### PR DESCRIPTION
Implements [TECH-990](https://dhis2.atlassian.net/browse/TECH-990)

### Key features

1. Define constants for empty objects and arrays so that we're not creating a new one with each call to the selector
2. Use PointerSensor instead of MouseSensor so dnd will work on more devices (also, PointerSensor is the default for dnd-kit)
3. useMemo and useCallback and React.memo in certain cases - led to a big reduction in renders of those components, although no real performance gain was seen.

