### PR TITLE
fix: message should handle case where an invalid date has been selected

### DIFF
--- a/src/modules/error.js
+++ b/src/modules/error.js
@@ -68,8 +68,10 @@ export const noOrgUnitError = () =>
 export const noPeriodError = () =>
     visualizationError(
         PeriodError,
-        i18n.t('No time dimension selected'),
-        i18n.t('Add at least one time dimension to the layout.')
+        i18n.t('Time dimension is missing or invalid'),
+        i18n.t(
+            'Check that at least one time dimension has been added and that it has a valid format.'
+        )
     )
 
 export const getAlertTypeByStatusCode = (statusCode) =>


### PR DESCRIPTION
Implements [TECH-1068](https://dhis2.atlassian.net/browse/TECH-1068)

### Key features

1. when entering start/end dates, it is possible to enter a date that is not considered valid by the backend, e.g., 10-10-20222.

In this case, a time dimension has been selected, but it is not valid. The error message has been updated to better reflect this.

![image](https://user-images.githubusercontent.com/6113918/161758462-bafe928e-8d80-4e01-99cc-b6755fc73b2f.png)

