### PR TITLE
test: add tests for negative legend sets

### DIFF
--- a/cypress/data/index.js
+++ b/cypress/data/index.js
@@ -64,6 +64,7 @@ export const TEST_DIM_COORDINATE = 'Analytics - Coordinate'
 // special
 export const TEST_DIM_ORG_UNIT = 'Analytics - Organisation unit'
 export const TEST_DIM_LEGEND_SET = 'Analytics - Number (legend set)'
+export const TEST_DIM_LEGEND_SET_NEGATIVE = TEST_DIM_NEGATIVE_INTEGER
 
 export const TEST_REL_PE_THIS_YEAR = {
     type: 'Years',

--- a/cypress/helpers/period.js
+++ b/cypress/helpers/period.js
@@ -38,13 +38,6 @@ const unselectAllPeriods = ({ label }) => {
     cy.getBySel('period-dimension-modal-action-confirm').click()
 }
 
-/*const selectStartEndDatePeriod = ({label, period}) => {
-    cy.getBySel('main-sidebar').contains(label).click()
-    // TODO: implement when a start/end date test is added
-    // cy.contains('Define start - end dates').click()
-    cy.contains('Add to Columns').click()
-}*/
-
 const getPreviousYearStr = () => (new Date().getFullYear() - 1).toString()
 
 const getCurrentYearStr = () => new Date().getFullYear().toString()

--- a/cypress/integration/legendSet.cy.js
+++ b/cypress/integration/legendSet.cy.js
@@ -2,6 +2,7 @@ import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js
 import {
     ANALYTICS_PROGRAM,
     TEST_DIM_LEGEND_SET,
+    TEST_DIM_LEGEND_SET_NEGATIVE,
     TEST_REL_PE_LAST_YEAR,
 } from '../data/index.js'
 import { typeInput } from '../helpers/common.js'
@@ -148,7 +149,6 @@ describe('Options - Legend', () => {
         // unaffected cells (date column) have default background and text color
         assertCellsHaveDefaultColors('tr td:nth-child(2)')
     })
-
     it('legend key is hidden by default', () => {
         expectLegendKeyToBeHidden()
     })
@@ -253,7 +253,6 @@ describe('Options - Legend', () => {
         // unaffected cells (date column) have default background and text color
         assertCellsHaveDefaultColors('tr td:nth-child(2)')
     })
-
     it('options can be saved and loaded', () => {
         cy.getBySel('menubar').contains('File').click()
 
@@ -292,9 +291,45 @@ describe('Options - Legend', () => {
         cy.getBySel('fixed-legend-set-select-content').contains(
             TEST_LEGEND_SET.name
         )
+    })
+    it('legend is applied to negative values (per data item)', () => {
+        cy.getBySel('options-modal-content')
+            .contains('Use pre-defined legend per data item')
+            .click()
 
-        cy.getBySel('options-modal-content').closePopper()
+        expectLegendDisplayStrategyToBeByDataItem()
 
+        clickOptionsModalUpdateButton()
+
+        openDimension(TEST_DIM_LEGEND_SET_NEGATIVE)
+
+        cy.contains('Add to Columns').click()
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        TEST_CELLS.concat([
+            { value: -50, color: 'rgb(255, 255, 178)' },
+            { value: -35, color: 'rgb(253, 141, 60)' },
+        ]).forEach((cell) =>
+            cy
+                .getBySel('table-body')
+                .contains(cell.value)
+                .should('have.css', 'color', defaultTextColor)
+                .closest('td')
+                .should('have.css', 'background-color', cell.color)
+        )
+
+        // unaffected cells (date column) have default background and text color
+        assertCellsHaveDefaultColors('tr td:nth-child(2)')
+    })
+    it('legend key displays correctly when two items are in use', () => {
+        expectLegendKeyToBeVisible()
+
+        expectLegedKeyToMatchLegendSets(['Age (COVID-19)', 'Negative'])
+    })
+    it('saved AO can be deleted', () => {
         cy.getBySel('menubar').contains('File').click()
 
         cy.getBySel('file-menu-container').contains('Delete').click()
@@ -306,8 +341,4 @@ describe('Options - Legend', () => {
 
         expectRouteToBeEmpty()
     })
-
-    // TODO:
-    // Test that multiple legend sets show up properly in the legend key - requires better test data in the db!
-    // Being able to apply legends to negative values (but not empty strings)  - requires better test data in the db!
 })

--- a/cypress/integration/legendSet.cy.js
+++ b/cypress/integration/legendSet.cy.js
@@ -20,7 +20,12 @@ import {
     expectLegendDisplayStyleToBeText,
     expectLegendKeyOptionToBeEnabled,
 } from '../helpers/options.js'
-import { selectRelativePeriod } from '../helpers/period.js'
+import {
+    getCurrentYearStr,
+    selectFixedPeriod,
+    selectRelativePeriod,
+    unselectAllPeriods,
+} from '../helpers/period.js'
 import { expectRouteToBeEmpty } from '../helpers/route.js'
 import {
     expectAOTitleToContain,
@@ -28,6 +33,7 @@ import {
     expectLegendKeyToBeHidden,
     expectLegendKeyToBeVisible,
     expectTableToBeVisible,
+    getTableRows,
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
@@ -328,6 +334,39 @@ describe('Options - Legend', () => {
         expectLegendKeyToBeVisible()
 
         expectLegedKeyToMatchLegendSets(['Age (COVID-19)', 'Negative'])
+    })
+    it("empty values doesn't display a legend color", () => {
+        const currentYear = getCurrentYearStr()
+
+        unselectAllPeriods({
+            label: periodLabel,
+        })
+
+        selectFixedPeriod({
+            label: periodLabel,
+            period: {
+                year: currentYear,
+                name: `January ${currentYear}`,
+            },
+        })
+
+        getTableRows()
+            .eq(0)
+            .find('td')
+            .eq(3)
+            .should('have.css', 'background-color', defaultBackgroundColor)
+            .invoke('text')
+            .invoke('trim')
+            .should('equal', '')
+
+        getTableRows()
+            .eq(1)
+            .find('td')
+            .eq(3)
+            .should('have.css', 'background-color', 'rgb(189, 0, 38)')
+            .invoke('text')
+            .invoke('trim')
+            .should('equal', '-12')
     })
     it('saved AO can be deleted', () => {
         cy.getBySel('menubar').contains('File').click()

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "start-server-and-test": "^1.14.0"
     },
     "dependencies": {
-        "@dhis2/analytics": "^23.13.9",
+        "@dhis2/analytics": "^24.0.8",
         "@dhis2/app-runtime": "^3.4.0",
         "@dhis2/ui": "^8.3.1",
         "@dnd-kit/core": "^5.0.3",

--- a/src/components/DetailsPanel/DetailsPanel.js
+++ b/src/components/DetailsPanel/DetailsPanel.js
@@ -27,7 +27,7 @@ const DetailsPanel = ({ interpretationsUnitRef, visualization, disabled }) => {
 
     return (
         <div className={classes.panel} data-test="details-panel">
-            <AboutAOUnit type="eventVisualizations" id={visualization.id} />
+            <AboutAOUnit type="eventVisualization" id={visualization.id} />
             <InterpretationsUnit
                 ref={interpretationsUnitRef}
                 type="eventVisualization"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,16 +2026,16 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^23.13.9":
-  version "23.13.9"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.13.9.tgz#ea08ba2107af3ac9d68f983afddc5e11b9cede13"
-  integrity sha512-TX3EUllHkDBhEQk+Uztam1OiE33Q93TGNDbJjCPVJGMkwvX4JEfmld6V/rH9NZeiWZHQ9I7rX8hGSLd4QOIKBQ==
+"@dhis2/analytics@^24.0.8":
+  version "24.0.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.0.8.tgz#a463bef8ea1f10b8581d202583fa3da5e474c9bf"
+  integrity sha512-Jkh23yiEkUz4SYgGItEkM1z4nXqsLUs9aqUl7oihwQmut2iIMHLo2355QsuELcQGP8DFf4Qgu9MT1mrOZADIFA==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     classnames "^2.3.1"
     d2-utilizr "^0.2.16"
     d3-color "^1.2.3"
-    highcharts "^10.1.0"
+    highcharts "^10.2.0"
     lodash "^4.17.21"
     mathjs "^9.4.2"
     react-beautiful-dnd "^10.1.1"
@@ -8736,10 +8736,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highcharts@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-10.1.0.tgz#561872ae8ea819131d78949136d05bcaaa99108b"
-  integrity sha512-gW/pzy/Qy/hiYeCflYHpwgsP2nqQavwuRUswRf+papmbutZ3I7K7AIZJ/yZ9NL5yzpF7X7r2dX7/nzZGN4A1rg==
+highcharts@^10.2.0:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-10.2.1.tgz#8723b53a5461c12b61f3ff268c28ff80187b9bf1"
+  integrity sha512-4QwLQwWc0XdBHXc2Uy6IJisAUir+sgQIMyFqYZc3BD9iFSFUdllLkRyoed6y33aPb73LAMZE2qLB5SuLqFE/fg==
 
 history@^5.3.0:
   version "5.3.0"


### PR DESCRIPTION
**Requires https://github.com/dhis2/analytics/pull/1335**

- Being able to apply legends to negative values
- Test that multiple legend sets show up properly in the legend key

---

### TODO

- [x] _Legend sets treat empty values as 0 (i.e. applies the same legend to empty values as it would do with 0 values), is this expected or a bug?_ - It's a bug and it's been fixed
