### PR TITLE
fix: do not pass empty stage when saving

### DIFF
--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -165,6 +165,8 @@ export const getVisualizationFromCurrent = (current) => {
         visualization.filters
     )
 
+    !visualization.programStage?.id && delete visualization.programStage
+
     // When saving a copy of an AO created with the Event Reports app, remove the legacy flag.
     // This copy won't work in Event Reports app anyway.
     // This also unlocks the Save button on the copied (and converted to new format) AO in LL app.


### PR DESCRIPTION
Makes sure we never pass empty program stage object when saving.