### PR TITLE
fix: interpretations use locale format (TECH-1175)

### DIFF
--- a/src/components/Interpretations/common/Message/Message.js
+++ b/src/components/Interpretations/common/Message/Message.js
@@ -9,9 +9,7 @@ const Message = ({ children, text, created, username }) => (
         <div className="header">
             <UserAvatar name={username} extrasmall />
             {username}
-            <time dateTime={created}>
-                {moment(created).format('DD/MM/YY hh:mm')}
-            </time>
+            <time dateTime={created}>{moment(created).format('lll')}</time>
         </div>
         <div className="content">
             <RichTextParser>{text}</RichTextParser>


### PR DESCRIPTION
Implements [TECH-1175](https://dhis2.atlassian.net/browse/TECH-1175)

---

### Key features

1. Uses locale format for interpretations instead of hardcoded static format

---

### Screenshots

_english before_
![image](https://user-images.githubusercontent.com/12590483/167648541-fee8763b-e4aa-481a-aaf8-807da58b992b.png)

_english after_
![image](https://user-images.githubusercontent.com/12590483/167647933-11e775f2-b818-4ba8-a9c5-42d284570060.png)

_mongolian before_
![image](https://user-images.githubusercontent.com/12590483/167648729-53b3c4d7-6064-4600-a882-643c48c7b713.png)

_mongolian after_
![image](https://user-images.githubusercontent.com/12590483/167648121-1b3e4007-1f45-4d2e-82f2-328cc2518524.png)

_burmese before_
![image](https://user-images.githubusercontent.com/12590483/167648840-f90cfa6b-1084-476a-9c73-23458be7acb4.png)

_burmese after_
![image](https://user-images.githubusercontent.com/12590483/167648267-0d3204af-4940-4096-92e8-70413719bb87.png)

