### PR TITLE
fix: use different color on hover for action buttons TECH-1086

### DIFF
--- a/src/components/Interpretations/common/Message/MessageIconButton.js
+++ b/src/components/Interpretations/common/Message/MessageIconButton.js
@@ -28,7 +28,7 @@ const MessageIconButton = ({
                     disabled={disabled}
                 >
                     {count && count}
-                    <Icon color={selected ? colors.teal500 : colors.grey700} />
+                    <Icon className={cx('icon', { selected })} />
                 </button>
                 <style jsx>{`
                     .wrapper {
@@ -50,6 +50,20 @@ const MessageIconButton = ({
                     .button.selected {
                         color: ${colors.teal600};
                         font-weight: 500;
+                    }
+                    .button:hover {
+                        color: ${colors.grey900};
+                    }
+                    .icon {
+                        color: ${colors.grey700};
+                    }
+
+                    .icon.selected {
+                        color: ${colors.teal500};
+                    }
+
+                    .icon:hover {
+                        color: #000;
                     }
                 `}</style>
             </span>

--- a/src/components/Interpretations/common/Message/MessageIconButton.js
+++ b/src/components/Interpretations/common/Message/MessageIconButton.js
@@ -28,7 +28,7 @@ const MessageIconButton = ({
                     disabled={disabled}
                 >
                     {count && count}
-                    <Icon className={cx('icon', { selected })} />
+                    <Icon />
                 </button>
                 <style jsx>{`
                     .wrapper {
@@ -51,19 +51,21 @@ const MessageIconButton = ({
                         color: ${colors.teal600};
                         font-weight: 500;
                     }
+
                     .button:hover {
                         color: ${colors.grey900};
                     }
-                    .icon {
-                        color: ${colors.grey700};
+
+                    .button.selected:hover {
+                        color: ${colors.teal800};
                     }
 
-                    .icon.selected {
+                    .button.selected :global(svg) {
                         color: ${colors.teal500};
                     }
 
-                    .icon:hover {
-                        color: #000;
+                    .button.selected:hover :global(svg) {
+                        color: ${colors.teal700};
                     }
                 `}</style>
             </span>


### PR DESCRIPTION
Implements [TECH-1086](https://dhis2.atlassian.net/browse/TECH-1086)

---

### Key features

1. use a different color when hovering the interpretation's action button

---

### Description

On hover a tooltip is shown but we also want to make it more visible that those are buttons.

---

### Screenshots
<img width="225" alt="Screenshot 2022-04-21 at 16 30 54" src="https://user-images.githubusercontent.com/150978/164480991-219c729d-3d5b-4feb-a45b-8c5fe9b6932f.png">

<img width="254" alt="Screenshot 2022-04-21 at 16 30 34" src="https://user-images.githubusercontent.com/150978/164480998-6c1b9b55-b1d2-466a-a915-777567b156da.png">


