### PR TITLE
fix: use system settings for DGS option TECH-1091

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -14,7 +14,10 @@ import { PROGRAM_TYPE_WITH_REGISTRATION } from '../modules/programTypes.js'
 import { getEnabledTimeDimensionIds } from '../modules/timeDimensions.js'
 import { OUTPUT_TYPE_EVENT } from '../modules/visualization.js'
 import { sGetMetadataById } from '../reducers/metadata.js'
-import { sGetRootOrgUnits } from '../reducers/settings.js'
+import {
+    sGetRootOrgUnits,
+    sGetSettingsDigitGroupSeparator,
+} from '../reducers/settings.js'
 import {
     ADD_UI_LAYOUT_DIMENSIONS,
     REMOVE_UI_LAYOUT_DIMENSIONS,
@@ -235,10 +238,12 @@ export const acSetShowExpandedLayoutPanel = (value) => ({
 
 export const tClearUi = () => (dispatch, getState) => {
     const rootOrgUnits = sGetRootOrgUnits(getState())
+    const digitGroupSeparator = sGetSettingsDigitGroupSeparator(getState())
 
     dispatch(
         acClearUi({
             rootOrgUnits,
+            digitGroupSeparator,
         })
     )
 }

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -5,7 +5,7 @@ export const ADD_SETTINGS = 'ADD_SETTINGS'
 export const DEFAULT_SETTINGS = {
     // keyDateFormat: 'yyyy-MM-dd',
     // keyAnalysisRelativePeriod: 'LAST_12_MONTHS',
-    // keyAnalysisDigitGroupSeparator: 'SPACE',
+    keyAnalysisDigitGroupSeparator: 'SPACE',
     // keyIgnoreAnalyticsApprovalYearThreshold: -1,
     displayNameProperty: 'displayName',
     // uiLocale: 'en',
@@ -32,8 +32,8 @@ export const sGetSettings = (state) => state.settings
 export const sGetSettingsDisplayNameProperty = (state) =>
     sGetSettings(state).displayNameProperty
 
-// export const sGetSettingsDigitGroupSeparator = state =>
-//     sGetSettings(state).keyAnalysisDigitGroupSeparator
+export const sGetSettingsDigitGroupSeparator = (state) =>
+    sGetSettings(state).keyAnalysisDigitGroupSeparator
 
 export const sGetRootOrgUnits = (state) => sGetSettings(state).rootOrgUnits
 

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -116,7 +116,9 @@ export const DEFAULT_UI = {
 }
 
 const getPreselectedUi = (options) => {
-    const rootOrgUnitIds = options.rootOrgUnits
+    const { rootOrgUnits, digitGroupSeparator } = options
+
+    const rootOrgUnitIds = rootOrgUnits
         .filter((root) => root.id)
         .map((root) => root.id)
     const parentGraphMap = { ...DEFAULT_UI.parentGraphMap }
@@ -129,7 +131,7 @@ const getPreselectedUi = (options) => {
         ...DEFAULT_UI,
         options: {
             ...DEFAULT_UI.options,
-            //digitGroupSeparator,
+            digitGroupSeparator,
         },
         itemsByDimension: {
             ...DEFAULT_UI.itemsByDimension,


### PR DESCRIPTION
Implements [TECH-1091](https://dhis2.atlassian.net/browse/TECH-1091)

---

### Key features

1. use default from system settings for DGS

---

### Description

In the Options dialog, use the default set in system settings for the digit group separator.

---

### Screenshots

https://user-images.githubusercontent.com/150978/163134973-e62f70c8-e528-4926-bf1f-6e735c395942.mov



