### PR TITLE
fix: mouse pointer and clickable area for chip (TECH-1083)

### DIFF
--- a/src/components/IconButton/styles/IconButton.module.css
+++ b/src/components/IconButton/styles/IconButton.module.css
@@ -10,7 +10,6 @@
     border-radius: 4px;
     width: 20px;
     height: 20px;
-    margin-left: 4px;
     color: var(--colors-grey700);
 }
 

--- a/src/components/Layout/styles/Chip.module.css
+++ b/src/components/Layout/styles/Chip.module.css
@@ -15,7 +15,6 @@
     user-select: none;
     width: fit-content;
     align-items: center;
-    padding: 0 2px 0 6px;
 }
 
 .chipBase {
@@ -24,8 +23,10 @@
     max-width: 360px;
     align-items: center;
     font-size: 14px;
-    line-height: 17px;
+    line-height: 16px;
     color: var(--colors-grey900);
+    margin-right: var(--spacers-dp4);
+    padding: 4px 2px 4px 6px;
 }
 
 .label {


### PR DESCRIPTION
Implements [TECH-1083](https://dhis2.atlassian.net/browse/TECH-1083)

---

### Key features

1. Tweaks the css for chip to fix the mouse pointer on hover and clickable area

---

### Description

Moves the padding and margin from the container and context menu to the chip base, to make sure the hoverable and clickable areas fill the whole container, rather than having dead space in chip (since the chip base has the `onClick` etc)

Visually, the before and after are pixel perfect identical (in Mac Chrome).

---

### Screenshots

_before_
![image](https://user-images.githubusercontent.com/12590483/162714647-56bb9978-51b8-48c3-b490-df0db6df6c01.png)

_after_
![image](https://user-images.githubusercontent.com/12590483/162714550-f8b28141-3938-40b7-befa-5e00e229cb47.png)