### PR TITLE
fix: prevent add to layout button from triggering an update (TECH-1084)

### DIFF
--- a/src/components/Dialogs/AddToLayoutButton/AddToLayoutButton.js
+++ b/src/components/Dialogs/AddToLayoutButton/AddToLayoutButton.js
@@ -54,7 +54,6 @@ const AddToLayoutButton = ({
         <AddToLayoutButton
             component={availableAxes.length > 1 ? renderMenu() : null}
             onClick={() => clickHandler(availableAxes[0])}
-            primary
             dataTest={dataTest}
         >
             {i18n.t(`Add to {{axisName}}`, {

--- a/src/components/Dialogs/DimensionModal.js
+++ b/src/components/Dialogs/DimensionModal.js
@@ -39,21 +39,21 @@ const DimensionModal = ({ children, dataTest, isInLayout, onClose, title }) => {
                     >
                         {i18n.t('Hide')}
                     </Button>
-                    <UpdateVisualizationContainer
-                        renderComponent={(handler) =>
-                            isInLayout ? (
+                    {isInLayout ? (
+                        <UpdateVisualizationContainer
+                            renderComponent={(handler) => (
                                 <UpdateButton
                                     onClick={() => onClick(handler)}
                                     dataTest={`${dataTest}-action-confirm`}
                                 />
-                            ) : (
-                                <AddToLayoutButton
-                                    onClick={() => onClick(handler)}
-                                    dataTest={`${dataTest}-action-confirm`}
-                                />
-                            )
-                        }
-                    />
+                            )}
+                        />
+                    ) : (
+                        <AddToLayoutButton
+                            onClick={onClose}
+                            dataTest={`${dataTest}-action-confirm`}
+                        />
+                    )}
                 </ButtonStrip>
             </ModalActions>
         </Modal>


### PR DESCRIPTION
Implements [TECH-1084](https://dhis2.atlassian.net/browse/TECH-1084)

---

### Key features

1. Prevents the _Add to layout_ button from triggering an update (and is thus now gray instead of blue)

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/162432976-a9630f09-387c-4205-a542-66ffd93da2f7.png)
