### PR TITLE
feat: add "Scheduled" event status  (DHIS2-13881)

### DIFF
--- a/cypress/integration/eventStatus.cy.js
+++ b/cypress/integration/eventStatus.cy.js
@@ -1,0 +1,106 @@
+import { DIMENSION_ID_SCHEDULED_DATE } from '../../src/modules/dimensionConstants.js'
+import { ANALYTICS_PROGRAM, TEST_REL_PE_THIS_YEAR } from '../data/index.js'
+import { selectEventProgram } from '../helpers/dimensions.js'
+import {
+    assertChipContainsText,
+    assertTooltipContainsEntries,
+} from '../helpers/layout.js'
+import { clickMenubarUpdateButton } from '../helpers/menubar.js'
+import { selectRelativePeriod, getCurrentYearStr } from '../helpers/period.js'
+import {
+    getTableHeaderCells,
+    expectTableToBeVisible,
+    expectTableToMatchRows,
+} from '../helpers/table.js'
+import { EXTENDED_TIMEOUT } from '../support/util.js'
+
+describe('event status', () => {
+    it('can be filtered', () => {
+        const event = ANALYTICS_PROGRAM
+        const dimensionName = 'Event status'
+
+        cy.visit('/', EXTENDED_TIMEOUT)
+
+        selectEventProgram(event)
+
+        selectRelativePeriod({
+            label: event[DIMENSION_ID_SCHEDULED_DATE],
+            period: TEST_REL_PE_THIS_YEAR,
+        })
+
+        cy.getBySel('main-sidebar')
+            .contains(dimensionName)
+            .closest(`[data-test*="dimension-item"]`)
+            .findBySel('dimension-menu-button')
+            .invoke('attr', 'style', 'visibility: initial')
+            .click()
+
+        cy.contains('Add to Columns').click()
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        expectTableToMatchRows([
+            'Active',
+            'Scheduled',
+            'Completed',
+            'Completed',
+            'Completed',
+            'Completed',
+            'Completed',
+        ])
+
+        getTableHeaderCells().contains(dimensionName).should('be.visible')
+
+        cy.getBySel('columns-axis')
+            .findBySelLike('layout-chip')
+            .contains(`${dimensionName}: all`)
+            .should('be.visible')
+
+        // Add filter 'Active'
+
+        cy.getBySel('columns-axis').contains(dimensionName).click()
+
+        cy.getBySel('event-status-checkbox')
+            .contains('Active')
+            .click()
+            .find('[type="checkbox"]')
+            .should('be.checked')
+
+        cy.getBySel('fixed-dimension-modal-actions').contains('Update').click()
+
+        expectTableToBeVisible()
+
+        expectTableToMatchRows([`${getCurrentYearStr()}-02-01`])
+
+        assertChipContainsText(`${dimensionName}: 1 selected`)
+
+        assertTooltipContainsEntries(['Active'])
+
+        // Add filter 'Scheduled'
+
+        cy.getBySel('columns-axis').contains(dimensionName).click()
+
+        cy.getBySel('event-status-checkbox')
+            .contains('Scheduled')
+            .click()
+            .find('[type="checkbox"]')
+            .should('be.checked')
+
+        cy.getBySel('fixed-dimension-modal-actions').contains('Update').click()
+
+        expectTableToBeVisible()
+
+        expectTableToMatchRows([
+            `${getCurrentYearStr()}-02-01`,
+            `${getCurrentYearStr()}-12-25`,
+        ])
+
+        expectTableToMatchRows(['Active', 'Scheduled'])
+
+        assertChipContainsText(`${dimensionName}: 2 selected`)
+
+        assertTooltipContainsEntries(['Scheduled'])
+    })
+})

