### PR TITLE
fix: show error message when no stage is selected for events and tracker programs (DHIS2-13786)

### DIFF
--- a/cypress/integration/createEvent.cy.js
+++ b/cypress/integration/createEvent.cy.js
@@ -9,14 +9,10 @@ import {
     ANALYTICS_PROGRAM,
     TEST_DIM_TEXT,
     TEST_FIX_PE_DEC_LAST_YEAR,
-    TEST_REL_PE_LAST_12_MONTHS,
 } from '../data/index.js'
-import {
-    selectEventProgram,
-    selectEventProgramDimensions,
-} from '../helpers/dimensions.js'
+import { selectEventProgramDimensions } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
-import { selectFixedPeriod, selectRelativePeriod } from '../helpers/period.js'
+import { selectFixedPeriod } from '../helpers/period.js'
 import {
     getTableRows,
     getTableHeaderCells,
@@ -98,99 +94,74 @@ const setUpTable = () => {
     cy.getBySelLike('layout-chip').contains(`${dimensionName}: all`)
 }
 describe('event', () => {
-    describe('event with stage', () => {
-        beforeEach(() => {
-            cy.visit('/', EXTENDED_TIMEOUT)
-            setUpTable()
-        })
-
-        it('creates an event line list', () => {
-            // check the correct number of columns
-            getTableHeaderCells().its('length').should('equal', 3)
-
-            // check that there is at least 1 row in the table
-            getTableRows().its('length').should('be.gte', 1)
-
-            // check the column headers in the table
-            getTableHeaderCells()
-                .contains('Organisation unit')
-                .should('be.visible')
-            getTableHeaderCells().contains(dimensionName).should('be.visible')
-            getTableHeaderCells().contains(periodLabel).should('be.visible')
-
-            //check the chips in the layout
-            cy.getBySel('columns-axis')
-                .findBySelLike('layout-chip')
-                .contains('Organisation unit: 1 selected')
-                .should('be.visible')
-
-            cy.getBySel('columns-axis')
-                .findBySelLike('layout-chip')
-                .contains(`${dimensionName}: all`)
-                .should('be.visible')
-
-            cy.getBySel('columns-axis')
-                .findBySelLike('layout-chip')
-                .contains(`${periodLabel}: 1 selected`)
-                .should('be.visible')
-        })
-
-        it('moves a dimension to filter', () => {
-            // move Report date from "Columns" to "Filter"
-            cy.getBySel('columns-axis')
-                .findBySelLike('layout-chip')
-                .findBySel('dimension-menu-button-eventDate')
-                .click()
-            cy.contains('Move to Filter').click()
-            clickMenubarUpdateButton()
-
-            // check the number of columns
-            getTableHeaderCells().its('length').should('equal', 2)
-
-            // check that there is at least 1 row in the table
-            getTableRows().its('length').should('be.gte', 1)
-
-            // check the column headers in the table
-            getTableHeaderCells()
-                .contains('Organisation unit')
-                .should('be.visible')
-            getTableHeaderCells().contains(dimensionName).should('be.visible')
-            getTableHeaderCells().contains(periodLabel).should('not.exist')
-
-            //check the chips in the layout
-            cy.getBySel('columns-axis')
-                .findBySelLike('layout-chip')
-                .contains('Organisation unit: 1 selected')
-                .should('be.visible')
-
-            cy.getBySel('columns-axis')
-                .findBySelLike('layout-chip')
-                .contains(`${dimensionName}: all`)
-                .should('be.visible')
-
-            cy.getBySel('filters-axis')
-                .findBySelLike('layout-chip')
-                .contains(`${periodLabel}: 1 selected`)
-                .should('be.visible')
-        })
+    beforeEach(() => {
+        cy.visit('/', EXTENDED_TIMEOUT)
+        setUpTable()
     })
 
-    describe('event without stage', () => {
-        it('creates an event line list', () => {
-            cy.visit('/', EXTENDED_TIMEOUT)
+    it('creates an event line list', () => {
+        // check the correct number of columns
+        getTableHeaderCells().its('length').should('equal', 3)
 
-            selectEventProgram({
-                programName: 'Adverse events following immunization',
-            })
+        // check that there is at least 1 row in the table
+        getTableRows().its('length').should('be.gte', 1)
 
-            selectRelativePeriod({
-                label: 'Event date',
-                period: TEST_REL_PE_LAST_12_MONTHS,
-            })
+        // check the column headers in the table
+        getTableHeaderCells().contains('Organisation unit').should('be.visible')
+        getTableHeaderCells().contains(dimensionName).should('be.visible')
+        getTableHeaderCells().contains(periodLabel).should('be.visible')
 
-            clickMenubarUpdateButton()
+        //check the chips in the layout
+        cy.getBySel('columns-axis')
+            .findBySelLike('layout-chip')
+            .contains('Organisation unit: 1 selected')
+            .should('be.visible')
 
-            expectTableToBeVisible()
-        })
+        cy.getBySel('columns-axis')
+            .findBySelLike('layout-chip')
+            .contains(`${dimensionName}: all`)
+            .should('be.visible')
+
+        cy.getBySel('columns-axis')
+            .findBySelLike('layout-chip')
+            .contains(`${periodLabel}: 1 selected`)
+            .should('be.visible')
+    })
+
+    it('moves a dimension to filter', () => {
+        // move Report date from "Columns" to "Filter"
+        cy.getBySel('columns-axis')
+            .findBySelLike('layout-chip')
+            .findBySel('dimension-menu-button-eventDate')
+            .click()
+        cy.contains('Move to Filter').click()
+        clickMenubarUpdateButton()
+
+        // check the number of columns
+        getTableHeaderCells().its('length').should('equal', 2)
+
+        // check that there is at least 1 row in the table
+        getTableRows().its('length').should('be.gte', 1)
+
+        // check the column headers in the table
+        getTableHeaderCells().contains('Organisation unit').should('be.visible')
+        getTableHeaderCells().contains(dimensionName).should('be.visible')
+        getTableHeaderCells().contains(periodLabel).should('not.exist')
+
+        //check the chips in the layout
+        cy.getBySel('columns-axis')
+            .findBySelLike('layout-chip')
+            .contains('Organisation unit: 1 selected')
+            .should('be.visible')
+
+        cy.getBySel('columns-axis')
+            .findBySelLike('layout-chip')
+            .contains(`${dimensionName}: all`)
+            .should('be.visible')
+
+        cy.getBySel('filters-axis')
+            .findBySelLike('layout-chip')
+            .contains(`${periodLabel}: 1 selected`)
+            .should('be.visible')
     })
 })

--- a/cypress/integration/layoutValidation.cy.js
+++ b/cypress/integration/layoutValidation.cy.js
@@ -66,7 +66,7 @@ describe('layout validation', () => {
 
         cy.getBySel('error-container').contains('No stage selected')
     })
-    it('validation succeeds', () => {
+    it('validation succeeds when all above are provided', () => {
         // select a stage
         selectEventProgram({
             programName: HIV_PROGRAM.programName,

--- a/cypress/integration/layoutValidation.cy.js
+++ b/cypress/integration/layoutValidation.cy.js
@@ -1,0 +1,80 @@
+import { HIV_PROGRAM, TEST_REL_PE_LAST_12_MONTHS } from '../data/index.js'
+import { selectEventProgram } from '../helpers/dimensions.js'
+import { clickMenubarUpdateButton } from '../helpers/menubar.js'
+import { selectRelativePeriod } from '../helpers/period.js'
+import { expectTableToBeVisible } from '../helpers/table.js'
+import { EXTENDED_TIMEOUT } from '../support/util.js'
+
+const openContextMenu = (id) =>
+    cy
+        .getBySel('main-sidebar')
+        .findBySel(`dimension-item-${id}`)
+        .findBySel('dimension-menu-button')
+        .invoke('attr', 'style', 'visibility: initial')
+        .click()
+
+describe('layout validation', () => {
+    it('columns is required', () => {
+        cy.visit('/', EXTENDED_TIMEOUT)
+
+        // remove org unit
+        openContextMenu('ou')
+        cy.containsExact('Remove').click()
+
+        clickMenubarUpdateButton()
+
+        cy.getBySel('error-container').contains('Columns is empty')
+    })
+    it('org unit dimension is required', () => {
+        // add something other than org unit to columns
+        openContextMenu('lastUpdatedBy')
+        cy.containsExact('Add to Columns').click()
+
+        clickMenubarUpdateButton()
+
+        cy.getBySel('error-container').contains('No organisation unit selected')
+    })
+    it('time dimension is required', () => {
+        // remove previously added dimension
+        openContextMenu('lastUpdatedBy')
+        cy.containsExact('Remove').click()
+
+        // add org unit to columns
+        openContextMenu('ou')
+        cy.containsExact('Add to Columns').click()
+
+        clickMenubarUpdateButton()
+
+        cy.getBySel('error-container').contains('No time dimension selected')
+    })
+    it('program is required', () => {
+        // add a time dimension to columns
+        selectRelativePeriod({
+            label: 'Event date',
+            period: TEST_REL_PE_LAST_12_MONTHS,
+        })
+
+        clickMenubarUpdateButton()
+
+        cy.getBySel('error-container').contains('No program selected')
+    })
+    it('stage is required', () => {
+        // select a program
+        selectEventProgram({ programName: HIV_PROGRAM.programName })
+
+        clickMenubarUpdateButton()
+
+        cy.getBySel('error-container').contains('No stage selected')
+    })
+    it('validation succeeds', () => {
+        // select a stage
+        selectEventProgram({
+            programName: HIV_PROGRAM.programName,
+            stageName: HIV_PROGRAM.stageName,
+        })
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+    })
+})

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -62,8 +62,9 @@ describe('table', () => {
             cy.getBySel('main-sidebar')
                 .contains(dimension)
                 .closest(`[data-test*="dimension-item"]`)
-                .find('button')
-                .click({ force: true })
+                .findBySel('dimension-menu-button')
+                .invoke('attr', 'style', 'visibility: initial')
+                .click()
 
             cy.contains('Add to Columns').click()
         })

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-06T11:12:41.461Z\n"
-"PO-Revision-Date: 2022-09-06T11:12:41.461Z\n"
+"POT-Creation-Date: 2022-09-22T12:13:43.831Z\n"
+"PO-Revision-Date: 2022-09-22T12:13:43.831Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -569,6 +569,12 @@ msgstr "No program selected"
 
 msgid "Choose a program from the Program Dimensions sidebar."
 msgstr "Choose a program from the Program Dimensions sidebar."
+
+msgid "No stage selected"
+msgstr "No stage selected"
+
+msgid "Choose a stage from the Program Dimensions sidebar."
+msgstr "Choose a stage from the Program Dimensions sidebar."
 
 msgid "Columns is empty"
 msgstr "Columns is empty"

--- a/src/api/options.js
+++ b/src/api/options.js
@@ -4,11 +4,11 @@ const optionsQuery = {
         const filters = [`optionSet.id:eq:${optionSetId}`]
 
         if (searchTerm) {
-            filters.push(`name:ilike:${searchTerm}`)
+            filters.push(`displayName:ilike:${searchTerm}`)
         }
 
         return {
-            fields: 'code,name,id',
+            fields: 'code,displayName~rename(name),id',
             filter: filters,
             paging: true,
             page,

--- a/src/components/Visualization/StartScreen.js
+++ b/src/components/Visualization/StartScreen.js
@@ -51,7 +51,10 @@ const StartScreen = ({ error, setLoadError }) => {
         <div className={styles.outer}>
             <div className={styles.inner}>
                 {error ? (
-                    <div className={styles.errorContainer}>
+                    <div
+                        className={styles.errorContainer}
+                        data-test={'error-container'}
+                    >
                         {isVisualizationError(error) ? (
                             <>
                                 <div className={styles.errorIcon}>

--- a/src/modules/error.js
+++ b/src/modules/error.js
@@ -51,6 +51,13 @@ export const noProgramError = () =>
         i18n.t('Choose a program from the Program Dimensions sidebar.')
     )
 
+export const noStageError = () =>
+    visualizationError(
+        EmptyBox,
+        i18n.t('No stage selected'),
+        i18n.t('Choose a stage from the Program Dimensions sidebar.')
+    )
+
 export const noColumnsError = () =>
     visualizationError(
         EmptyBox,

--- a/src/modules/error.js
+++ b/src/modules/error.js
@@ -69,14 +69,18 @@ export const noOrgUnitError = () =>
     visualizationError(
         DataError,
         i18n.t('No organisation unit selected'),
-        i18n.t('Add at least one organisation unit to the layout.')
+        i18n.t(
+            'Make sure to add the organisation unit dimension with at least one selection to the layout.'
+        )
     )
 
 export const noPeriodError = () =>
     visualizationError(
         PeriodError,
         i18n.t('No time dimension selected'),
-        i18n.t('Add at least one time dimension to the layout.')
+        i18n.t(
+            'Make sure to add a time dimension with at least one selection to the layout.'
+        )
     )
 
 export const indicatorError = () =>

--- a/src/modules/layoutValidation.js
+++ b/src/modules/layoutValidation.js
@@ -58,7 +58,7 @@ const validateLineListLayout = (layout) => {
         throw noPeriodError()
     }
 
-    if (!layout?.program?.id) {
+    if (!layoutHasProgramId(layout)) {
         throw noProgramError()
     }
 

--- a/src/modules/layoutValidation.js
+++ b/src/modules/layoutValidation.js
@@ -11,7 +11,9 @@ import {
     noOrgUnitError,
     noPeriodError,
     noProgramError,
+    noStageError,
 } from './error.js'
+import { OUTPUT_TYPE_EVENT } from './visualization.js'
 
 // Layout validation helper functions
 const isAxisValid = (axis) =>
@@ -58,6 +60,10 @@ const validateLineListLayout = (layout) => {
 
     if (!layout?.program?.id) {
         throw noProgramError()
+    }
+
+    if (layout.outputType === OUTPUT_TYPE_EVENT && !layout?.programStage?.id) {
+        throw noStageError()
     }
 }
 


### PR DESCRIPTION
Implements [DHIS2-13786](https://dhis2.atlassian.net/browse/DHIS2-13786)


---

### Key features

1. adds a custom error when no stage is selected (when using type: event)

---

### TODO

-   [x] Cypress tests

---

### Screenshots

_error when no stage is selected_
![image](https://user-images.githubusercontent.com/12590483/191743884-91ea2980-a9ba-4f13-a1e7-b16562e5b981.png)

_selecting stage clears the error_
![image](https://user-images.githubusercontent.com/12590483/191743958-b383f3cb-6d7c-486c-9b7e-9a523c4fd20a.png)

_enrollment is unaffected_
![image](https://user-images.githubusercontent.com/12590483/191744068-6c3512d8-e370-4b58-8536-278c5b5bf5d0.png)
