### PR TITLE
fix: use dnd pointer sensor so most devices can use drag and drop

### DIFF
--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -4,7 +4,7 @@ import {
     DragOverlay,
     useSensor,
     useSensors,
-    MouseSensor,
+    PointerSensor,
 } from '@dnd-kit/core'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -36,6 +36,12 @@ const DIMENSION_PANEL_SOURCE = 'Sortable'
 export const getDropzoneId = (axisId, position) => `${axisId}-${position}`
 export const FIRST = 'first'
 export const LAST = 'last'
+
+const activateAt15pixels = {
+    activationConstraint: {
+        distance: 15,
+    },
+}
 
 function getIntersectionRatio(entry, target) {
     const top = Math.max(target.top, entry.top)
@@ -122,12 +128,8 @@ const OuterDndContext = ({ children }) => {
         useSelector((state) => sGetUiConditionsByDimension(state, id)) || {}
 
     // Wait 15px movement before starting drag, so that click event isn't overridden
-    const mouseSensor = useSensor(MouseSensor, {
-        activationConstraint: {
-            distance: 15,
-        },
-    })
-    const sensors = useSensors(mouseSensor)
+    const sensor = useSensor(PointerSensor, activateAt15pixels)
+    const sensors = useSensors(sensor)
 
     const dispatch = useDispatch()
 


### PR DESCRIPTION
### Key features

1. PointerSensor is actually the default sensor for dndkit. We modify the sensor so that a 15 pixel movement is needed before drag behaviour triggers. This is so that the chips and dimensions can still be clicked on to open the modal. I had inadvertently used the MouseSensor for this instead of PointerSensor
