### PR TITLE
fix: do not pass unnecessary props to 'save as'

### DIFF
--- a/src/components/Toolbar/MenuBar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar/MenuBar.js
@@ -3,7 +3,6 @@ import {
     useCachedDataQuery,
     VIS_TYPE_LINE_LIST,
     visTypeDisplayNames,
-    layoutGetAllDimensions,
 } from '@dhis2/analytics'
 import { useDataMutation, useAlert } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
@@ -147,13 +146,9 @@ const MenuBar = ({
             visualization.description = details.description
         }
 
-        layoutGetAllDimensions(visualization).forEach((dimension) => {
-            delete dimension.dimensionType
-            delete dimension.valueType
-        })
-
         if (copy) {
             delete visualization.id
+
             postVisualization({ visualization })
         } else {
             putVisualization({ visualization })

--- a/src/components/Toolbar/MenuBar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar/MenuBar.js
@@ -3,6 +3,7 @@ import {
     useCachedDataQuery,
     VIS_TYPE_LINE_LIST,
     visTypeDisplayNames,
+    layoutGetAllDimensions,
 } from '@dhis2/analytics'
 import { useDataMutation, useAlert } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
@@ -146,9 +147,13 @@ const MenuBar = ({
             visualization.description = details.description
         }
 
+        layoutGetAllDimensions(visualization).forEach((dimension) => {
+            delete dimension.dimensionType
+            delete dimension.valueType
+        })
+
         if (copy) {
             delete visualization.id
-
             postVisualization({ visualization })
         } else {
             putVisualization({ visualization })

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -125,6 +125,16 @@ export const visTypeDescriptions = {
     ),
 }
 
+const removeDimensionPropsBeforeSaving = (axis) => {
+    return axis.map((dim) => {
+        const dimension = Object.assign({}, dim)
+        delete dimension.dimensionType
+        delete dimension.valueType
+
+        return dimension
+    })
+}
+
 export const getVisualizationFromCurrent = (current) => {
     const visualization = Object.assign({}, current)
     const nonSavableOptions = Object.keys(options).filter(
@@ -132,6 +142,13 @@ export const getVisualizationFromCurrent = (current) => {
     )
 
     nonSavableOptions.forEach((option) => delete visualization[option])
+
+    visualization.columns = removeDimensionPropsBeforeSaving(
+        visualization.columns
+    )
+    visualization.filters = removeDimensionPropsBeforeSaving(
+        visualization.filters
+    )
 
     return visualization
 }


### PR DESCRIPTION
Implements [DHIS2-12948](https://jira.dhis2.org/browse/DHIS2-12948)

Passing dimension type and value type is unnecessary, and in some cases it causes problems related to “data element” vs “program data element”. Let's not pass these props at all.