### PR TITLE
fix: remove legacy flag when saving a copy TECH-1092

### DIFF
--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -10,7 +10,7 @@ const configureStore = (middleware) => {
         typeof window === 'object' &&
         window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
             ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-                  name: 'event-reports-app',
+                  name: 'line-listing-app',
               })
             : compose
 

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -156,6 +156,11 @@ export const getVisualizationFromCurrent = (current) => {
         visualization.filters
     )
 
+    // When saving a copy of an AO created with the Event Reports app, remove the legacy flag.
+    // This copy won't work in Event Reports app anyway.
+    // This also unlocks the Save button on the copied (and converted to new format) AO in LL app.
+    delete visualization.legacy
+
     return visualization
 }
 


### PR DESCRIPTION
Implements [TECH-1092](https://dhis2.atlassian.net/browse/TECH-1092)

---

### Key features

1. remove legacy flag when saving a copy

---

### Description

When saving a copy of an AO created with the Event Reports app, remove the legacy flag, which would have a `true` value.
This copy won't work in Event Reports app anyway.
This also unlocks the Save button on the copied (and converted to new format) AO in LL app.

---

### Screenshots

Snipped of the payload, where `legacy` is not present:

<img width="363" alt="Screenshot 2022-04-11 at 10 19 18" src="https://user-images.githubusercontent.com/150978/162700944-63c30ca1-ef43-436d-b3b6-eb64e400ddbe.png">

