### PR TITLE
fix: incorrect hover color for dimensions in filter (DHIS2-13785)

### DIFF
--- a/src/components/Layout/styles/Chip.module.css
+++ b/src/components/Layout/styles/Chip.module.css
@@ -125,6 +125,10 @@
     background-color: var(--colors-grey300);
 }
 
+.chipEmpty:hover {
+    background-color: var(--colors-grey400);
+}
+
 .leftIcon {
     margin-right: 6px;
     line-height: 0;


### PR DESCRIPTION
Implements [DHIS2-13785](https://dhis2.atlassian.net/browse/DHIS2-13785)

---

### Key features

1. add hover color to empty chip

---

### Screenshots

_before: no hover_
![image](https://user-images.githubusercontent.com/12590483/191689413-abd22fe7-c64c-4151-a3ff-9f40a2bbb0e0.png)

_before: hover_
![image](https://user-images.githubusercontent.com/12590483/191689447-c38d49b8-2f8a-491c-bea7-33f698097a59.png)

_after: no hover_
![image](https://user-images.githubusercontent.com/12590483/191689216-f05eaf7d-e896-461c-93b0-0fbce48020a7.png)

_after: hover_
![image](https://user-images.githubusercontent.com/12590483/191689261-212008d0-9f7d-481f-a207-3d8e635599f5.png)

