### PR TITLE
fix: do not show Invalid date for empty dates (TECH-1060)

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -130,10 +130,13 @@ export const Visualization = ({
         ) {
             return metadata[value]?.name || value
         } else if (header?.valueType === VALUE_TYPE_DATE) {
-            return moment(value).format(
-                header.name === headersMap[DIMENSION_ID_LAST_UPDATED]
-                    ? 'yyyy-MM-DD hh:mm'
-                    : 'yyyy-MM-DD'
+            return (
+                value &&
+                moment(value).format(
+                    header.name === headersMap[DIMENSION_ID_LAST_UPDATED]
+                        ? 'yyyy-MM-DD hh:mm'
+                        : 'yyyy-MM-DD'
+                )
             )
         } else if (header?.valueType === VALUE_TYPE_URL) {
             return (


### PR DESCRIPTION
Implements [TECH-1060](https://dhis2.atlassian.net/browse/TECH-1060)

---

### Key features

1. do not show "Invalid date" for empty dates

---

### Description

`moment` is used to format the dates in the DataTable.
When an empty/undefined value is passed, `format` returns the "Invalid date" text.
If the date value is empty/undefined, do not attempt to format it with `moment`.

---

### Screenshots

Before:
<img width="411" alt="Screenshot 2022-03-29 at 11 02 20" src="https://user-images.githubusercontent.com/150978/160576267-beb8484b-fc54-4128-b3d1-ce6d56550509.png">

After:
<img width="415" alt="Screenshot 2022-03-29 at 11 02 41" src="https://user-images.githubusercontent.com/150978/160576288-97b47f40-77bd-44ef-abc6-5afa2abd0c0a.png">

