### PR TITLE
fix: stage is remembered internally after program is cleared

### DIFF
--- a/src/components/VisualizationOptions/Options/Legend.js
+++ b/src/components/VisualizationOptions/Options/Legend.js
@@ -48,7 +48,7 @@ const Legend = ({
             })
         } else {
             onChange({
-                [OPTION_LEGEND_DISPLAY_STRATEGY]: LEGEND_DISPLAY_STRATEGY_FIXED,
+                [OPTION_LEGEND_DISPLAY_STRATEGY]: undefined,
             })
             onChange({
                 [OPTION_LEGEND_SET]: undefined,

--- a/src/modules/current.js
+++ b/src/modules/current.js
@@ -22,6 +22,8 @@ export const getDefaultFromUi = (current, ui) => {
     }
 
     return {
+        // merge with current if current is a saved visualization to keep id, access etc
+        ...(current?.id && current),
         [BASE_FIELD_TYPE]: adaptedUi.type,
         outputType: adaptedUi.input.type,
         ...getProgramFromUi(adaptedUi),
@@ -35,12 +37,9 @@ export const getProgramFromUi = (ui) => ({
     program: { id: ui.program?.id },
 })
 
-export const getProgramStageFromUi = (ui) =>
-    ui.program?.stageId
-        ? {
-              programStage: { id: ui.program?.stageId },
-          }
-        : {}
+export const getProgramStageFromUi = (ui) => ({
+    programStage: { id: ui.program?.stageId },
+})
 
 export const getOptionsFromUi = (ui) => {
     const legend = {

--- a/src/modules/current.js
+++ b/src/modules/current.js
@@ -22,7 +22,6 @@ export const getDefaultFromUi = (current, ui) => {
     }
 
     return {
-        ...current, // TODO: This turns it in to an "update existing" rather than a "create from scratch" operation, is this intentional?
         [BASE_FIELD_TYPE]: adaptedUi.type,
         outputType: adaptedUi.input.type,
         ...getProgramFromUi(adaptedUi),


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-13793

- Only merge current state with the new state for saved visualizations.
- Always pass a program stage object. If no id, the id prop is undefined.
- When legend is toggled off we now set the legend strategy to undefined.
