### PR TITLE
fix: catch error code for indicator error and display a custom error msg (TECH-1097)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-04-06T08:22:39.970Z\n"
-"PO-Revision-Date: 2022-04-06T08:22:39.970Z\n"
+"POT-Creation-Date: 2022-04-13T07:27:47.683Z\n"
+"PO-Revision-Date: 2022-04-13T07:27:47.683Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -667,6 +667,9 @@ msgstr "No time dimension selected"
 
 msgid "Add at least one time dimension to the layout."
 msgstr "Add at least one time dimension to the layout."
+
+msgid "There's a problem with at least one selected indicator"
+msgstr "There's a problem with at least one selected indicator"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -27,7 +27,11 @@ import {
     DIMENSION_ID_PROGRAM_STATUS,
     DIMENSION_ID_LAST_UPDATED,
 } from '../../modules/dimensionConstants.js'
-import { genericServerError, noPeriodError } from '../../modules/error.js'
+import {
+    genericServerError,
+    indicatorError,
+    noPeriodError,
+} from '../../modules/error.js'
 import {
     DISPLAY_DENSITY_COMFORTABLE,
     DISPLAY_DENSITY_COMPACT,
@@ -90,6 +94,9 @@ export const Visualization = ({
             switch (error.details.errorCode) {
                 case 'E7205':
                     output = noPeriodError()
+                    break
+                case 'E7132':
+                    output = indicatorError()
                     break
                 default:
                     output = error

--- a/src/modules/error.js
+++ b/src/modules/error.js
@@ -74,7 +74,7 @@ export const noPeriodError = () =>
 
 export const indicatorError = () =>
     visualizationError(
-        GenericError,
+        DataError,
         genericErrorTitle,
         i18n.t("There's a problem with at least one selected indicator")
     )

--- a/src/modules/error.js
+++ b/src/modules/error.js
@@ -72,6 +72,13 @@ export const noPeriodError = () =>
         i18n.t('Add at least one time dimension to the layout.')
     )
 
+export const indicatorError = () =>
+    visualizationError(
+        GenericError,
+        genericErrorTitle,
+        i18n.t("There's a problem with at least one selected indicator")
+    )
+
 export const getAlertTypeByStatusCode = (statusCode) =>
     String(statusCode).match(/50\d/) ? 'error' : 'warning'
 


### PR DESCRIPTION
Implements [TECH-1097](https://dhis2.atlassian.net/browse/TECH-1097)

---

### Key features

1. Catches E7132 and outputs a user-friendly error message instead

---


### Screenshots

![image](https://user-images.githubusercontent.com/12590483/163125150-3a70a04d-1ab6-46f9-aa0a-d4d6cd0d469e.png)