### PR TITLE
fix: use feature toggling for the legend tab in options (DHIS2-75)

### DIFF
--- a/src/components/VisualizationOptions/VisualizationOptionsManager.js
+++ b/src/components/VisualizationOptions/VisualizationOptionsManager.js
@@ -1,4 +1,5 @@
 import { VisualizationOptions } from '@dhis2/analytics'
+import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import React, { useState } from 'react'
 import { getOptionsByType } from '../../modules/options/config.js'
@@ -7,13 +8,14 @@ import UpdateVisualizationContainer from '../UpdateButton/UpdateVisualizationCon
 
 const VisualizationOptionsManager = () => {
     const [dialogIsOpen, setDialogIsOpen] = useState(false)
+    const { serverVersion } = useConfig()
 
     const onClick = (handler) => {
         handler()
         setDialogIsOpen(false)
     }
 
-    const optionsConfig = getOptionsByType()
+    const optionsConfig = getOptionsByType({ serverVersion })
 
     return (
         <>

--- a/src/modules/options/config.js
+++ b/src/modules/options/config.js
@@ -2,11 +2,11 @@ import { VIS_TYPE_PIVOT_TABLE } from '@dhis2/analytics'
 import lineListConfig from './lineListConfig.js'
 import pivotTableConfig from './pivotTableConfig.js'
 
-export const getOptionsByType = (type) => {
+export const getOptionsByType = ({ type, serverVersion }) => {
     switch (type) {
         case VIS_TYPE_PIVOT_TABLE:
             return pivotTableConfig()
         default:
-            return lineListConfig()
+            return lineListConfig(serverVersion)
     }
 }

--- a/src/modules/options/lineListConfig.js
+++ b/src/modules/options/lineListConfig.js
@@ -17,8 +17,9 @@ export default (serverVersion) => [
             ]),
         },
     ]),
-    ...(serverVersion.minor >= 39 ||
-    (serverVersion.minor === 38 && serverVersion.patch >= 1)
+    ...(`${serverVersion.major}.${serverVersion.minor}.${
+        serverVersion.patch || 0
+    }` > '2.38.1'
         ? [getLegendTab()]
         : []),
 ]

--- a/src/modules/options/lineListConfig.js
+++ b/src/modules/options/lineListConfig.js
@@ -6,7 +6,7 @@ import FontSize from '../../components/VisualizationOptions/Options/FontSize.js'
 import getLegendTab from './tabs/legend.js'
 import getStyleTab from './tabs/style.js'
 
-export default () => [
+export default (serverVersion) => [
     getStyleTab([
         {
             key: 'style-section-1',
@@ -17,5 +17,7 @@ export default () => [
             ]),
         },
     ]),
-    getLegendTab(),
+    (serverVersion.minor >= 39 ||
+        (serverVersion.minor === 38 && serverVersion.patch >= 1)) &&
+        getLegendTab(),
 ]

--- a/src/modules/options/lineListConfig.js
+++ b/src/modules/options/lineListConfig.js
@@ -17,7 +17,8 @@ export default (serverVersion) => [
             ]),
         },
     ]),
-    (serverVersion.minor >= 39 ||
-        (serverVersion.minor === 38 && serverVersion.patch >= 1)) &&
-        getLegendTab(),
+    ...(serverVersion.minor >= 39 ||
+    (serverVersion.minor === 38 && serverVersion.patch >= 1)
+        ? [getLegendTab()]
+        : []),
 ]


### PR DESCRIPTION
Implements [DHIS2-75](https://jira.dhis2.org/browse/DHIS2-75)

---

### Key features

1. Prevent the legend tab from being displayed on servers < 2.38.1

---

### Description

This is based on the theory (currently untested) that only the saving part for legend sets needs to be feature toggled. As legend sets themselves are optional, so if the user can't save an AO with one then legend sets will never be present when loading (since the `/eventVisualizations` endpoint handles non-existing params gracefully).
