### PR TITLE
fix: start the proxy on the same port as in cypress.env.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "format": "d2-style apply",
         "validate-commit": "d2-style check --staged",
         "validate-push": "yarn test",
-        "start-cy-proxy": "BROWSER=none d2-app-scripts start --proxy https://debug.dhis2.org/dev",
+        "start-cy-proxy": "BROWSER=none d2-app-scripts start --proxy https://debug.dhis2.org/dev --proxyPort 8081",
         "cypress:capture": "start-server-and-test 'yarn start-cy-proxy' http://localhost:3000 'yarn cypress run --env networkMode=capture'",
         "cypress:stub": "start-server-and-test 'yarn start-cy-proxy' http://localhost:3000 'yarn cypress run --env networkMode=stub'",
         "cypress:live": "start-server-and-test 'yarn start-cy-proxy' http://localhost:3000 'yarn cypress open --env networkMode=live'"


### PR DESCRIPTION
### Key features

1. start the proxy on the same port specified in `cypress.env.json`

---

### Description

Most likely people copy-paste the configuration for the `cypress.env.json` from the `README` file, where we use `8081` as the proxy port for the backend.
Starting the proxy on the same port avoids the proxy to use the default `8080` is no proxy on that port is already running.
