### PR TITLE
fix: format date and datetime

### DIFF
--- a/src/components/Dialogs/Conditions/DateCondition.js
+++ b/src/components/Dialogs/Conditions/DateCondition.js
@@ -12,7 +12,7 @@ const TYPE_TIME = 'time'
 const API_TIME_DIVIDER = '.' // TODO: Currently just picked a random character, use the correct character preferred by backend
 const UI_TIME_DIVIDER = ':'
 
-const BaseCondition = ({ condition, onChange, onRemove, type }) => {
+const BaseCondition = ({ condition, onChange, onRemove, type, max }) => {
     let operator, value
 
     if (condition.includes(NULL_VALUE)) {
@@ -58,6 +58,7 @@ const BaseCondition = ({ condition, onChange, onRemove, type }) => {
                     type={type}
                     onChange={({ value }) => setValue(value)}
                     className={classes.dateInput}
+                    max={max}
                     dense
                 />
             )}
@@ -79,14 +80,15 @@ BaseCondition.propTypes = {
     type: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
+    max: PropTypes.string,
 }
 
 export const DateCondition = (props) => (
-    <BaseCondition type={TYPE_DATE} {...props} />
+    <BaseCondition type={TYPE_DATE} max="9999-12-31" {...props} />
 )
 
 export const DateTimeCondition = (props) => (
-    <BaseCondition type={TYPE_DATETIME} {...props} />
+    <BaseCondition type={TYPE_DATETIME} max="9999-12-31T23:59:59" {...props} />
 )
 
 export const TimeCondition = (props) => (

--- a/src/components/Dialogs/Conditions/DateCondition.js
+++ b/src/components/Dialogs/Conditions/DateCondition.js
@@ -2,15 +2,17 @@ import i18n from '@dhis2/d2-i18n'
 import { SingleSelectField, SingleSelectOption, Button, Input } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { NULL_VALUE, DATE_OPERATORS } from '../../../modules/conditions.js'
+import {
+    NULL_VALUE,
+    DATE_OPERATORS,
+    UI_TIME_DIVIDER,
+    API_TIME_DIVIDER,
+} from '../../../modules/conditions.js'
 import classes from './styles/Condition.module.css'
 
 const TYPE_DATE = 'date'
 const TYPE_DATETIME = 'datetime-local'
 const TYPE_TIME = 'time'
-
-const API_TIME_DIVIDER = '.' // TODO: Currently just picked a random character, use the correct character preferred by backend
-const UI_TIME_DIVIDER = ':'
 
 const BaseCondition = ({ condition, onChange, onRemove, type, max }) => {
     let operator, value

--- a/src/modules/conditions.js
+++ b/src/modules/conditions.js
@@ -83,6 +83,11 @@ export const VALUE_TYPE_TIME = 'TIME'
 export const VALUE_TYPE_DATETIME = 'DATETIME'
 export const VALUE_TYPE_ORGANISATION_UNIT = 'ORGANISATION_UNIT'
 
+export const API_TIME_DIVIDER = '.'
+export const UI_TIME_DIVIDER = ':'
+export const API_DATETIME_DIVIDER = 'T'
+export const UI_DATETIME_DIVIDER = ' '
+
 export const prefixOperator = (operator, isCaseSensitive) => {
     if (isCaseSensitive) {
         // e.g. LIKE -> LIKE
@@ -218,6 +223,15 @@ export const getConditions = ({
             const parts = condition.split(':')
             operator = unprefixOperator(parts[0])
             value = parts[1]
+        }
+
+        if (
+            [VALUE_TYPE_TIME, VALUE_TYPE_DATETIME].includes(dimension.valueType)
+        ) {
+            value = value.replaceAll(API_TIME_DIVIDER, UI_TIME_DIVIDER)
+        }
+        if (dimension.valueType === VALUE_TYPE_DATETIME) {
+            value = value.replaceAll(API_DATETIME_DIVIDER, UI_DATETIME_DIVIDER)
         }
 
         const operatorName = operators[operator]


### PR DESCRIPTION
### Key features

1. adds `max` to `datetime` and `date` condition inputs
2. formats the tooltip for `datetime` and `time`

---

### Screenshots

_set max to `date`_

![image](https://user-images.githubusercontent.com/12590483/164013634-404df523-129d-45cd-b1a6-8c542e5d4447.png)

_set max to `datetime`_

![image](https://user-images.githubusercontent.com/12590483/164013671-f6f68dd6-8071-494c-ae67-980b867d2d88.png)

---

_`datetime` tooltip before_

![image](https://user-images.githubusercontent.com/12590483/164017584-14caab30-7e3d-409a-a54d-8ff82fbd9b83.png)

_`datetime` tooltip after_

![image](https://user-images.githubusercontent.com/12590483/164017692-47541ec3-9f7d-484f-a95b-04d78efa49e2.png)

---

_`time` tooltip before_

![image](https://user-images.githubusercontent.com/12590483/164017763-4df75bce-f3c3-4b2c-b973-29ff75d8446b.png)


_`time` tooltip after_

![image](https://user-images.githubusercontent.com/12590483/164017717-cd3533f7-6553-4d69-a057-85789d852a87.png)
