### PR TITLE
fix: empty row height

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -302,7 +302,10 @@ export const Visualization = ({
                                         className={cx(
                                             styles.cell,
                                             fontSizeClass,
-                                            sizeClass
+                                            sizeClass,
+                                            {
+                                                [styles.emptyCell]: !value,
+                                            }
                                         )}
                                         backgroundColor={
                                             visualization.legend?.style ===

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -112,6 +112,11 @@
     padding: 4px 8px;
 }
 
+/* Empty cell */
+.dataTable .emptyCell::after {
+    content: '\00a0';
+}
+
 /* Sizes for the table footer */
 .dataTable .stickyNavigation.sizeComfortable {
     padding: 14px 12px;


### PR DESCRIPTION
Adds a fix for empty rows being shorter than rows with actual content

_before_
![image](https://user-images.githubusercontent.com/12590483/187435507-1f14b740-af9d-4828-a417-c4241830d7e4.png)

_after_
![image](https://user-images.githubusercontent.com/12590483/187435423-431b832e-3f27-41d2-a676-a9be24d25ff3.png)
