### PR TITLE
test: refactor lists to individual objects

### DIFF
--- a/cypress/data/index.js
+++ b/cypress/data/index.js
@@ -6,7 +6,7 @@ import {
 } from '../../src/modules/dimensionConstants.js'
 import { getPreviousYearStr } from '../helpers/period.js'
 
-const ANALYTICS_PROGRAM = {
+export const ANALYTICS_PROGRAM = {
     programName: 'Analytics program',
     //stageName: 'Stage 1 - Repeatable',
     [DIMENSION_ID_EVENT_DATE]: 'Event date (analytics)',
@@ -22,20 +22,9 @@ export const TEST_AOS = [
     },
 ]
 
-export const TEST_EVENT_DATA = [
-    {
-        ...ANALYTICS_PROGRAM,
-        dimensions: ['Analytics - Text'],
-    },
-    {
-        ...ANALYTICS_PROGRAM,
-        dimensions: ['Analytics - Number'],
-    },
-    {
-        ...ANALYTICS_PROGRAM,
-        dimensions: ['Analytics - Yes/no'],
-    },
-]
+export const TEST_DIM_TEXT = 'Analytics - Text'
+export const TEST_DIM_NUMBER = 'Analytics - Number'
+export const TEST_DIM_YESNO = 'Analytics - Yes/no'
 
 export const TEST_ENROLLMENT_DATA = [
     {
@@ -48,17 +37,22 @@ export const TEST_ENROLLMENT_DATA = [
     },
 ]
 
-export const TEST_FIXED_PERIODS = [
-    {
-        //type: 'Monthly',
-        year: `${getPreviousYearStr()}`,
-        name: `December ${getPreviousYearStr()}`,
-    },
-]
+export const TEST_DIM_DATE = 'Analytics - Date'
+export const TEST_DIM_TIME = 'Analytics - Time'
+export const TEST_DIM_DATETIME = 'Analytics - Date & Time'
 
-export const TEST_RELATIVE_PERIODS = [
-    {
-        type: 'Years',
-        name: 'This year',
-    },
-]
+export const TEST_REL_PE_THIS_YEAR = {
+    type: 'Years',
+    name: 'This year',
+}
+
+export const TEST_REL_PE_LAST_12_MONTHS = {
+    //type: 'Months',
+    name: 'Last 12 months',
+}
+
+export const TEST_FIX_PE_DEC_LAST_YEAR = {
+    //type: 'Monthly',
+    year: `${getPreviousYearStr()}`,
+    name: `December ${getPreviousYearStr()}`,
+}

--- a/cypress/helpers/dimensions.js
+++ b/cypress/helpers/dimensions.js
@@ -29,12 +29,18 @@ const selectProgramAndStage = ({ inputType, programName, stageName }) => {
 export const selectEventProgram = ({ programName, stageName }) =>
     selectProgramAndStage({ inputType: INPUT_EVENT, programName, stageName })
 
-// export const selectEnrollmentProgram = ({ programName, stageName }) =>
-//     selectProgramAndStage({
-//         inputType: INPUT_ENROLLMENT,
-//         programName,
-//         stageName,
-//     })
+export const selectEnrollmentProgram = ({ programName, stageName }) =>
+    selectProgramAndStage({
+        inputType: INPUT_ENROLLMENT,
+        programName,
+        stageName,
+    })
+
+export const openDimension = (dimensionName) => {
+    cy.getWithDataTest('{program-dimension-list}')
+        .contains(dimensionName)
+        .click()
+}
 
 const selectProgramDimensions = ({
     inputType,
@@ -46,9 +52,7 @@ const selectProgramDimensions = ({
 
     // add the dimensions as columns
     dimensions.forEach((dimensionName) => {
-        cy.getWithDataTest('{program-dimension-list}')
-            .contains(dimensionName)
-            .click()
+        openDimension(dimensionName)
         cy.contains('Add to Columns').click()
     })
 

--- a/cypress/helpers/dimensions.js
+++ b/cypress/helpers/dimensions.js
@@ -37,9 +37,7 @@ export const selectEnrollmentProgram = ({ programName, stageName }) =>
     })
 
 export const openDimension = (dimensionName) => {
-    cy.getWithDataTest('{program-dimension-list}')
-        .contains(dimensionName)
-        .click()
+    cy.getBySel('program-dimension-list').contains(dimensionName).click()
 }
 
 const selectProgramDimensions = ({

--- a/cypress/integration/conditions/boolean_conditions.cy.js
+++ b/cypress/integration/conditions/boolean_conditions.cy.js
@@ -6,7 +6,10 @@ import {
 } from '../../data/index.js'
 import { selectEventProgramDimensions } from '../../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
-import { selectRelativePeriod } from '../../helpers/period.js'
+import {
+    selectRelativePeriod,
+    getCurrentYearStr,
+} from '../../helpers/period.js'
 import {
     expectTableToBeVisible,
     expectTableToMatchRows,
@@ -57,7 +60,10 @@ describe('boolean conditions', () => {
     it('Yes selected', () => {
         addConditions(['Yes'])
 
-        expectTableToMatchRows(['2022-01-01'])
+        expectTableToMatchRows([
+            `${getCurrentYearStr()}-01-01`,
+            `${getCurrentYearStr()}-04-19`,
+        ])
 
         cy.getBySelLike('layout-chip')
             .contains(`${dimensionName}: 1 condition`)
@@ -69,7 +75,7 @@ describe('boolean conditions', () => {
     it('No selected', () => {
         addConditions(['No'])
 
-        expectTableToMatchRows(['2022-01-03'])
+        expectTableToMatchRows([`${getCurrentYearStr()}-01-03`])
 
         cy.getBySelLike('layout-chip')
             .contains(`${dimensionName}: 1 condition`)
@@ -82,10 +88,11 @@ describe('boolean conditions', () => {
         addConditions(['Yes', 'Not answered'])
 
         expectTableToMatchRows([
-            '2022-01-01',
-            '2022-03-01',
-            '2022-01-01',
-            '2022-02-01',
+            `${getCurrentYearStr()}-01-01`,
+            `${getCurrentYearStr()}-03-01`,
+            `${getCurrentYearStr()}-01-01`,
+            `${getCurrentYearStr()}-02-01`,
+            `${getCurrentYearStr()}-04-19`,
         ])
 
         cy.getBySelLike('layout-chip')

--- a/cypress/integration/conditions/boolean_conditions.cy.js
+++ b/cypress/integration/conditions/boolean_conditions.cy.js
@@ -1,5 +1,9 @@
 import { DIMENSION_ID_EVENT_DATE } from '../../../src/modules/dimensionConstants.js'
-import { TEST_EVENT_DATA, TEST_RELATIVE_PERIODS } from '../../data/index.js'
+import {
+    ANALYTICS_PROGRAM,
+    TEST_DIM_YESNO,
+    TEST_REL_PE_THIS_YEAR,
+} from '../../data/index.js'
 import { selectEventProgramDimensions } from '../../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
 import { selectRelativePeriod } from '../../helpers/period.js'
@@ -9,17 +13,17 @@ import {
 } from '../../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
-const event = TEST_EVENT_DATA[2]
-const dimensionName = event.dimensions[0]
+const event = ANALYTICS_PROGRAM
+const dimensionName = TEST_DIM_YESNO
 const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
 
 const setUpTable = () => {
-    selectEventProgramDimensions(event)
+    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
 
     selectRelativePeriod({
         label: periodLabel,
-        period: TEST_RELATIVE_PERIODS[0],
+        period: TEST_REL_PE_THIS_YEAR,
     })
 
     clickMenubarUpdateButton()

--- a/cypress/integration/conditions/numeric_conditions.cy.js
+++ b/cypress/integration/conditions/numeric_conditions.cy.js
@@ -1,5 +1,9 @@
 import { DIMENSION_ID_EVENT_DATE } from '../../../src/modules/dimensionConstants.js'
-import { TEST_EVENT_DATA, TEST_RELATIVE_PERIODS } from '../../data/index.js'
+import {
+    ANALYTICS_PROGRAM,
+    TEST_DIM_NUMBER,
+    TEST_REL_PE_THIS_YEAR,
+} from '../../data/index.js'
 import { selectEventProgramDimensions } from '../../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
 import { selectRelativePeriod } from '../../helpers/period.js'
@@ -11,17 +15,17 @@ import {
 } from '../../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
-const event = TEST_EVENT_DATA[1]
-const dimensionName = event.dimensions[0]
+const event = ANALYTICS_PROGRAM
+const dimensionName = TEST_DIM_NUMBER
 const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
 
 const setUpTable = () => {
-    selectEventProgramDimensions(event)
+    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
 
     selectRelativePeriod({
         label: periodLabel,
-        period: TEST_RELATIVE_PERIODS[0],
+        period: TEST_REL_PE_THIS_YEAR,
     })
 
     clickMenubarUpdateButton()
@@ -163,7 +167,7 @@ describe('number conditions', () => {
         assertTooltipContainsEntries([stageName, 'Is not empty / not null'])
     })
 
-    it('2 conditions: greater than and less than', () => {
+    it('2 conditions: greater than + less than', () => {
         addConditions([
             { conditionName: 'greater than (>)', value: '11' },
             { conditionName: 'less than (<)', value: '13' },

--- a/cypress/integration/conditions/numeric_conditions.cy.js
+++ b/cypress/integration/conditions/numeric_conditions.cy.js
@@ -75,7 +75,7 @@ describe('number conditions', () => {
     it('greater than', () => {
         addConditions([{ conditionName: 'greater than (>)', value: '12' }])
 
-        expectTableToMatchRows(['2 000 000'])
+        expectTableToMatchRows(['2 000 000', '5 557 779 990'])
 
         cy.getBySelLike('layout-chip')
             .contains(`${dimensionName}: 1 condition`)
@@ -88,7 +88,7 @@ describe('number conditions', () => {
         addConditions([
             { conditionName: 'greater than or equal to', value: '12' },
         ])
-        expectTableToMatchRows(['12', '2 000 000'])
+        expectTableToMatchRows(['12', '2 000 000', '5 557 779 990'])
 
         cy.getBySelLike('layout-chip')
             .contains(`${dimensionName}: 1 condition`)
@@ -102,7 +102,7 @@ describe('number conditions', () => {
 
     it('less than', () => {
         addConditions([{ conditionName: 'less than (<)', value: '12' }])
-        expectTableToMatchRows(['11'])
+        expectTableToMatchRows(['11', '3.7'])
 
         cy.getBySelLike('layout-chip')
             .contains(`${dimensionName}: 1 condition`)
@@ -113,7 +113,7 @@ describe('number conditions', () => {
 
     it('less than or equal to', () => {
         addConditions([{ conditionName: 'less than or equal to', value: '12' }])
-        expectTableToMatchRows(['11', '12'])
+        expectTableToMatchRows(['11', '12', '3.7'])
 
         cy.getBySelLike('layout-chip')
             .contains(`${dimensionName}: 1 condition`)
@@ -128,7 +128,7 @@ describe('number conditions', () => {
     it('not equal to', () => {
         addConditions([{ conditionName: 'not equal to', value: '12' }])
 
-        expectTableToMatchRows(['11', '2 000 000'])
+        expectTableToMatchRows(['11', '2 000 000', '5 557 779 990', '3.7'])
 
         cy.getBySelLike('layout-chip')
             .contains(`${dimensionName}: 1 condition`)
@@ -140,7 +140,7 @@ describe('number conditions', () => {
     it('is empty / null', () => {
         addConditions([{ conditionName: 'is empty / null' }])
 
-        getTableRows().should('have.length', 2)
+        getTableRows().should('have.length', 1)
 
         getTableDataCells()
             .eq(1)
@@ -158,7 +158,13 @@ describe('number conditions', () => {
     it('is not empty / not null', () => {
         addConditions([{ conditionName: 'is not empty / not null' }])
 
-        expectTableToMatchRows(['11', '12', '2 000 000'])
+        expectTableToMatchRows([
+            '11',
+            '12',
+            '2 000 000',
+            '5 557 779 990',
+            '3.7',
+        ])
 
         cy.getBySelLike('layout-chip')
             .contains(`${dimensionName}: 1 condition`)

--- a/cypress/integration/contextMenu.cy.js
+++ b/cypress/integration/contextMenu.cy.js
@@ -1,5 +1,5 @@
 import { AXIS_ID_COLUMNS, AXIS_ID_FILTERS } from '@dhis2/analytics'
-import { TEST_EVENT_DATA } from '../data/index.js'
+import { ANALYTICS_PROGRAM } from '../data/index.js'
 import { selectEventProgram } from '../helpers/dimensions.js'
 import {
     expectAxisToHaveDimension,
@@ -70,7 +70,7 @@ describe('using the layout chip context menu', () => {
 })
 
 describe('using the dimension list context menu', () => {
-    const event = TEST_EVENT_DATA[0]
+    const event = ANALYTICS_PROGRAM
     const TEST_DIM_ID = 'Xd6cKnFMO4L.wkSjJes0DMI' // "Analytics - Integer"
     const openContextMenu = (id) =>
         cy

--- a/cypress/integration/create_enrollment.cy.js
+++ b/cypress/integration/create_enrollment.cy.js
@@ -1,5 +1,9 @@
 import { DIMENSION_ID_ENROLLMENT_DATE } from '../../src/modules/dimensionConstants.js'
-import { TEST_ENROLLMENT_DATA, TEST_FIXED_PERIODS } from '../data/index.js'
+import {
+    ANALYTICS_PROGRAM,
+    TEST_DIM_TEXT,
+    TEST_FIX_PE_DEC_LAST_YEAR,
+} from '../data/index.js'
 import { selectEnrollmentProgramDimensions } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
@@ -10,14 +14,17 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const enrollment = TEST_ENROLLMENT_DATA[0]
-const dimensionName = enrollment.dimensions[0]
+const enrollment = ANALYTICS_PROGRAM
+const dimensionName = TEST_DIM_TEXT
 const periodLabel = enrollment[DIMENSION_ID_ENROLLMENT_DATE]
 
 const setUpTable = () => {
-    selectEnrollmentProgramDimensions(enrollment)
+    selectEnrollmentProgramDimensions({
+        ...enrollment,
+        dimensions: [dimensionName],
+    })
 
-    selectFixedPeriod({ label: periodLabel, period: TEST_FIXED_PERIODS[0] })
+    selectFixedPeriod({ label: periodLabel, period: TEST_FIX_PE_DEC_LAST_YEAR })
 
     clickMenubarUpdateButton()
 

--- a/cypress/integration/create_event.cy.js
+++ b/cypress/integration/create_event.cy.js
@@ -1,5 +1,9 @@
 import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js'
-import { TEST_EVENT_DATA, TEST_FIXED_PERIODS } from '../data/index.js'
+import {
+    ANALYTICS_PROGRAM,
+    TEST_DIM_TEXT,
+    TEST_FIX_PE_DEC_LAST_YEAR,
+} from '../data/index.js'
 import { selectEventProgramDimensions } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
@@ -10,14 +14,14 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const event = TEST_EVENT_DATA[0]
-const dimensionName = event.dimensions[0]
+const event = ANALYTICS_PROGRAM
+const dimensionName = TEST_DIM_TEXT
 const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 
 const setUpTable = () => {
-    selectEventProgramDimensions(event)
+    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
 
-    selectFixedPeriod({ label: periodLabel, period: TEST_FIXED_PERIODS[0] })
+    selectFixedPeriod({ label: periodLabel, period: TEST_FIX_PE_DEC_LAST_YEAR })
 
     clickMenubarUpdateButton()
 

--- a/cypress/integration/new.cy.js
+++ b/cypress/integration/new.cy.js
@@ -1,12 +1,12 @@
 import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js'
-import { TEST_EVENT_DATA, TEST_FIXED_PERIODS } from '../data/index.js'
-import { selectEventProgramDimensions } from '../helpers/dimensions.js'
+import { ANALYTICS_PROGRAM, TEST_FIX_PE_DEC_LAST_YEAR } from '../data/index.js'
+import { selectEventProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
 import { expectTableToBeVisible, getTableRows } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const event = TEST_EVENT_DATA[0]
+const event = ANALYTICS_PROGRAM
 const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 
 describe('new', () => {
@@ -15,9 +15,12 @@ describe('new', () => {
 
         cy.getBySelLike('layout-chip').contains(`Organisation unit: 1 selected`)
 
-        selectEventProgramDimensions(event)
+        selectEventProgram(event)
 
-        selectFixedPeriod({ label: periodLabel, period: TEST_FIXED_PERIODS[0] })
+        selectFixedPeriod({
+            label: periodLabel,
+            period: TEST_FIX_PE_DEC_LAST_YEAR,
+        })
 
         clickMenubarUpdateButton()
 

--- a/cypress/integration/options.cy.js
+++ b/cypress/integration/options.cy.js
@@ -1,9 +1,9 @@
 import { DIMENSION_ID_ENROLLMENT_DATE } from '../../src/modules/dimensionConstants.js'
 import {
+    ANALYTICS_PROGRAM,
     TEST_AOS,
-    TEST_ENROLLMENT_DATA,
-    TEST_EVENT_DATA,
-    TEST_RELATIVE_PERIODS,
+    TEST_DIM_NUMBER,
+    TEST_REL_PE_THIS_YEAR,
 } from '../data/index.js'
 import { selectEnrollmentProgramDimensions } from '../helpers/dimensions.js'
 import {
@@ -59,11 +59,14 @@ describe('options', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
 
         //set up table
-        selectEnrollmentProgramDimensions(TEST_ENROLLMENT_DATA[1])
+        selectEnrollmentProgramDimensions({
+            ...ANALYTICS_PROGRAM,
+            dimensions: [TEST_DIM_NUMBER],
+        })
 
         selectRelativePeriod({
-            label: TEST_EVENT_DATA[0][DIMENSION_ID_ENROLLMENT_DATE],
-            period: TEST_RELATIVE_PERIODS[0],
+            label: ANALYTICS_PROGRAM[DIMENSION_ID_ENROLLMENT_DATE],
+            period: TEST_REL_PE_THIS_YEAR,
         })
 
         clickMenubarUpdateButton()

--- a/cypress/integration/userDimensions.cy.js
+++ b/cypress/integration/userDimensions.cy.js
@@ -1,6 +1,6 @@
 import { DIMENSION_ID_ENROLLMENT_DATE } from '../../src/modules/dimensionConstants.js'
-import { TEST_ENROLLMENT_DATA, TEST_FIXED_PERIODS } from '../data/index.js'
-import { selectEnrollmentProgramDimensions } from '../helpers/dimensions.js'
+import { ANALYTICS_PROGRAM, TEST_FIX_PE_DEC_LAST_YEAR } from '../data/index.js'
+import { selectEnrollmentProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
 import {
@@ -9,7 +9,7 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const enrollment = TEST_ENROLLMENT_DATA[0]
+const enrollment = ANALYTICS_PROGRAM
 const periodLabel = enrollment[DIMENSION_ID_ENROLLMENT_DATE]
 const TEST_DIMENSIONS = ['Created by', 'Last updated by']
 
@@ -18,10 +18,10 @@ describe('user dimensions', () => {
         it(`${dimensionName} is added to the layout`, () => {
             // set up table
             cy.visit('/', EXTENDED_TIMEOUT)
-            selectEnrollmentProgramDimensions(enrollment)
+            selectEnrollmentProgram(enrollment)
             selectFixedPeriod({
                 label: periodLabel,
-                period: TEST_FIXED_PERIODS[0],
+                period: TEST_FIX_PE_DEC_LAST_YEAR,
             })
 
             // open modal


### PR DESCRIPTION
Using lists for test data started as a good idea but turned out to be very confusing to use, e.g. `SOME_LIST[0]` gives no contextual meaning to which object it's referring to.
The lists are now split into individual objects which are easier to pick and understand.