### PR TITLE
fix: swap the order of layout validation to prioritise "no program" (DHIS2-13898)

### DIFF
--- a/cypress/integration/layoutValidation.cy.js
+++ b/cypress/integration/layoutValidation.cy.js
@@ -1,3 +1,4 @@
+import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js'
 import { HIV_PROGRAM, TEST_REL_PE_LAST_12_MONTHS } from '../data/index.js'
 import { selectEventProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
@@ -14,8 +15,29 @@ const openContextMenu = (id) =>
         .click()
 
 describe('layout validation', () => {
-    it('columns is required', () => {
+    const event = HIV_PROGRAM
+
+    it('program is required', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
+
+        clickMenubarUpdateButton()
+
+        cy.getBySel('error-container').contains('No program selected')
+    })
+    it('stage is required', () => {
+        // select a program
+        selectEventProgram({ programName: event.programName })
+
+        clickMenubarUpdateButton()
+
+        cy.getBySel('error-container').contains('No stage selected')
+    })
+    it('columns is required', () => {
+        // select a stage
+        selectEventProgram({
+            programName: event.programName,
+            stageName: event.stageName,
+        })
 
         // remove org unit
         openContextMenu('ou')
@@ -47,30 +69,11 @@ describe('layout validation', () => {
 
         cy.getBySel('error-container').contains('No time dimension selected')
     })
-    it('program is required', () => {
+    it('validation succeeds when all above are provided', () => {
         // add a time dimension to columns
         selectRelativePeriod({
-            label: 'Event date',
+            label: event[DIMENSION_ID_EVENT_DATE],
             period: TEST_REL_PE_LAST_12_MONTHS,
-        })
-
-        clickMenubarUpdateButton()
-
-        cy.getBySel('error-container').contains('No program selected')
-    })
-    it('stage is required', () => {
-        // select a program
-        selectEventProgram({ programName: HIV_PROGRAM.programName })
-
-        clickMenubarUpdateButton()
-
-        cy.getBySel('error-container').contains('No stage selected')
-    })
-    it('validation succeeds when all above are provided', () => {
-        // select a stage
-        selectEventProgram({
-            programName: HIV_PROGRAM.programName,
-            stageName: HIV_PROGRAM.stageName,
         })
 
         clickMenubarUpdateButton()

--- a/src/modules/layoutValidation.js
+++ b/src/modules/layoutValidation.js
@@ -37,6 +37,14 @@ const validateAxis = (axis, error) => {
 }
 
 const validateLineListLayout = (layout) => {
+    if (!layoutHasProgramId(layout)) {
+        throw noProgramError()
+    }
+
+    if (layout.outputType === OUTPUT_TYPE_EVENT && !layout?.programStage?.id) {
+        throw noStageError()
+    }
+
     validateAxis(layout.columns, noColumnsError())
     validateDimension(
         layoutGetDimension(layout, DIMENSION_ID_ORGUNIT),
@@ -56,14 +64,6 @@ const validateLineListLayout = (layout) => {
 
     if (!layoutHasTimeDimension) {
         throw noPeriodError()
-    }
-
-    if (!layoutHasProgramId(layout)) {
-        throw noProgramError()
-    }
-
-    if (layout.outputType === OUTPUT_TYPE_EVENT && !layout?.programStage?.id) {
-        throw noStageError()
     }
 }
 


### PR DESCRIPTION
Implements [DHIS2-13898](https://dhis2.atlassian.net/browse/DHIS2-13898)

---

### Key features

1. reorders the layout validation to prioritise program/stage
2. updates the Cypress tests to reflect the changes above

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/194860174-8096b348-940c-4f06-b9a4-dc0679e54ba6.png)
