### PR TITLE
fix: avoid encoding when interpolating certain variables in i18n.t

### DIFF
--- a/src/components/MainSidebar/DimensionsList/DimensionsList.js
+++ b/src/components/MainSidebar/DimensionsList/DimensionsList.js
@@ -8,7 +8,7 @@ import styles from './DimensionsList.module.css'
 
 const getNoResultsMessage = (searchTerm, programName) => {
     if (searchTerm) {
-        return i18n.t("No dimensions found for '{{searchTerm}}'", {
+        return i18n.t("No dimensions found for '{{- searchTerm}}'", {
             searchTerm,
         })
     }

--- a/src/components/Toolbar/MenuBar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar/MenuBar.js
@@ -84,7 +84,7 @@ const MenuBar = ({
         history.push('/')
 
         showAlert({
-            message: i18n.t('"{{deletedObject}}" successfully deleted.', {
+            message: i18n.t('"{{- deletedObject}}" successfully deleted.', {
                 deletedObject: deletedVisualization,
             }),
             options: {


### PR DESCRIPTION

### Key features

1. avoid encoding when interpolating certain variables in i18n.t.