### PR TITLE
fix: untie Plugin component from the app's Redux store

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -14,6 +14,7 @@ import {
 import { acAddMetadata, tSetInitMetadata } from '../actions/metadata.js'
 import {
     acSetUiFromVisualization,
+    acSetUiOpenDimensionModal,
     acAddParentGraphMap,
     acSetShowExpandedLayoutPanel,
 } from '../actions/ui.js'
@@ -221,6 +222,9 @@ const App = () => {
         dispatch(acSetLoadError(output))
     }
 
+    const onColumnHeaderClick = (dimensionId) =>
+        dispatch(acSetUiOpenDimensionModal(dimensionId))
+
     const onResponsesReceived = (response) => {
         const itemsMetadata = Object.entries(response.metaData.items).reduce(
             (obj, [id, item]) => {
@@ -358,6 +362,9 @@ const App = () => {
                                             visualization={current}
                                             onResponsesReceived={
                                                 onResponsesReceived
+                                            }
+                                            onColumnHeaderClick={
+                                                onColumnHeaderClick
                                             }
                                             onError={onError}
                                         />

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,8 +20,11 @@ import {
 import { acSetVisualization } from '../actions/visualization.js'
 import { EVENT_TYPE } from '../modules/dataStatistics.js'
 import {
+    dataAccessError,
     emptyResponseError,
     genericServerError,
+    indicatorError,
+    noPeriodError,
     visualizationNotFoundError,
 } from '../modules/error.js'
 import history from '../modules/history.js'
@@ -195,6 +198,29 @@ const App = () => {
         setPreviousLocation(location.pathname)
     }
 
+    const onError = (error) => {
+        let output
+
+        if (error.details?.errorCode) {
+            switch (error.details.errorCode) {
+                case 'E7205':
+                    output = noPeriodError()
+                    break
+                case 'E7132':
+                    output = indicatorError()
+                    break
+                case 'E7121':
+                    output = dataAccessError()
+                    break
+                default:
+                    output = genericServerError()
+            }
+        } else {
+            output = genericServerError()
+        }
+        dispatch(acSetLoadError(output))
+    }
+
     const onResponsesReceived = (response) => {
         const itemsMetadata = Object.entries(response.metaData.items).reduce(
             (obj, [id, item]) => {
@@ -333,6 +359,7 @@ const App = () => {
                                             onResponsesReceived={
                                                 onResponsesReceived
                                             }
+                                            onError={onError}
                                         />
                                     )}
                                     {current && (

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -24,10 +24,7 @@ import cx from 'classnames'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-// TODO this action cannot be used and a callback prop should be passed instead
-// when the plugin is used in dashboard, this feature should be disabled
-import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
+import { useSelector } from 'react-redux'
 import {
     DIMENSION_ID_EVENT_STATUS,
     DIMENSION_ID_PROGRAM_STATUS,
@@ -79,9 +76,9 @@ export const Visualization = ({
     filters,
     visualization,
     onResponsesReceived,
+    onColumnHeaderClick,
     onError,
 }) => {
-    const dispatch = useDispatch()
     // TODO remove need for metadata
     const metadata = useSelector(sGetMetadata)
     const [uniqueLegendSets, setUniqueLegendSets] = useState([])
@@ -233,7 +230,11 @@ export const Visualization = ({
         return (
             <span
                 className={cx(styles.headerCell, styles.dimensionModalHandler)}
-                onClick={() => dispatch(acSetUiOpenDimensionModal(dimensionId))}
+                onClick={
+                    onColumnHeaderClick
+                        ? () => onColumnHeaderClick(dimensionId)
+                        : undefined
+                }
             >
                 {headerName}
             </span>
@@ -420,5 +421,6 @@ Visualization.propTypes = {
     visualization: PropTypes.object.isRequired,
     onResponsesReceived: PropTypes.func.isRequired,
     filters: PropTypes.object,
+    onColumnHeaderClick: PropTypes.func,
     onError: PropTypes.func,
 }

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -26,8 +26,6 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 // TODO this action cannot be used and a callback prop should be passed instead
-import { acSetLoadError } from '../../actions/loader.js'
-// TODO this action cannot be used and a callback prop should be passed instead
 // when the plugin is used in dashboard, this feature should be disabled
 import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
 import {
@@ -35,12 +33,6 @@ import {
     DIMENSION_ID_PROGRAM_STATUS,
     DIMENSION_ID_LAST_UPDATED,
 } from '../../modules/dimensionConstants.js'
-import {
-    dataAccessError,
-    genericServerError,
-    indicatorError,
-    noPeriodError,
-} from '../../modules/error.js'
 import {
     DISPLAY_DENSITY_COMFORTABLE,
     DISPLAY_DENSITY_COMPACT,
@@ -87,6 +79,7 @@ export const Visualization = ({
     filters,
     visualization,
     onResponsesReceived,
+    onError,
 }) => {
     const dispatch = useDispatch()
     // TODO remove need for metadata
@@ -133,26 +126,8 @@ export const Visualization = ({
         }
     }, [data, visualization])
 
-    if (error) {
-        let output
-        if (error.details?.errorCode) {
-            switch (error.details.errorCode) {
-                case 'E7205':
-                    output = noPeriodError()
-                    break
-                case 'E7132':
-                    output = indicatorError()
-                    break
-                case 'E7121':
-                    output = dataAccessError()
-                    break
-                default:
-                    output = genericServerError()
-            }
-        } else {
-            output = genericServerError()
-        }
-        dispatch(acSetLoadError(output))
+    if (error && onError) {
+        onError(error)
     }
 
     if (!data || error) {
@@ -445,4 +420,5 @@ Visualization.propTypes = {
     visualization: PropTypes.object.isRequired,
     onResponsesReceived: PropTypes.func.isRequired,
     filters: PropTypes.object,
+    onError: PropTypes.func,
 }


### PR DESCRIPTION
### Key features

1. replace `acSetLoadError` with a `onError` callback
2. replace `acSetUiDimensionModal` with a `onColumnHeaderClick` callback

---

### Description

The plugin cannot rely on the app's Redux store, as it should be standalone so it can be reused in different places, like dashboard app.

The error handling is now using a callback, similarly to how it's done already in the DV plugin.
If there is an error in the plugin (most likely an error returned from the analytics endpoint) and if the `onError` callback prop is provided, the plugin simply calls the callback.
The error is now handled in the `App` component.

In the LL app we want the column header to open the correct dimension modal when clicked, this is now also achieved via a callback, so the app is responsible of setting the modal id in its Redux store.