### PR TITLE
fix: avoid crash when pager object in response is malformed DHIS2-13493

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -357,7 +357,13 @@ export const Visualization = ({
                                     <Pagination
                                         disabled={fetching}
                                         page={data.pager.page}
-                                        pageSize={data.pager.pageSize}
+                                        // DHIS2-13493: avoid a crash when the pager object in the analytics response is malformed.
+                                        // When that happens pageSize is 0 which causes the crash because the Rows per page select does not have 0 listed as possible option.
+                                        // The backend should always return the value passed in the request, even if there are no rows for the query.
+                                        // The workaround here makes sure that if the pageSize returned is 0 we use a value which can be selected in the Rows per page select.
+                                        pageSize={
+                                            data.pager.pageSize || PAGE_SIZE
+                                        }
                                         isLastPage={data.pager.isLastPage}
                                         onPageChange={setPage}
                                         onPageSizeChange={setPageSize}


### PR DESCRIPTION
Implements [DHIS2-13493](https://jira.dhis2.org/browse/DHIS2-13493)

---

### Key features

1. avoid crash when pager object in analytics response is malformed

---

### Description

The analytics API in some circumstances returns a malformed `pager` object in the response.
The request made from the analytics apps pass `pageSize` in the query string, this same value should be always returned back from the API.
Also, if  nothing is returned in `rows`, `isLastPage` should be `true`.

The crash is caused by the `Rows per page` select in the `Pagination` component, which does not have `0` listed in its options.

To avoid the crash, instead of relying solely on the API response, we now use a value present among the `Rows per page` options whenever the `pageSize` from the API response is `0`.

---

### Screenshots

Malformed response (notice `pageSize=0` and `isLastPage=false`):
<img width="382" alt="Screenshot 2022-08-25 at 09 38 45" src="https://user-images.githubusercontent.com/150978/186605769-5c394ea2-ea81-4769-ab28-b7d987682e15.png">

Pagination component error that causes the app to crash:
<img width="369" alt="Screenshot 2022-08-24 at 15 01 41" src="https://user-images.githubusercontent.com/150978/186604538-d90baf8b-1d8d-4087-a9bc-d8e6f148b3a0.png">

