### PR TITLE
fix: prevent fetchError from reemerging when not loading (TECH-1139)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -110,7 +110,6 @@ const dataStatisticsMutation = {
 const App = () => {
     const dataEngine = useDataEngine()
     const [data, setData] = useState()
-    const [fetchError, setFetchError] = useState()
     const [previousLocation, setPreviousLocation] = useState()
     const [initialLoadIsComplete, setInitialLoadIsComplete] = useState(false)
     const [postDataStatistics] = useDataMutation(dataStatisticsMutation)
@@ -128,29 +127,6 @@ const App = () => {
         interpretationsUnitRef.current.refresh()
     }
 
-    useEffect(() => {
-        if (!error && fetchError) {
-            if (fetchError.details?.httpStatusCode === 404) {
-                dispatch(
-                    acClearAll({
-                        error: visualizationNotFoundError(),
-                        digitGroupSeparator,
-                        rootOrgUnits,
-                    })
-                )
-            } else {
-                dispatch(
-                    acClearAll({
-                        error:
-                            fetchError.details.message || genericServerError(),
-                        digitGroupSeparator,
-                        rootOrgUnits,
-                    })
-                )
-            }
-        }
-    }, [error, fetchError])
-
     const parseLocation = (location) => {
         const pathParts = location.pathname.slice(1).split('/')
         const id = pathParts[0]
@@ -159,7 +135,6 @@ const App = () => {
     }
 
     const loadVisualization = async (location) => {
-        setFetchError(undefined)
         dispatch(acSetVisualizationLoading(true))
         const isExisting = location.pathname.length > 1
         if (isExisting) {
@@ -180,8 +155,28 @@ const App = () => {
                 })
 
                 setData(data)
-            } catch (error) {
-                setFetchError(error)
+            } catch (fetchError) {
+                if (!error && fetchError) {
+                    if (fetchError.details?.httpStatusCode === 404) {
+                        dispatch(
+                            acClearAll({
+                                error: visualizationNotFoundError(),
+                                digitGroupSeparator,
+                                rootOrgUnits,
+                            })
+                        )
+                    } else {
+                        dispatch(
+                            acClearAll({
+                                error:
+                                    fetchError.details.message ||
+                                    genericServerError(),
+                                digitGroupSeparator,
+                                rootOrgUnits,
+                            })
+                        )
+                    }
+                }
             }
         } else {
             dispatch(


### PR DESCRIPTION
Implements [TECH-1139](https://dhis2.atlassian.net/browse/TECH-1139)

---

### Key features

1. Only set `fetchError` when actually loading

---

### Description

Previously, after loading a 404 AO (e.g. `#/nothing`) the `fetchError` would reappear later when the user made changes to the layout. This was because `fetchError` was kept in the local state of `App.js`. There's no apparent reason for keeping this local state, as the error handling for fetch errors proceed with saving the error in the redux store, so no need to keep it locally as well.

This PR removes `fetchError` from the local state to make sure the "zombie error" doesn't reemerge at an unexpected time.
