### PR TITLE
fix: reinitialize metadata when new, opening, and deleting an AO

### DIFF
--- a/src/actions/loader.js
+++ b/src/actions/loader.js
@@ -4,6 +4,7 @@ import {
     SET_VISUALIZATION_LOADING,
 } from '../reducers/loader.js'
 import { acClearCurrent } from './current.js'
+import { tSetInitMetadata } from './metadata.js'
 import { tClearUi } from './ui.js'
 import { acClearVisualization } from './visualization.js'
 
@@ -28,6 +29,7 @@ export const acClearAll =
             dispatch(acClearLoadError())
         }
 
+        dispatch(tSetInitMetadata())
         dispatch(acClearVisualization())
         dispatch(acClearCurrent())
         dispatch(tClearUi())

--- a/src/actions/metadata.js
+++ b/src/actions/metadata.js
@@ -24,7 +24,6 @@ export const tSetInitMetadata = () => (dispatch, getState) => {
         }
     })
 
-    console.log('tSetInitMetadata')
     dispatch(acClearMetadata())
     dispatch(acAddMetadata(metaData))
 }

--- a/src/actions/metadata.js
+++ b/src/actions/metadata.js
@@ -1,10 +1,14 @@
 import { getDefaultMetadata } from '../modules/metadata.js'
-import { ADD_METADATA } from '../reducers/metadata.js'
+import { ADD_METADATA, CLEAR_METADATA } from '../reducers/metadata.js'
 import { sGetRootOrgUnits } from '../reducers/settings.js'
 
 export const acAddMetadata = (value) => ({
     type: ADD_METADATA,
     value,
+})
+
+const acClearMetadata = () => ({
+    type: CLEAR_METADATA,
 })
 
 export const tSetInitMetadata = () => (dispatch, getState) => {
@@ -20,5 +24,7 @@ export const tSetInitMetadata = () => (dispatch, getState) => {
         }
     })
 
+    console.log('tSetInitMetadata')
+    dispatch(acClearMetadata())
     dispatch(acAddMetadata(metaData))
 }

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -236,8 +236,6 @@ export const acSetShowExpandedLayoutPanel = (value) => ({
 export const tClearUi = () => (dispatch, getState) => {
     const rootOrgUnits = sGetRootOrgUnits(getState())
 
-    dispatch(acAddMetadata(getDefaultTimeDimensionsMetadata()))
-
     dispatch(
         acClearUi({
             rootOrgUnits,

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -42,7 +42,6 @@ import {
     sGetUiProgramId,
     sGetUiInputType,
 } from '../reducers/ui.js'
-import { acAddMetadata } from './metadata.js'
 
 export const acSetUiDraggingId = (value) => ({
     type: SET_UI_DRAGGING_ID,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -255,6 +255,7 @@ const App = ({
                 ...getDynamicTimeDimensionsMetadata(program, programStage),
             }
 
+            setInitMetadata()
             addParentGraphMap(getParentGraphMapFromVisualization(visualization))
             setVisualization(visualization)
             setCurrent(visualization)

--- a/src/reducers/metadata.js
+++ b/src/reducers/metadata.js
@@ -1,4 +1,5 @@
 export const ADD_METADATA = 'ADD_METADATA'
+export const CLEAR_METADATA = 'CLEAR_METADATA'
 
 export const DEFAULT_METADATA = {}
 
@@ -11,6 +12,8 @@ export default (state = DEFAULT_METADATA, action) => {
             )
             return result
         }
+        case CLEAR_METADATA:
+            return DEFAULT_METADATA
         default:
             return state
     }

--- a/src/reducers/metadata.js
+++ b/src/reducers/metadata.js
@@ -1,9 +1,9 @@
 export const ADD_METADATA = 'ADD_METADATA'
 export const CLEAR_METADATA = 'CLEAR_METADATA'
 
-export const DEFAULT_METADATA = {}
+const EMPTY_METADATA = {}
 
-export default (state = DEFAULT_METADATA, action) => {
+export default (state = EMPTY_METADATA, action) => {
     switch (action.type) {
         case ADD_METADATA: {
             const result = { ...state }
@@ -13,7 +13,7 @@ export default (state = DEFAULT_METADATA, action) => {
             return result
         }
         case CLEAR_METADATA:
-            return DEFAULT_METADATA
+            return EMPTY_METADATA
         default:
             return state
     }


### PR DESCRIPTION
Implements [TECH-1049](https://dhis2.atlassian.net/browse/TECH-1049)

### Key features

1. Add CLEAR_METADATA to tSetInitMetadata and make sure it is called when use clicks New, Open and Delete. This will ensure that the metadata in the store doesn't grow in size and potentially become a performance bottleneck.