### PR TITLE
fix: various updates to duplicate dimensions (TECH-1032)

### DIFF
--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -498,7 +498,11 @@ const ConditionsManager = ({
             dataTest={'dialog-manager-modal'}
             isInLayout={isInLayout}
             onClose={closeModal}
-            title={dimension.name}
+            title={
+                stage?.name
+                    ? `${dimension.name} - ${stage.name}`
+                    : dimension.name
+            }
         >
             {isRepeatable ? renderTabs() : renderConditions()}
         </DimensionModal>

--- a/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -56,10 +56,10 @@ const DefaultAxis = ({ axisId, className }) => {
         const dimensions = dimensionIds.map((id) => {
             let dimension = {}
             if (metadata[id]) {
-                dimension = metadata[id]
+                dimension = { ...metadata[id] }
             } else {
                 const [rawDimensionId] = id.split('.').reverse()
-                dimension = metadata[rawDimensionId]
+                dimension = { ...metadata[rawDimensionId] }
             }
             return dimension
         })

--- a/src/components/Layout/TooltipContent.js
+++ b/src/components/Layout/TooltipContent.js
@@ -11,6 +11,7 @@ import {
     DIMENSION_TYPE_STATUS,
     DIMENSION_TYPE_PERIOD,
     DIMENSION_TYPE_OU,
+    DIMENSION_TYPE_DATA_ELEMENT,
 } from '../../modules/dimensionConstants.js'
 import { sGetMetadata } from '../../reducers/metadata.js'
 import {
@@ -45,6 +46,16 @@ export const TooltipContent = ({
                 }`,
             `${label}: `
         )
+
+    let stageName
+    if (dimension.stageName) {
+        stageName = dimension.stageName
+    } else {
+        const stageId =
+            dimension.id.indexOf('.') !== -1 &&
+            dimension.id.substring(0, dimension.id.indexOf('.'))
+        stageName = metadata[stageId]?.name
+    }
 
     const getItemDisplayNames = () => {
         const levelIds = []
@@ -146,7 +157,22 @@ export const TooltipContent = ({
                         : renderNoItemsLabel()}
                 </ul>
             )
-
+        case DIMENSION_TYPE_DATA_ELEMENT: {
+            return (
+                <ul className={styles.list}>
+                    {stageName && (
+                        <li className={styles.item}>
+                            {i18n.t('Program stage: {{stageName}}', {
+                                stageName,
+                            })}
+                        </li>
+                    )}
+                    {conditions?.condition || conditions?.legendSet
+                        ? renderConditions(conditions)
+                        : renderAllItemsLabel()}
+                </ul>
+            )
+        }
         default: {
             return (
                 <ul className={styles.list}>

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -168,10 +168,19 @@ const fetchAnalyticsData = async ({
 }
 
 const extractHeaders = (analyticsResponse) =>
-    analyticsResponse.headers.map((header, index) => ({
-        ...header,
-        index,
-    }))
+    analyticsResponse.headers.map((header, index) => {
+        const result = { ...header, index }
+        const [dimensionId, stageId] = header.name.split('.').reverse()
+        if (
+            stageId &&
+            analyticsResponse.headers.filter((h) =>
+                h.name.includes(dimensionId)
+            ).length > 1
+        ) {
+            result.column += ` - ${analyticsResponse.metaData.items[stageId].name}`
+        }
+        return result
+    })
 
 const extractRows = (analyticsResponse, headers) => {
     const filteredRows = []


### PR DESCRIPTION
Implements [TECH-1032](https://dhis2.atlassian.net/browse/TECH-1032)

---

### Key features

1. Shows program stage name in the data table headers when duplicates are present
2. Shows program stage name in the modal title for all data elements
3. Shows program stage name in the chip tooltip for all data elements
4. Prevents program stage name from getting stuck in the chip title when a duplicate is removed

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/160428039-3f10ac36-b70c-4eaf-9205-4b890e19a778.png)
_program stage name in the data table headers for duplicates_

![image](https://user-images.githubusercontent.com/12590483/160428155-dca62372-701a-4f84-8579-9a528d28ca04.png)
_program stage name in the modal title_

![image](https://user-images.githubusercontent.com/12590483/160428253-817780fb-3e43-4897-a5a8-1a7281c6b7a9.png)
_program stage name in the chip tooltip for all data elements_

![image](https://user-images.githubusercontent.com/12590483/160428318-a051f4f0-a700-4bf0-abc7-dffe0276341c.png)
_program stage is hidden when a duplicate is removed_
