### PR TITLE
fix: option set to use code instead of value for paging (TECH-1082)

### DIFF
--- a/src/components/Dialogs/Conditions/OptionSetCondition.js
+++ b/src/components/Dialogs/Conditions/OptionSetCondition.js
@@ -97,7 +97,7 @@ const OptionSetCondition = ({
             selectedOptions.length >= newOptions.length &&
             newOptions.every((newOption) =>
                 selectedOptions.find(
-                    (selectedItem) => selectedItem.value === newOption.value
+                    (selectedItem) => selectedItem.code === newOption.code
                 )
             )
         ) {


### PR DESCRIPTION
Implements [TECH-1082](https://dhis2.atlassian.net/browse/TECH-1082)

---

### Key features

1. use `code` instead of `value` when evaluating paging

---

### Description

There's a special edge case for the Transfer component (described in a long comment in the code), which was previously evaluating the `value` prop, which is incorrect for fetching options (copy-paste error from DV), so it has now been switched to evaluate `code` instead.

The "Select all" button now works properly again.

---

### Screenshots

_Clicking "Select all" no longer triggers an infinite loop of loading new results_

![image](https://user-images.githubusercontent.com/12590483/162710796-a2e52ef8-0858-4323-84ec-a1e2a953f520.png)

