### PR TITLE
fix: condition for Integer data element accepts decimal, causing 409 (DHIS2-13326)

### DIFF
--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -205,7 +205,7 @@ const ConditionsManager = ({
         const renderNumericCondition = ({
             enableDecimalSteps,
             allowIntegerOnly,
-        }) => {
+        } = {}) => {
             return (
                 (conditionsList.length && conditionsList) ||
                 (selectedLegendSet && [''])

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -202,9 +202,10 @@ const ConditionsManager = ({
             ))
         }
 
-        const renderNumericCondition = () => {
-            const enableDecimalSteps = valueType === VALUE_TYPE_UNIT_INTERVAL
-
+        const renderNumericCondition = ({
+            enableDecimalSteps,
+            allowIntegerOnly,
+        }) => {
             return (
                 (conditionsList.length && conditionsList) ||
                 (selectedLegendSet && [''])
@@ -222,6 +223,7 @@ const ConditionsManager = ({
                             setSelectedLegendSet(value)
                         }
                         enableDecimalSteps={enableDecimalSteps}
+                        allowIntegerOnly={allowIntegerOnly}
                         dimension={dimension}
                     />
                     {getDividerContent(index)}
@@ -234,13 +236,17 @@ const ConditionsManager = ({
         }
 
         switch (valueType) {
-            case VALUE_TYPE_NUMBER:
-            case VALUE_TYPE_UNIT_INTERVAL:
-            case VALUE_TYPE_PERCENTAGE:
+            case VALUE_TYPE_UNIT_INTERVAL: {
+                return renderNumericCondition({ enableDecimalSteps: true })
+            }
             case VALUE_TYPE_INTEGER:
             case VALUE_TYPE_INTEGER_POSITIVE:
             case VALUE_TYPE_INTEGER_NEGATIVE:
             case VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE: {
+                return renderNumericCondition({ allowIntegerOnly: true })
+            }
+            case VALUE_TYPE_NUMBER:
+            case VALUE_TYPE_PERCENTAGE: {
                 return renderNumericCondition()
             }
             case VALUE_TYPE_PHONE_NUMBER: {

--- a/src/components/Dialogs/Conditions/NumericCondition.js
+++ b/src/components/Dialogs/Conditions/NumericCondition.js
@@ -32,6 +32,7 @@ const NumericCondition = ({
     onLegendSetChange,
     enableDecimalSteps,
     dimension,
+    allowIntegerOnly,
 }) => {
     let operator, value
 
@@ -145,7 +146,11 @@ const NumericCondition = ({
                     <Input
                         value={value}
                         type="number"
-                        onChange={({ value }) => setValue(value)}
+                        onChange={({ value }) =>
+                            setValue(
+                                allowIntegerOnly ? parseInt(value, 10) : value
+                            )
+                        }
                         className={classes.numericInput}
                         dense
                         step={enableDecimalSteps ? '0.1' : '1'}
@@ -232,6 +237,7 @@ NumericCondition.propTypes = {
     onChange: PropTypes.func.isRequired,
     onLegendSetChange: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
+    allowIntegerOnly: PropTypes.bool,
     dimension: PropTypes.shape({
         dimensionType: PropTypes.string,
         id: PropTypes.string,


### PR DESCRIPTION
Implements [DHIS2-13326](https://jira.dhis2.org/browse/DHIS2-13326)

---

### Key features

1. Restrict decimals from being used with integer conditions

---

### Description

This prevents decimals from being used with integer types (Integer, Positive Integer, Negative Integer, Positive or Zero Integer) in the conditions modal. Similar to how the repeatable events modal restricts decimals as well, as seen here: https://github.com/dhis2/line-listing-app/blob/014bdbff42b9d9704c3c48b71a476c62447f54ce/src/components/Dialogs/Conditions/RepeatableEvents.js#L49