--- a/cypress/integration/repeatedEvents.cy.js
+++ b/cypress/integration/repeatedEvents.cy.js
@@ -88,12 +88,12 @@ describe('repeated events', () => {
         // initially only has 1 column and 1 row
         getTableHeaderCells().its('length').should('equal', 1)
         getTableHeaderCells().eq(0).containsExact('Analytics - Percentage')
-        getTableDataCells().eq(0).contains('5')
+        getTableDataCells().eq(0).invoke('text').should('eq', '')
         expectRepetitionToBe({ dimensionName, recent: 1, oldest: 0 })
 
         // repetition 3/0 can be set successfully
         setRepetition({ dimensionName, recent: 3, oldest: 0 })
-        let result = ['11', '', '5']
+        let result = ['', '5', '']
         result.forEach((value, index) => {
             getTableDataCells().eq(index).invoke('text').should('eq', value)
         })
@@ -131,7 +131,7 @@ describe('repeated events', () => {
 
         // repetition 3/3 can be set successfully
         setRepetition({ dimensionName, recent: 3, oldest: 3 })
-        result = ['56', '0', '100', '11', '', '5']
+        result = ['56', '0', '100', '', '5', '']
         result.forEach((value, index) => {
             getTableDataCells().eq(index).invoke('text').should('eq', value)
         })
@@ -165,21 +165,33 @@ describe('repeated events', () => {
         setUpTable({ enrollment: ANALYTICS_PROGRAM, dimensionName })
 
         // repetition 10/0 can be set successfully
-        setRepetition({ dimensionName, recent: 10, oldest: 0 })
-        const result = ['', '56', '0', '100', '50', '35', '10', '11', '', '5']
+        setRepetition({ dimensionName, recent: 11, oldest: 0 })
+        const result = [
+            '',
+            '56',
+            '0',
+            '100',
+            '50',
+            '35',
+            '10',
+            '11',
+            '',
+            '5',
+            '',
+        ]
         result.forEach((value, index) => {
             getTableDataCells().eq(index).invoke('text').should('eq', value)
         })
         expectHeaderToContainExact(
             0,
-            'Analytics - Percentage - Stage 1 - Repeatable (most recent -9)'
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent -10)'
         )
         expectHeaderToContainExact(
             5,
-            'Analytics - Percentage - Stage 1 - Repeatable (most recent -4)'
+            'Analytics - Percentage - Stage 1 - Repeatable (most recent -5)'
         )
         expectHeaderToContainExact(
-            9,
+            10,
             'Analytics - Percentage - Stage 1 - Repeatable (most recent)'
         )
     })

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -20,9 +20,9 @@ const event = ANALYTICS_PROGRAM
 const timeDimensions = [
     { id: DIMENSION_ID_EVENT_DATE, rowsLength: 6 },
     { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 4 },
-    { id: DIMENSION_ID_SCHEDULED_DATE, rowsLength: 6 },
+    { id: DIMENSION_ID_SCHEDULED_DATE, rowsLength: 7 },
     { id: DIMENSION_ID_INCIDENT_DATE, rowsLength: 4 },
-    { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 13 },
+    { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 14 },
 ]
 
 describe('event', () => {

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-30T08:21:12.177Z\n"
-"PO-Revision-Date: 2022-09-30T08:21:12.177Z\n"
+"POT-Creation-Date: 2022-10-07T12:47:41.100Z\n"
+"PO-Revision-Date: 2022-10-07T12:47:41.100Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -702,6 +702,9 @@ msgstr "Cancelled"
 
 msgid "Completed"
 msgstr "Completed"
+
+msgid "Scheduled"
+msgstr "Scheduled"
 
 msgid "List data from tracked entities and events."
 msgstr "List data from tracked entities and events."

--- a/src/components/Dialogs/FixedDimension.js
+++ b/src/components/Dialogs/FixedDimension.js
@@ -4,6 +4,7 @@ import {
     DIMENSION_ID_ORGUNIT,
     useCachedDataQuery,
 } from '@dhis2/analytics'
+import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { Checkbox } from '@dhis2/ui'
 import PropTypes from 'prop-types'
@@ -20,6 +21,7 @@ import {
     STATUS_ACTIVE,
     STATUS_CANCELLED,
     STATUS_COMPLETED,
+    STATUS_SCHEDULED,
     statusNames,
 } from '../../modules/visualization.js'
 import { sGetMetadata } from '../../reducers/metadata.js'
@@ -45,6 +47,7 @@ const FixedDimension = ({
     setUiItems,
 }) => {
     const { rootOrgUnits } = useCachedDataQuery()
+    const { serverVersion } = useConfig()
     const selectUiItems = ({ dimensionId, items }) => {
         setUiItems({
             dimensionId,
@@ -138,6 +141,17 @@ const FixedDimension = ({
             { id: STATUS_ACTIVE, name: statusNames[STATUS_ACTIVE] },
             { id: STATUS_COMPLETED, name: statusNames[STATUS_COMPLETED] },
         ]
+
+        if (
+            `${serverVersion.major}.${serverVersion.minor}.${
+                serverVersion.patch || 0
+            }` >= '2.39.0'
+        ) {
+            ALL_STATUSES.push({
+                id: STATUS_SCHEDULED,
+                name: statusNames[STATUS_SCHEDULED],
+            })
+        }
 
         return (
             <>

--- a/src/components/Dialogs/FixedDimension.js
+++ b/src/components/Dialogs/FixedDimension.js
@@ -129,6 +129,7 @@ const FixedDimension = ({
                             }
                             dense
                             className={classes.verticalCheckbox}
+                            dataTest={'program-status-checkbox'}
                         />
                     ))}
                 </div>
@@ -172,6 +173,7 @@ const FixedDimension = ({
                             }
                             dense
                             className={classes.verticalCheckbox}
+                            dataTest={'event-status-checkbox'}
                         />
                     ))}
                 </div>

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -29,6 +29,7 @@ import { default as options } from './options.js'
 export const STATUS_ACTIVE = 'ACTIVE'
 export const STATUS_CANCELLED = 'CANCELLED'
 export const STATUS_COMPLETED = 'COMPLETED'
+export const STATUS_SCHEDULED = 'SCHEDULE'
 
 export const OUTPUT_TYPE_EVENT = 'EVENT'
 export const OUTPUT_TYPE_ENROLLMENT = 'ENROLLMENT'
@@ -37,6 +38,7 @@ export const statusNames = {
     [STATUS_ACTIVE]: i18n.t('Active'),
     [STATUS_CANCELLED]: i18n.t('Cancelled'),
     [STATUS_COMPLETED]: i18n.t('Completed'),
+    [STATUS_SCHEDULED]: i18n.t('Scheduled'),
 }
 
 export const headersMap = {


### PR DESCRIPTION
Implements [DHIS2-13881](https://dhis2.atlassian.net/browse/DHIS2-13881)

---

### Key features

1. Add support for event status 'Scheduled' for `>=2.39`
2. Changes some test data as there's now an additional event in the db that needs to be taken into account

---

### TODO

-   [x] Cypress tests

---

### Known issues

-   [x] this is only supported in 2.39 but "SCHEDULE" items still show up in 2.38?

---

### Screenshots

_conditions modal_
![image](https://user-images.githubusercontent.com/12590483/194542408-a62698d4-585a-439f-9263-f613510aa6c5.png)

_visualization_
![image](https://user-images.githubusercontent.com/12590483/194542495-4e44f357-c247-4570-bc4c-a1208c2e11b9.png)
