### PR TITLE
fix: do not pass empty stage when saving

### DIFF
--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -152,6 +152,7 @@ const removeDimensionPropsBeforeSaving = (
 
 export const getVisualizationFromCurrent = (current) => {
     const visualization = Object.assign({}, current)
+
     const nonSavableOptions = Object.keys(options).filter(
         (option) => !options[option].savable
     )
@@ -164,6 +165,8 @@ export const getVisualizationFromCurrent = (current) => {
     visualization.filters = removeDimensionPropsBeforeSaving(
         visualization.filters
     )
+
+    !visualization.programStage?.id && delete visualization.programStage
 
     // When saving a copy of an AO created with the Event Reports app, remove the legacy flag.
     // This copy won't work in Event Reports app anyway.


### PR DESCRIPTION
Removes empty stage object before saving a visualization.