### PR TITLE
fix: dimension item fixes (TECH-1135)

### DIFF
--- a/src/components/DimensionMenu/DimensionMenu.js
+++ b/src/components/DimensionMenu/DimensionMenu.js
@@ -35,7 +35,10 @@ const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
         e.stopPropagation()
     }
 
-    const closeMenu = () => setMenuIsOpen(false)
+    const closeMenu = (_, e) => {
+        setMenuIsOpen(false)
+        e.stopPropagation()
+    }
 
     const getMenuId = () => `menu-for-${dimensionId}`
 

--- a/src/components/DimensionMenu/DimensionMenu.js
+++ b/src/components/DimensionMenu/DimensionMenu.js
@@ -30,7 +30,12 @@ const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
     const buttonRef = useRef()
     const [menuIsOpen, setMenuIsOpen] = useState(false)
 
-    const toggleMenu = () => setMenuIsOpen(!menuIsOpen)
+    const openMenu = (e) => {
+        setMenuIsOpen(true)
+        e.stopPropagation()
+    }
+
+    const closeMenu = () => setMenuIsOpen(false)
 
     const getMenuId = () => `menu-for-${dimensionId}`
 
@@ -56,14 +61,14 @@ const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
                 <IconButton
                     ariaOwns={menuIsOpen ? getMenuId() : null}
                     ariaHaspopup={true}
-                    onClick={toggleMenu}
+                    onClick={openMenu}
                     dataTest={`layout-dimension-menu-button-${dimensionId}`}
                 >
                     <IconMore16 />
                 </IconButton>
             </div>
             {menuIsOpen && (
-                <Layer onClick={toggleMenu}>
+                <Layer onClick={closeMenu}>
                     <Popper reference={buttonRef} placement="bottom-start">
                         <MenuItems
                             dimensionId={dimensionId}
@@ -71,7 +76,7 @@ const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
                             visType={visType}
                             axisItemHandler={axisItemHandler}
                             removeItemHandler={removeItemHandler}
-                            onClose={toggleMenu}
+                            onClose={closeMenu}
                             dataTest={'layout-dimension-menu-dimension-menu'}
                         />
                     </Popper>

--- a/src/components/DimensionMenu/DimensionMenu.js
+++ b/src/components/DimensionMenu/DimensionMenu.js
@@ -30,14 +30,9 @@ const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
     const buttonRef = useRef()
     const [menuIsOpen, setMenuIsOpen] = useState(false)
 
-    const openMenu = (e) => {
-        setMenuIsOpen(true)
-        e.stopPropagation()
-    }
-
-    const closeMenu = (_, e) => {
-        setMenuIsOpen(false)
-        e.stopPropagation()
+    const toggleMenu = (e) => {
+        setMenuIsOpen(!menuIsOpen)
+        e && e.stopPropagation()
     }
 
     const getMenuId = () => `menu-for-${dimensionId}`
@@ -64,14 +59,14 @@ const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
                 <IconButton
                     ariaOwns={menuIsOpen ? getMenuId() : null}
                     ariaHaspopup={true}
-                    onClick={openMenu}
+                    onClick={toggleMenu}
                     dataTest={`layout-dimension-menu-button-${dimensionId}`}
                 >
                     <IconMore16 />
                 </IconButton>
             </div>
             {menuIsOpen && (
-                <Layer onClick={closeMenu}>
+                <Layer onClick={(_, e) => toggleMenu(e)}>
                     <Popper reference={buttonRef} placement="bottom-start">
                         <MenuItems
                             dimensionId={dimensionId}
@@ -79,7 +74,7 @@ const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
                             visType={visType}
                             axisItemHandler={axisItemHandler}
                             removeItemHandler={removeItemHandler}
-                            onClose={closeMenu}
+                            onClose={toggleMenu}
                             dataTest={'layout-dimension-menu-dimension-menu'}
                         />
                     </Popper>

--- a/src/components/MainSidebar/DimensionItem/DimensionItemBase.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionItemBase.js
@@ -22,8 +22,9 @@ const DimensionItemBase = ({
             [styles.disabled]: disabled,
             [styles.dragging]: dragging,
         })}
+        onClick={onClick}
     >
-        <div className={styles.iconAndLabelWrapper} onClick={onClick}>
+        <div className={styles.iconAndLabelWrapper}>
             <div className={styles.icon}>
                 <DimensionIcon dimensionType={dimensionType} />
             </div>

--- a/src/components/MainSidebar/TimeDimensions.module.css
+++ b/src/components/MainSidebar/TimeDimensions.module.css
@@ -1,5 +1,4 @@
 .span {
-    display: inline-flex;
     pointer-events: all;
 }
 .span > :global(button:disabled) {


### PR DESCRIPTION
Implements [TECH-1135](https://dhis2.atlassian.net/browse/TECH-1135)

---

### Key features

1. Fixes time dimensions so they span the full width
2. Make the right side of the dimension items clickable

---

### 

Part 1: see screenshot below.
Part 2: there's a special way to handle the onClick callbacks, as all three implementers of the `toggleMenu` does it differently. `Layer` has `e` as the second prop, hence the `_` fix (thanks @edoardo. That one plus the "open" (from the dot-dot-dot menu) as `e` and needs the `stopPropagation`, while the last case (when closing because a menu item has been clicked) doesn't have an event (`e`) at all.

---

### Screenshots

_time dimensions span the full width now_

![image](https://user-images.githubusercontent.com/12590483/166452546-6ee9c074-ee4f-4d1a-a803-ef39d3d3f0f4.png)
