### PR TITLE
fix: prevent replaceAll from crashing due to undefined value (TECH-1183)

### DIFF
--- a/src/components/Dialogs/Conditions/DateCondition.js
+++ b/src/components/Dialogs/Conditions/DateCondition.js
@@ -36,7 +36,7 @@ const BaseCondition = ({ condition, onChange, onRemove, type, max }) => {
     const setValue = (input) => {
         onChange(
             `${operator}:${
-                input.replaceAll(UI_TIME_DIVIDER, API_TIME_DIVIDER) || ''
+                input?.replaceAll(UI_TIME_DIVIDER, API_TIME_DIVIDER) || ''
             }`
         )
     }
@@ -56,7 +56,7 @@ const BaseCondition = ({ condition, onChange, onRemove, type, max }) => {
             </SingleSelectField>
             {operator && !operator.includes(NULL_VALUE) && (
                 <Input
-                    value={value.replaceAll(API_TIME_DIVIDER, UI_TIME_DIVIDER)}
+                    value={value?.replaceAll(API_TIME_DIVIDER, UI_TIME_DIVIDER)}
                     type={type}
                     onChange={({ value }) => setValue(value)}
                     className={classes.dateInput}

--- a/src/modules/conditions.js
+++ b/src/modules/conditions.js
@@ -227,11 +227,12 @@ export const getConditions = ({
         }
 
         if (
+            value &&
             [VALUE_TYPE_TIME, VALUE_TYPE_DATETIME].includes(dimension.valueType)
         ) {
             value = value.replaceAll(API_TIME_DIVIDER, UI_TIME_DIVIDER)
         }
-        if (dimension.valueType === VALUE_TYPE_DATETIME) {
+        if (value && dimension.valueType === VALUE_TYPE_DATETIME) {
             value = value.replaceAll(API_DATETIME_DIVIDER, UI_DATETIME_DIVIDER)
         }
 


### PR DESCRIPTION
Implements [TECH-1183](https://dhis2.atlassian.net/browse/TECH-1183)

---

### Key features

1. Prevent `replaceAll` from crashing when `value` is `undefined`
