### PR TITLE
fix: prevent time dims from being wiped when reopening modal (TECH-1061)

### DIFF
--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -150,9 +150,13 @@ export const PeriodDimension = ({ dimension, onClose }) => {
                 {entryMethod === OPTION_START_END_DATES && (
                     <StartEndDate
                         value={selectedIds[0] || ''}
-                        setValue={(value) =>
-                            updatePeriodDimensionItems([{ id: value }])
-                        }
+                        setValue={(value) => {
+                            if (!value && selectedIds.length) {
+                                updatePeriodDimensionItems([])
+                            } else if (value && value !== selectedIds[0]) {
+                                updatePeriodDimensionItems([{ id: value }])
+                            }
+                        }}
                     />
                 )}
             </div>

--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -101,7 +101,11 @@ export const PeriodDimension = ({ dimension, onClose }) => {
     }, [presets])
 
     useEffect(() => {
-        updatePeriodDimensionItems(startEndDate ? [{ id: startEndDate }] : [])
+        if (startEndDate) {
+            updatePeriodDimensionItems([{ id: startEndDate }])
+        } else if (!presets?.length) {
+            updatePeriodDimensionItems([])
+        }
     }, [startEndDate])
 
     const updatePeriodDimensionItems = (items) => {

--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -5,7 +5,7 @@ import {
 import i18n from '@dhis2/d2-i18n'
 import { SegmentedControl } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React, { useEffect, useState, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import { useDispatch, useSelector, useStore } from 'react-redux'
 import { tSetCurrentFromUi } from '../../../actions/current.js'
 import { acSetUiItems } from '../../../actions/ui.js'
@@ -84,29 +84,6 @@ export const PeriodDimension = ({ dimension, onClose }) => {
             ? OPTION_START_END_DATES
             : OPTION_PRESETS
     )
-    const [presets, setPresets] = useState(() =>
-        selectedIds
-            .filter((id) => !isStartEndDate(id))
-            .map((id) => ({ id, name: getNameFromMetadata(id) }))
-    )
-
-    const [startEndDate, setStartEndDate] = useState(
-        () => selectedIds.find((id) => isStartEndDate(id)) || ''
-    )
-
-    useEffect(() => {
-        if (presets) {
-            updatePeriodDimensionItems(presets)
-        }
-    }, [presets])
-
-    useEffect(() => {
-        if (startEndDate) {
-            updatePeriodDimensionItems([{ id: startEndDate }])
-        } else if (!presets?.length) {
-            updatePeriodDimensionItems([])
-        }
-    }, [startEndDate])
 
     const updatePeriodDimensionItems = (items) => {
         const { uiItems, metadata } = items.reduce(
@@ -140,6 +117,11 @@ export const PeriodDimension = ({ dimension, onClose }) => {
         onClose()
     }
 
+    const onSegmentedControlChange = ({ value }) => {
+        setEntryMethod(value)
+        updatePeriodDimensionItems([])
+    }
+
     return dimension ? (
         <DimensionModal
             dataTest={'period-dimension-modal'}
@@ -151,19 +133,26 @@ export const PeriodDimension = ({ dimension, onClose }) => {
             <SegmentedControl
                 options={segmentedControlOptions}
                 selected={entryMethod}
-                onChange={({ value }) => setEntryMethod(value)}
+                onChange={onSegmentedControlChange}
             ></SegmentedControl>
             <div className={styles.entry}>
                 {entryMethod === OPTION_PRESETS && (
                     <BasePeriodDimension
-                        selectedPeriods={presets}
-                        onSelect={({ items }) => setPresets(items)}
+                        selectedPeriods={selectedIds.map((id) => ({
+                            id,
+                            name: getNameFromMetadata(id),
+                        }))}
+                        onSelect={({ items }) =>
+                            updatePeriodDimensionItems(items)
+                        }
                     />
                 )}
                 {entryMethod === OPTION_START_END_DATES && (
                     <StartEndDate
-                        value={startEndDate}
-                        setValue={setStartEndDate}
+                        value={selectedIds[0] || ''}
+                        setValue={(value) =>
+                            updatePeriodDimensionItems([{ id: value }])
+                        }
                     />
                 )}
             </div>

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -10,7 +10,7 @@ export const StartEndDate = ({ value, setValue }) => {
     const [endDate, setEndDate] = useState(endDateStr)
 
     useEffect(() => {
-        setValue(startDate && endDate ? `${startDate}_${endDate}` : '')
+        setValue(startDate && endDate ? `${startDate}_${endDate}` : null)
     }, [startDate, endDate])
 
     const onStartDateChange = ({ value }) => {

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -10,7 +10,7 @@ export const StartEndDate = ({ value, setValue }) => {
     const [endDate, setEndDate] = useState(endDateStr)
 
     useEffect(() => {
-        setValue(startDate && endDate ? `${startDate}_${endDate}` : null)
+        setValue(startDate && endDate ? `${startDate}_${endDate}` : '')
     }, [startDate, endDate])
 
     const onStartDateChange = ({ value }) => {

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -10,11 +10,7 @@ export const StartEndDate = ({ value, setValue }) => {
     const [endDate, setEndDate] = useState(endDateStr)
 
     useEffect(() => {
-        if (startDate && endDate) {
-            setValue(`${startDate}_${endDate}`)
-        } else if (value) {
-            setValue('')
-        }
+        setValue(startDate && endDate ? `${startDate}_${endDate}` : '')
     }, [startDate, endDate])
 
     const onStartDateChange = ({ value }) => {

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -10,7 +10,11 @@ export const StartEndDate = ({ value, setValue }) => {
     const [endDate, setEndDate] = useState(endDateStr)
 
     useEffect(() => {
-        setValue(startDate && endDate ? `${startDate}_${endDate}` : '')
+        if (startDate && endDate) {
+            setValue(`${startDate}_${endDate}`)
+        } else if (value) {
+            setValue('')
+        }
     }, [startDate, endDate])
 
     const onStartDateChange = ({ value }) => {


### PR DESCRIPTION
Implements [TECH-1061](https://dhis2.atlassian.net/browse/TECH-1061)

Prevents time dimensions from being wiped when the modal is reopened. Incomplete start/end dates are still removed as they should.

Needs to be tested thoroughly.