### PR TITLE
test: repeated events

### DIFF
--- a/cypress/integration/repeated_events.cy.js
+++ b/cypress/integration/repeated_events.cy.js
@@ -4,6 +4,7 @@ import {
     openDimension,
     selectEnrollmentProgram,
     selectEnrollmentProgramDimensions,
+    selectEventProgram,
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
@@ -13,6 +14,9 @@ import {
     getTableDataCells,
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
+
+const getRepeatedEventsTab = () =>
+    cy.getBySel('conditions-modal-content').contains('Repeated events')
 
 const setUpTable = ({ enrollment, dimensionName }) => {
     selectEnrollmentProgramDimensions({
@@ -42,7 +46,7 @@ const setUpTable = ({ enrollment, dimensionName }) => {
 
 const setRepetition = ({ dimensionName, recent, oldest }) => {
     cy.getBySelLike('layout-chip').contains(dimensionName).click()
-    cy.getBySel('conditions-modal-content').contains('Repeated events').click()
+    getRepeatedEventsTab().click()
     cy.getBySel('most-recent-input')
         .find('input')
         .type('{backspace}')
@@ -58,7 +62,7 @@ const setRepetition = ({ dimensionName, recent, oldest }) => {
 
 const expectRepetitionToBe = ({ dimensionName, recent, oldest }) => {
     cy.getBySelLike('layout-chip').contains(dimensionName).click()
-    cy.getBySel('conditions-modal-content').contains('Repeated events').click()
+    getRepeatedEventsTab().click()
     cy.getBySel('most-recent-input')
         .find('input')
         .should('be.visible')
@@ -185,8 +189,7 @@ describe('repeated events', () => {
 
         openDimension('Bednet distributed')
 
-        cy.getBySel('conditions-modal-content')
-            .contains('Repeated events')
+        getRepeatedEventsTab()
             .should('have.class', 'disabled')
             .trigger('mouseover')
 
@@ -194,5 +197,11 @@ describe('repeated events', () => {
             'Only available for repeatable stages'
         )
     })
-    // TODO: Test "Analytics - Percentage" with Event - no repetiton tab is shown
+    it('repetition is hidden for event programs', () => {
+        selectEventProgram(ANALYTICS_PROGRAM)
+
+        openDimension('Analytics - Percentage')
+
+        getRepeatedEventsTab().should('not.exist')
+    })
 })

--- a/cypress/integration/repeated_events.cy.js
+++ b/cypress/integration/repeated_events.cy.js
@@ -161,7 +161,7 @@ describe('repeated events', () => {
         )
     })
     it.skip('repetition out of bounds returns as empty value', () => {
-        // FIXME: Backend issue, the repetition out of bounds is returned as 0 when it should be an empty string
+        // FIXME: Backend issue, the repetition out of bounds is returned as 0 when it should be an empty string, https://jira.dhis2.org/browse/DHIS2-13633
         const dimensionName = 'Analytics - Percentage'
         setUpTable({ enrollment: ANALYTICS_PROGRAM, dimensionName })
 

--- a/cypress/integration/repeated_events.cy.js
+++ b/cypress/integration/repeated_events.cy.js
@@ -70,6 +70,9 @@ const expectRepetitionToBe = ({ dimensionName, recent, oldest }) => {
     cy.getBySel('conditions-modal').contains('Hide').click()
 }
 
+const expectHeaderToContainExact = (index, value) =>
+    getTableHeaderCells().eq(index).containsExact(value)
+
 describe('repeated events', () => {
     beforeEach(() => {
         cy.visit('/', EXTENDED_TIMEOUT)
@@ -90,21 +93,18 @@ describe('repeated events', () => {
         result.forEach((value, index) => {
             getTableDataCells().eq(index).contains(value)
         })
-        getTableHeaderCells()
-            .eq(0)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent -2)'
-            )
-        getTableHeaderCells()
-            .eq(1)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent -1)'
-            )
-        getTableHeaderCells()
-            .eq(2)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
-            )
+        expectHeaderToContainExact(
+            0,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent -2)'
+        )
+        expectHeaderToContainExact(
+            1,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent -1)'
+        )
+        expectHeaderToContainExact(
+            2,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
+        )
 
         // repetition 0/3 can be set successfully
         setRepetition({ dimensionName, recent: 0, oldest: 3 })
@@ -112,21 +112,18 @@ describe('repeated events', () => {
         result.forEach((value, index) => {
             getTableDataCells().eq(index).contains(value)
         })
-        getTableHeaderCells()
-            .eq(0)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (oldest)'
-            )
-        getTableHeaderCells()
-            .eq(1)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (oldest +1)'
-            )
-        getTableHeaderCells()
-            .eq(2)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (oldest +2)'
-            )
+        expectHeaderToContainExact(
+            0,
+            'Analytics - Percentage - Stage 1 - Repeatable (oldest)'
+        )
+        expectHeaderToContainExact(
+            1,
+            'Analytics - Percentage - Stage 1 - Repeatable (oldest +1)'
+        )
+        expectHeaderToContainExact(
+            2,
+            'Analytics - Percentage - Stage 1 - Repeatable (oldest +2)'
+        )
 
         // repetition 3/3 can be set successfully
         setRepetition({ dimensionName, recent: 3, oldest: 3 })
@@ -134,36 +131,30 @@ describe('repeated events', () => {
         result.forEach((value, index) => {
             getTableDataCells().eq(index).contains(value)
         })
-        getTableHeaderCells()
-            .eq(0)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (oldest)'
-            )
-        getTableHeaderCells()
-            .eq(1)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (oldest +1)'
-            )
-        getTableHeaderCells()
-            .eq(2)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (oldest +2)'
-            )
-        getTableHeaderCells()
-            .eq(3)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent -2)'
-            )
-        getTableHeaderCells()
-            .eq(4)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent -1)'
-            )
-        getTableHeaderCells()
-            .eq(5)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
-            )
+        expectHeaderToContainExact(
+            0,
+            'Analytics - Percentage - Stage 1 - Repeatable (oldest)'
+        )
+        expectHeaderToContainExact(
+            1,
+            'Analytics - Percentage - Stage 1 - Repeatable (oldest +1)'
+        )
+        expectHeaderToContainExact(
+            2,
+            'Analytics - Percentage - Stage 1 - Repeatable (oldest +2)'
+        )
+        expectHeaderToContainExact(
+            3,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent -2)'
+        )
+        expectHeaderToContainExact(
+            4,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent -1)'
+        )
+        expectHeaderToContainExact(
+            5,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
+        )
     })
     it.skip('repetition out of bounds returns as a empty value', () => {
         // FIXME: Backend issue, the repetition out of bounds is returned as 0 when it should be an empty string
@@ -176,21 +167,18 @@ describe('repeated events', () => {
         result.forEach((value, index) => {
             getTableDataCells().eq(index).invoke('text').should('eq', value)
         })
-        getTableHeaderCells()
-            .eq(0)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent -9)'
-            )
-        getTableHeaderCells()
-            .eq(5)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent -4)'
-            )
-        getTableHeaderCells()
-            .eq(9)
-            .containsExact(
-                'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
-            )
+        expectHeaderToContainExact(
+            0,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent -9)'
+        )
+        expectHeaderToContainExact(
+            5,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent -4)'
+        )
+        expectHeaderToContainExact(
+            9,
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
+        )
     })
     it('repetition is disabled for non repetable stages', () => {
         selectEnrollmentProgram({ programName: 'MAL-CS' })

--- a/cypress/integration/repeated_events.cy.js
+++ b/cypress/integration/repeated_events.cy.js
@@ -1,0 +1,210 @@
+import { DIMENSION_ID_ENROLLMENT_DATE } from '../../src/modules/dimensionConstants.js'
+import { ANALYTICS_PROGRAM, TEST_REL_PE_LAST_YEAR } from '../data/index.js'
+import {
+    openDimension,
+    selectEnrollmentProgram,
+    selectEnrollmentProgramDimensions,
+} from '../helpers/dimensions.js'
+import { clickMenubarUpdateButton } from '../helpers/menubar.js'
+import { selectRelativePeriod } from '../helpers/period.js'
+import {
+    getTableHeaderCells,
+    expectTableToBeVisible,
+    getTableDataCells,
+} from '../helpers/table.js'
+import { EXTENDED_TIMEOUT } from '../support/util.js'
+
+const setUpTable = ({ enrollment, dimensionName }) => {
+    selectEnrollmentProgramDimensions({
+        ...enrollment,
+        dimensions: [dimensionName],
+    })
+
+    selectRelativePeriod({
+        label: enrollment[DIMENSION_ID_ENROLLMENT_DATE],
+        period: TEST_REL_PE_LAST_YEAR,
+    })
+
+    cy.getBySel('columns-axis')
+        .findBySel('dimension-menu-button-enrollmentDate')
+        .click()
+    cy.contains('Move to Filter').click()
+
+    cy.getBySel('columns-axis').findBySel('dimension-menu-button-ou').click()
+    cy.contains('Move to Filter').click()
+
+    clickMenubarUpdateButton()
+
+    expectTableToBeVisible()
+
+    cy.getBySelLike('layout-chip').contains(`${dimensionName}: all`)
+}
+
+const setRepetition = ({ dimensionName, recent, oldest }) => {
+    cy.getBySelLike('layout-chip').contains(dimensionName).click()
+    cy.getBySel('conditions-modal-content').contains('Repeated events').click()
+    cy.getBySel('most-recent-input')
+        .find('input')
+        .type('{backspace}')
+        .type('{moveToEnd}')
+        .type(recent)
+    cy.getBySel('oldest-input')
+        .find('input')
+        .type('{backspace}')
+        .type('{moveToEnd}')
+        .type(oldest)
+    cy.getBySel('conditions-modal').contains('Update').click()
+}
+
+const expectRepetitionToBe = ({ dimensionName, recent, oldest }) => {
+    cy.getBySelLike('layout-chip').contains(dimensionName).click()
+    cy.getBySel('conditions-modal-content').contains('Repeated events').click()
+    cy.getBySel('most-recent-input')
+        .find('input')
+        .should('be.visible')
+        .and('have.value', recent)
+    cy.getBySel('oldest-input')
+        .find('input')
+        .should('be.visible')
+        .and('have.value', oldest)
+    cy.getBySel('conditions-modal').contains('Hide').click()
+}
+
+describe('repeated events', () => {
+    beforeEach(() => {
+        cy.visit('/', EXTENDED_TIMEOUT)
+    })
+    it('can use repetition for an enrollment program', () => {
+        const dimensionName = 'Analytics - Percentage'
+        setUpTable({ enrollment: ANALYTICS_PROGRAM, dimensionName })
+
+        // initially only has 1 column and 1 row
+        getTableHeaderCells().its('length').should('equal', 1)
+        getTableHeaderCells().eq(0).containsExact('Analytics - Percentage')
+        getTableDataCells().eq(0).contains('5')
+        expectRepetitionToBe({ dimensionName, recent: 1, oldest: 0 })
+
+        // repetition 3/0 can be set successfully
+        setRepetition({ dimensionName, recent: 3, oldest: 0 })
+        let result = ['11', '0', '5']
+        result.forEach((value, index) => {
+            getTableDataCells().eq(index).contains(value)
+        })
+        getTableHeaderCells()
+            .eq(0)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent -2)'
+            )
+        getTableHeaderCells()
+            .eq(1)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent -1)'
+            )
+        getTableHeaderCells()
+            .eq(2)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
+            )
+
+        // repetition 0/3 can be set successfully
+        setRepetition({ dimensionName, recent: 0, oldest: 3 })
+        result = ['56', '0', '100']
+        result.forEach((value, index) => {
+            getTableDataCells().eq(index).contains(value)
+        })
+        getTableHeaderCells()
+            .eq(0)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (oldest)'
+            )
+        getTableHeaderCells()
+            .eq(1)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (oldest +1)'
+            )
+        getTableHeaderCells()
+            .eq(2)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (oldest +2)'
+            )
+
+        // repetition 3/3 can be set successfully
+        setRepetition({ dimensionName, recent: 3, oldest: 3 })
+        result = ['56', '0', '100', '11', '0', '5']
+        result.forEach((value, index) => {
+            getTableDataCells().eq(index).contains(value)
+        })
+        getTableHeaderCells()
+            .eq(0)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (oldest)'
+            )
+        getTableHeaderCells()
+            .eq(1)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (oldest +1)'
+            )
+        getTableHeaderCells()
+            .eq(2)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (oldest +2)'
+            )
+        getTableHeaderCells()
+            .eq(3)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent -2)'
+            )
+        getTableHeaderCells()
+            .eq(4)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent -1)'
+            )
+        getTableHeaderCells()
+            .eq(5)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
+            )
+    })
+    it.skip('repetition out of bounds returns as a empty value', () => {
+        // FIXME: Backend issue, the repetition out of bounds is returned as 0 when it should be an empty string
+        const dimensionName = 'Analytics - Percentage'
+        setUpTable({ enrollment: ANALYTICS_PROGRAM, dimensionName })
+
+        // repetition 10/0 can be set successfully
+        setRepetition({ dimensionName, recent: 10, oldest: 0 })
+        const result = ['', '56', '0', '100', '50', '35', '10', '11', '0', '5']
+        result.forEach((value, index) => {
+            getTableDataCells().eq(index).invoke('text').should('eq', value)
+        })
+        getTableHeaderCells()
+            .eq(0)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent -9)'
+            )
+        getTableHeaderCells()
+            .eq(5)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent -4)'
+            )
+        getTableHeaderCells()
+            .eq(9)
+            .containsExact(
+                'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
+            )
+    })
+    it('repetition is disabled for non repetable stages', () => {
+        selectEnrollmentProgram({ programName: 'MAL-CS' })
+
+        openDimension('Bednet distributed')
+
+        cy.getBySel('conditions-modal-content')
+            .contains('Repeated events')
+            .should('have.class', 'disabled')
+            .trigger('mouseover')
+
+        cy.getBySelLike('repeatable-events-tooltip-content').contains(
+            'Only available for repeatable stages'
+        )
+    })
+    // TODO: Test "Analytics - Percentage" with Event - no repetiton tab is shown
+})

