### PR TITLE
fix: date max (TECH-1068)

### DIFF
--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -33,6 +33,7 @@ export const StartEndDate = ({ value, setValue }) => {
                     onChange={onStartDateChange}
                     label={i18n.t('Start date')}
                     inputWidth="200px"
+                    max="2500-12-31"
                 />
                 <div className={styles.icon}>
                     <IconArrowRight16 color={colors.grey500} />
@@ -43,6 +44,7 @@ export const StartEndDate = ({ value, setValue }) => {
                     onChange={onEndDateChange}
                     label={i18n.t('End date')}
                     inputWidth="200px"
+                    max="2500-12-31"
                 />
             </div>
         </Field>

--- a/src/modules/error.js
+++ b/src/modules/error.js
@@ -68,10 +68,8 @@ export const noOrgUnitError = () =>
 export const noPeriodError = () =>
     visualizationError(
         PeriodError,
-        i18n.t('Time dimension is missing or invalid'),
-        i18n.t(
-            'Check that at least one time dimension has been added and that it has a valid format.'
-        )
+        i18n.t('No time dimension selected'),
+        i18n.t('Add at least one time dimension to the layout.')
     )
 
 export const getAlertTypeByStatusCode = (statusCode) =>


### PR DESCRIPTION
Implements [TECH-1068](https://dhis2.atlassian.net/browse/TECH-1068)

---

### Key features

1. Sets a max date for manually entered periods to 2500-12-31
2. Reverses the change to an ambiguous error message for the period dimension (as its now obsolete)

---

### Description

This removes the need for an ambiguous error message for the period dimension by setting a max date far off in the future (year 2500, could be increased if needed though). The backend allows anything up to year 9999 though, so 2500 could be changed if needed.

---

### Screenshots


_with fix_

https://user-images.githubusercontent.com/12590483/161930652-0684529e-956c-46c3-9871-e8bdbc4d2e93.mov

_without fix_

https://user-images.githubusercontent.com/12590483/161932194-cd45d1b0-f203-48de-89a1-3e2319909b6c.mov


