### PR TITLE
fix: preserve fetched dimensions when collapsing Program Dimensions panel

### DIFF
--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsList.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsList.js
@@ -1,7 +1,5 @@
-import { useCachedDataQuery } from '@dhis2/analytics'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { DERIVED_USER_SETTINGS_DISPLAY_NAME_PROPERTY } from '../../../modules/userSettings.js'
 import LoadingMask from '../../LoadingMask/LoadingMask.js'
 import { DimensionsList } from '../DimensionsList/index.js'
 import { useProgramDimensions } from './useProgramDimensions.js'
@@ -12,8 +10,8 @@ const ProgramDimensionsList = ({
     stageId,
     searchTerm,
     dimensionType,
+    visible,
 }) => {
-    const { userSettings } = useCachedDataQuery()
     const { dimensions, loading, fetching, error, setIsListEndVisible } =
         useProgramDimensions({
             inputType,
@@ -21,8 +19,11 @@ const ProgramDimensionsList = ({
             stageId,
             searchTerm,
             dimensionType,
-            nameProp: userSettings[DERIVED_USER_SETTINGS_DISPLAY_NAME_PROPERTY],
         })
+
+    if (!visible) {
+        return null
+    }
 
     if (loading) {
         return <LoadingMask />
@@ -52,6 +53,7 @@ ProgramDimensionsList.propTypes = {
     dimensionType: PropTypes.string,
     searchTerm: PropTypes.string,
     stageId: PropTypes.string,
+    visible: PropTypes.bool,
 }
 
 export { ProgramDimensionsList }

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -104,7 +104,7 @@ const ProgramDimensionsPanel = ({ visible }) => {
         setDimensionType(DIMENSION_TYPE_ALL)
     }, [inputType, selectedProgramId])
 
-    if (!visible || !called) {
+    if (!called) {
         return null
     }
 
@@ -131,39 +131,43 @@ const ProgramDimensionsPanel = ({ visible }) => {
 
     return (
         <div className={styles.container}>
-            <div className={cx(styles.section, styles.bordered)}>
-                <ProgramSelect
-                    programs={filteredPrograms}
-                    selectedProgram={selectedProgram}
-                    setSelectedProgramId={setSelectedProgramId}
-                    requiredStageSelection={requiredStageSelection}
-                />
-            </div>
-            <div
-                className={cx(styles.section, {
-                    [styles.bordered]: !!selectedProgramId,
-                })}
-            >
-                {isProgramSelectionComplete ? (
-                    <ProgramDimensionsFilter
-                        program={selectedProgram}
-                        searchTerm={searchTerm}
-                        setSearchTerm={setSearchTerm}
-                        dimensionType={dimensionType}
-                        setDimensionType={setDimensionType}
+            {visible && (
+                <div className={cx(styles.section, styles.bordered)}>
+                    <ProgramSelect
+                        programs={filteredPrograms}
+                        selectedProgram={selectedProgram}
+                        setSelectedProgramId={setSelectedProgramId}
+                        requiredStageSelection={requiredStageSelection}
                     />
-                ) : (
-                    <div className={styles.helptext}>
-                        {requiredStageSelection
-                            ? i18n.t(
-                                  'Choose a program and stage above to add program dimensions.'
-                              )
-                            : i18n.t(
-                                  'Choose a program above to add program dimensions.'
-                              )}
-                    </div>
-                )}
-            </div>
+                </div>
+            )}
+            {visible && (
+                <div
+                    className={cx(styles.section, {
+                        [styles.bordered]: !!selectedProgramId,
+                    })}
+                >
+                    {isProgramSelectionComplete ? (
+                        <ProgramDimensionsFilter
+                            program={selectedProgram}
+                            searchTerm={searchTerm}
+                            setSearchTerm={setSearchTerm}
+                            dimensionType={dimensionType}
+                            setDimensionType={setDimensionType}
+                        />
+                    ) : (
+                        <div className={styles.helptext}>
+                            {requiredStageSelection
+                                ? i18n.t(
+                                      'Choose a program and stage above to add program dimensions.'
+                                  )
+                                : i18n.t(
+                                      'Choose a program above to add program dimensions.'
+                                  )}
+                        </div>
+                    )}
+                </div>
+            )}
             {isProgramSelectionComplete && (
                 <ProgramDimensionsList
                     inputType={inputType}
@@ -171,6 +175,7 @@ const ProgramDimensionsPanel = ({ visible }) => {
                     dimensionType={dimensionType}
                     searchTerm={debouncedSearchTerm}
                     stageId={selectedStageId}
+                    visible={visible}
                 />
             )}
         </div>

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -132,41 +132,41 @@ const ProgramDimensionsPanel = ({ visible }) => {
     return (
         <div className={styles.container}>
             {visible && (
-                <div className={cx(styles.section, styles.bordered)}>
-                    <ProgramSelect
-                        programs={filteredPrograms}
-                        selectedProgram={selectedProgram}
-                        setSelectedProgramId={setSelectedProgramId}
-                        requiredStageSelection={requiredStageSelection}
-                    />
-                </div>
-            )}
-            {visible && (
-                <div
-                    className={cx(styles.section, {
-                        [styles.bordered]: !!selectedProgramId,
-                    })}
-                >
-                    {isProgramSelectionComplete ? (
-                        <ProgramDimensionsFilter
-                            program={selectedProgram}
-                            searchTerm={searchTerm}
-                            setSearchTerm={setSearchTerm}
-                            dimensionType={dimensionType}
-                            setDimensionType={setDimensionType}
+                <>
+                    <div className={cx(styles.section, styles.bordered)}>
+                        <ProgramSelect
+                            programs={filteredPrograms}
+                            selectedProgram={selectedProgram}
+                            setSelectedProgramId={setSelectedProgramId}
+                            requiredStageSelection={requiredStageSelection}
                         />
-                    ) : (
-                        <div className={styles.helptext}>
-                            {requiredStageSelection
-                                ? i18n.t(
-                                      'Choose a program and stage above to add program dimensions.'
-                                  )
-                                : i18n.t(
-                                      'Choose a program above to add program dimensions.'
-                                  )}
-                        </div>
-                    )}
-                </div>
+                    </div>
+                    <div
+                        className={cx(styles.section, {
+                            [styles.bordered]: !!selectedProgramId,
+                        })}
+                    >
+                        {isProgramSelectionComplete ? (
+                            <ProgramDimensionsFilter
+                                program={selectedProgram}
+                                searchTerm={searchTerm}
+                                setSearchTerm={setSearchTerm}
+                                dimensionType={dimensionType}
+                                setDimensionType={setDimensionType}
+                            />
+                        ) : (
+                            <div className={styles.helptext}>
+                                {requiredStageSelection
+                                    ? i18n.t(
+                                          'Choose a program and stage above to add program dimensions.'
+                                      )
+                                    : i18n.t(
+                                          'Choose a program above to add program dimensions.'
+                                      )}
+                            </div>
+                        )}
+                    </div>
+                </>
             )}
             {isProgramSelectionComplete && (
                 <ProgramDimensionsList

--- a/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
@@ -1,9 +1,11 @@
+import { useCachedDataQuery } from '@dhis2/analytics'
 import { useDataEngine } from '@dhis2/app-runtime'
 import { useEffect, useReducer, useCallback, useRef, useMemo } from 'react'
 import {
     DIMENSION_TYPE_ALL,
     DIMENSION_TYPE_DATA_ELEMENT,
 } from '../../../modules/dimensionConstants.js'
+import { DERIVED_USER_SETTINGS_DISPLAY_NAME_PROPERTY } from '../../../modules/userSettings.js'
 import { extractDimensionIdParts } from '../../../modules/utils.js'
 import {
     OUTPUT_TYPE_EVENT,
@@ -192,8 +194,8 @@ const useProgramDimensions = ({
     stageId,
     searchTerm,
     dimensionType,
-    nameProp,
 }) => {
+    const { userSettings } = useCachedDataQuery()
     const deDimensionsMapRef = useRef(new Map())
     const engine = useDataEngine()
     const [
@@ -216,6 +218,8 @@ const useProgramDimensions = ({
             }, new Map()),
         [program]
     )
+
+    const nameProp = userSettings[DERIVED_USER_SETTINGS_DISPLAY_NAME_PROPERTY]
 
     const setIsListEndVisible = (isVisible) => {
         if (isVisible !== isListEndVisible) {


### PR DESCRIPTION
Implements [TECH-1089](https://dhis2.atlassian.net/browse/TECH-1089)

---

### Key features

1. In order to preserve the fetched dimensions, ProgramDimensionsList cannot be un-mounted when collapsing the Program Dimensions panel, so that the useProgramDimensions hook retains its local state.
2. Very small refactor: move the `userSettings` hook to useProgramDimensions, where it is actually needed.

---

### Known issues

-   When expanding the panel, the list will scroll up to the top. Not sure if this is an annoyance or a bonus.
-  There might be a teeny-tiny bit of sluggishness when expanding the panel, if the dimension list is very long (due to lots of previous scrolling down)

---

### Screenshots

https://user-images.githubusercontent.com/6113918/165491134-265bec51-b375-4ffb-bc32-420edb4f1feb.mov



