### PR TITLE
fix: add overflow-wrap: anywhere for wrapping of text in dimension item

### DIFF
--- a/src/components/MainSidebar/DimensionItem/DimensionItemBase.module.css
+++ b/src/components/MainSidebar/DimensionItem/DimensionItemBase.module.css
@@ -56,6 +56,7 @@
 .label .primary {
     font-size: 14px;
     line-height: 17px;
+    overflow-wrap: anywhere;
 }
 
 .iconAndLabelWrapper {

--- a/src/components/MainSidebar/DimensionItem/DimensionItemBase.module.css
+++ b/src/components/MainSidebar/DimensionItem/DimensionItemBase.module.css
@@ -73,4 +73,5 @@
     line-height: 15px;
     color: var(--colors-grey600);
     padding-left: var(--spacers-dp8);
+    overflow-wrap: anywhere;
 }


### PR DESCRIPTION
Implements [TECH-1133](https://dhis2.atlassian.net/browse/TECH-1133)

### Screenshots

Before:
<img width="274" alt="image" src="https://user-images.githubusercontent.com/6113918/165952705-c7a4f195-ecbb-4542-9a15-355ddba13293.png">

After:
<img width="274" alt="image" src="https://user-images.githubusercontent.com/6113918/165952652-a1855f8e-a021-4845-a3c0-2dafbaf350e2.png">

Before (with stage):
<img width="278" alt="image" src="https://user-images.githubusercontent.com/6113918/165955270-45d5cf46-40d2-489b-a1ea-1465721a133b.png">


After, (with stage ):
<img width="277" alt="image" src="https://user-images.githubusercontent.com/6113918/165955418-701e0ab0-ae4b-4f22-98ae-1ec962387bef.png">