--- a/cypress/integration/repeated_events.cy.js
+++ b/cypress/integration/repeated_events.cy.js
@@ -160,7 +160,7 @@ describe('repeated events', () => {
             'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
         )
     })
-    it.skip('repetition out of bounds returns as a empty value', () => {
+    it.skip('repetition out of bounds returns as empty value', () => {
         // FIXME: Backend issue, the repetition out of bounds is returned as 0 when it should be an empty string
         const dimensionName = 'Analytics - Percentage'
         setUpTable({ enrollment: ANALYTICS_PROGRAM, dimensionName })

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -471,6 +471,7 @@ const ConditionsManager = ({
                             content={i18n.t(
                                 'Only available for repeatable stages'
                             )}
+                            dataTest={'repeatable-events-tooltip'}
                         >
                             {repeatableTab}
                         </Tooltip>

--- a/src/components/Dialogs/Conditions/RepeatableEvents.js
+++ b/src/components/Dialogs/Conditions/RepeatableEvents.js
@@ -86,6 +86,7 @@ const RepeatableEvents = ({ dimensionId }) => {
                         value={mostRecent.toString()}
                         onChange={({ value }) => onMostRecentChange(value)}
                         min="0"
+                        dataTest={'most-recent-input'}
                     />
                 </div>
                 <div className={classes.repeatableWrapper}>
@@ -102,6 +103,7 @@ const RepeatableEvents = ({ dimensionId }) => {
                         value={oldest.toString()}
                         onChange={({ value }) => onOldestChange(value)}
                         min="0"
+                        dataTest={'oldest-input'}
                     />
                 </div>
             </div>


### PR DESCRIPTION
Adds tests for the repeated events tab in the conditions modal, which is only enabled for repeatable stages in enrollment programs.