### PR TITLE
fix: do not render ProgramDimensionsList if panel is closed

### DIFF
--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsList.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsList.js
@@ -9,7 +9,6 @@ const ProgramDimensionsList = ({
     stageId,
     searchTerm,
     dimensionType,
-    visible,
 }) => {
     const { dimensions, loading, fetching, error, setIsListEndVisible } =
         useProgramDimensions({
@@ -19,10 +18,6 @@ const ProgramDimensionsList = ({
             searchTerm,
             dimensionType,
         })
-
-    if (!visible) {
-        return null
-    }
 
     const draggableDimensions = dimensions.map((dimension) => ({
         draggableId: `program-${dimension.id}`,
@@ -48,7 +43,6 @@ ProgramDimensionsList.propTypes = {
     dimensionType: PropTypes.string,
     searchTerm: PropTypes.string,
     stageId: PropTypes.string,
-    visible: PropTypes.bool,
 }
 
 export { ProgramDimensionsList }

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -104,7 +104,7 @@ const ProgramDimensionsPanel = ({ visible }) => {
         setDimensionType(DIMENSION_TYPE_ALL)
     }, [inputType, selectedProgramId])
 
-    if (!called) {
+    if (!visible || !called) {
         return null
     }
 
@@ -131,43 +131,40 @@ const ProgramDimensionsPanel = ({ visible }) => {
 
     return (
         <div className={styles.container}>
-            {visible && (
-                <>
-                    <div className={cx(styles.section, styles.bordered)}>
-                        <ProgramSelect
-                            programs={filteredPrograms}
-                            selectedProgram={selectedProgram}
-                            setSelectedProgramId={setSelectedProgramId}
-                            requiredStageSelection={requiredStageSelection}
-                        />
+            <div className={cx(styles.section, styles.bordered)}>
+                <ProgramSelect
+                    programs={filteredPrograms}
+                    selectedProgram={selectedProgram}
+                    setSelectedProgramId={setSelectedProgramId}
+                    requiredStageSelection={requiredStageSelection}
+                />
+            </div>
+            <div
+                className={cx(styles.section, {
+                    [styles.bordered]: !!selectedProgramId,
+                })}
+            >
+                {isProgramSelectionComplete ? (
+                    <ProgramDimensionsFilter
+                        program={selectedProgram}
+                        searchTerm={searchTerm}
+                        setSearchTerm={setSearchTerm}
+                        dimensionType={dimensionType}
+                        setDimensionType={setDimensionType}
+                    />
+                ) : (
+                    <div className={styles.helptext}>
+                        {requiredStageSelection
+                            ? i18n.t(
+                                  'Choose a program and stage above to add program dimensions.'
+                              )
+                            : i18n.t(
+                                  'Choose a program above to add program dimensions.'
+                              )}
                     </div>
-                    <div
-                        className={cx(styles.section, {
-                            [styles.bordered]: !!selectedProgramId,
-                        })}
-                    >
-                        {isProgramSelectionComplete ? (
-                            <ProgramDimensionsFilter
-                                program={selectedProgram}
-                                searchTerm={searchTerm}
-                                setSearchTerm={setSearchTerm}
-                                dimensionType={dimensionType}
-                                setDimensionType={setDimensionType}
-                            />
-                        ) : (
-                            <div className={styles.helptext}>
-                                {requiredStageSelection
-                                    ? i18n.t(
-                                          'Choose a program and stage above to add program dimensions.'
-                                      )
-                                    : i18n.t(
-                                          'Choose a program above to add program dimensions.'
-                                      )}
-                            </div>
-                        )}
-                    </div>
-                </>
-            )}
+                )}
+            </div>
+
             {isProgramSelectionComplete && (
                 <ProgramDimensionsList
                     inputType={inputType}
@@ -175,7 +172,6 @@ const ProgramDimensionsPanel = ({ visible }) => {
                     dimensionType={dimensionType}
                     searchTerm={debouncedSearchTerm}
                     stageId={selectedStageId}
-                    visible={visible}
                 />
             )}
         </div>


### PR DESCRIPTION
Implements [TECH-1136](https://dhis2.atlassian.net/browse/TECH-1136)
Reverts (minus the refactor) of https://github.com/dhis2/line-listing-app/pull/112
---

### Key features

1. Turns out that expanding/collapsing the ProgramDimensionsPanel becomes sluggish when several pages of program dimensions have been loaded, especially when cpu is throttled. The sluggishness is less marked with the original solution, which is to refetch the dimensions when expanding.
