### PR TITLE
fix: use small circular loader in program dim list TECH-1137

### DIFF
--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsList.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsList.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import LoadingMask from '../../LoadingMask/LoadingMask.js'
 import { DimensionsList } from '../DimensionsList/index.js'
 import { useProgramDimensions } from './useProgramDimensions.js'
 
@@ -23,10 +22,6 @@ const ProgramDimensionsList = ({
 
     if (!visible) {
         return null
-    }
-
-    if (loading) {
-        return <LoadingMask />
     }
 
     const draggableDimensions = dimensions.map((dimension) => ({

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -124,7 +124,7 @@ const ProgramDimensionsPanel = ({ visible }) => {
     if (fetching) {
         return (
             <CenteredContent>
-                <CircularLoader />
+                <CircularLoader small />
             </CenteredContent>
         )
     }


### PR DESCRIPTION
Implements [TECH-1137](https://dhis2.atlassian.net/browse/TECH-1137)

---

### Key features

1. Use the small version of the spinner in the program dimensions list
2. Removed the `LoadingMask` usage since a `loading` prop is passed to the
child component and it controls a spinner already.

---

### Description

See screenshots

---

### Screenshots

Before:
<img width="286" alt="Screenshot 2022-04-29 at 11 50 39" src="https://user-images.githubusercontent.com/150978/165922771-4cc24568-1613-4ff8-9702-e99e1d00253a.png">

After:
<img width="292" alt="Screenshot 2022-04-29 at 11 48 34" src="https://user-images.githubusercontent.com/150978/165922792-7e925d19-2fe4-46af-936d-461e4a403c8a.png">

