### PR TITLE
fix: show translated title TECH-1170

### DIFF
--- a/src/components/TitleBar/TitleBar.js
+++ b/src/components/TitleBar/TitleBar.js
@@ -24,7 +24,7 @@ const getTitleText = (titleState, visualization) => {
             return getTitleUnsaved()
         case STATE_SAVED:
         case STATE_DIRTY:
-            return visualization.name
+            return visualization.displayName
         default:
             return ''
     }


### PR DESCRIPTION
Implements [TECH-1170](https://dhis2.atlassian.net/browse/TECH-1170)

---

### Key features

1. show translated title

---

### Description

`displayName` should be used to show the translated title based on the current user's locale when available.

---

### Screenshots

Before:
<img width="786" alt="Screenshot 2022-05-06 at 12 33 20" src="https://user-images.githubusercontent.com/150978/167116105-1d6d28eb-c147-4989-b670-d20b72407563.png">

After:
<img width="777" alt="Screenshot 2022-05-06 at 12 34 25" src="https://user-images.githubusercontent.com/150978/167116117-ce543d37-64f0-4b4f-8b42-a45463200444.png">

