### PR TITLE
fix: translations do not work in conditions dialog (DHIS2-13772)

### DIFF
--- a/src/api/options.js
+++ b/src/api/options.js
@@ -4,11 +4,11 @@ const optionsQuery = {
         const filters = [`optionSet.id:eq:${optionSetId}`]
 
         if (searchTerm) {
-            filters.push(`name:ilike:${searchTerm}`)
+            filters.push(`displayName:ilike:${searchTerm}`)
         }
 
         return {
-            fields: 'code,name,id',
+            fields: 'code,displayName~rename(name),id',
             filter: filters,
             paging: true,
             page,


### PR DESCRIPTION
Implements [DHIS2-13772](https://dhis2.atlassian.net/browse/DHIS2-13772)

---

### Key features

1. Add missing translations for option set options

---

### Description

Switches the option set options from `name` to `displayName` to make sure translated names are returned.

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/191687732-3c915d09-c440-49eb-a00d-891398da1b9c.png)
