### PR TITLE
fix: add missing margin to dimension menu

### DIFF
--- a/src/components/MainSidebar/DimensionItem/DimensionItemBase.module.css
+++ b/src/components/MainSidebar/DimensionItem/DimensionItemBase.module.css
@@ -63,6 +63,10 @@
     align-items: center;
 }
 
+.iconAndLabelWrapper:not(:only-child) {
+    margin-right: var(--spacers-dp4);
+}
+
 .label .secondary {
     font-size: 13px;
     line-height: 15px;


### PR DESCRIPTION
Adds margin that went missing after https://github.com/dhis2/line-listing-app/pull/91

### Screenshots

_before_
![image](https://user-images.githubusercontent.com/12590483/163129623-bcc15e68-0c61-44fa-8997-1c97d8784e6a.png)


_after_
![image](https://user-images.githubusercontent.com/12590483/163129658-3d4bddee-12f0-4544-837d-b00bfe3b7eb6.png)

