### PR TITLE
fix: update d2-ui-rich-text dependency LIBS-317

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@dhis2/analytics": "^23.8.5",
         "@dhis2/app-runtime": "^3.4.0",
-        "@dhis2/d2-ui-rich-text": "^7.3.4",
+        "@dhis2/d2-ui-rich-text": "^7.4.0",
         "@dhis2/ui": "^8.2.4",
         "@dnd-kit/core": "^5.0.3",
         "@dnd-kit/sortable": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,10 +2115,10 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-ui-rich-text@^7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.3.4.tgz#95038f1811a56e57021ffec67ab460113976cc63"
-  integrity sha512-xGTzw2fsR7OW2vY65zRhBT6cSJLQlxc1wAgjQPSn2m6bD1r4KHnh4BdNzSQx9rQgqlENoiINIEgaD/3zAmitrA==
+"@dhis2/d2-ui-rich-text@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.4.0.tgz#e1fb6eff7309ea80a6af3bee2a247c9f93ea721d"
+  integrity sha512-q8woPPyYHiqQfNtujuCQH8eq7zRcN0140XqrKHw1DXF/fnqmrcVDTNZkPSaWMuUsdPhcgTHcnuEySP0MRAXv6g==
   dependencies:
     babel-runtime "^6.26.0"
     markdown-it "^8.4.2"
@@ -16066,10 +16066,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Implements [LIBS-317](https://dhis2.atlassian.net/browse/LIBS-317)

**Requires https://github.com/dhis2/d2-ui/pull/730**

---

### Key features

1. enable support for Markdown links (via `d2-ui-rich-text` dependency) 

---

### Description

See screenshots

---

### Screenshots

Before:
<img width="364" alt="Screenshot 2022-05-09 at 11 54 42" src="https://user-images.githubusercontent.com/150978/167838104-2f95926f-490d-44cc-9c31-5745837c323b.png">

After:
<img width="375" alt="Screenshot 2022-05-09 at 11 56 35" src="https://user-images.githubusercontent.com/150978/167838122-f8e8d26e-6f05-48d9-a835-899e962f5c53.png">

