### PR TITLE
chore: enable program dimensions tests by expanding structure of test program data

### DIFF
--- a/cypress/data/index.js
+++ b/cypress/data/index.js
@@ -60,31 +60,6 @@ export const ENROLLMENT_ANALYTICS_PROGRAM = {
     },
 }
 
-export const ENROLLMENT_HIV_PROGRAM = {
-    programName: 'HIV Case Surveillance',
-
-    [DIMENSION_ID_EVENT_DATE]: {
-        label: 'Event date',
-        enabled: false,
-    },
-    [DIMENSION_ID_ENROLLMENT_DATE]: {
-        label: 'Enrollment date',
-        enabled: true,
-    },
-    [DIMENSION_ID_SCHEDULED_DATE]: {
-        label: 'Scheduled date',
-        enabled: false,
-    },
-    [DIMENSION_ID_INCIDENT_DATE]: {
-        label: 'Incident date',
-        enabled: false,
-    },
-    [DIMENSION_ID_LAST_UPDATED]: {
-        label: 'Last updated on',
-        enabled: true,
-    },
-}
-
 export const HIV_PROGRAM = {
     programName: 'HIV Case Surveillance',
     stages: {

--- a/cypress/data/index.js
+++ b/cypress/data/index.js
@@ -36,6 +36,55 @@ export const ANALYTICS_PROGRAM = {
     },
 }
 
+export const ENROLLMENT_ANALYTICS_PROGRAM = {
+    programName: 'Analytics program',
+    [DIMENSION_ID_EVENT_DATE]: {
+        label: 'Event date (analytics)',
+        enabled: false,
+    },
+    [DIMENSION_ID_ENROLLMENT_DATE]: {
+        label: 'Enrollment date (analytics)',
+        enabled: true,
+    },
+    [DIMENSION_ID_SCHEDULED_DATE]: {
+        label: 'Scheduled date (analytics)',
+        enabled: false,
+    },
+    [DIMENSION_ID_INCIDENT_DATE]: {
+        label: 'Incident date (analytics)',
+        enabled: true,
+    },
+    [DIMENSION_ID_LAST_UPDATED]: {
+        label: 'Last updated on',
+        enabled: true,
+    },
+}
+
+export const ENROLLMENT_HIV_PROGRAM = {
+    programName: 'HIV Case Surveillance',
+
+    [DIMENSION_ID_EVENT_DATE]: {
+        label: 'Event date',
+        enabled: false,
+    },
+    [DIMENSION_ID_ENROLLMENT_DATE]: {
+        label: 'Enrollment date',
+        enabled: true,
+    },
+    [DIMENSION_ID_SCHEDULED_DATE]: {
+        label: 'Scheduled date',
+        enabled: false,
+    },
+    [DIMENSION_ID_INCIDENT_DATE]: {
+        label: 'Incident date',
+        enabled: false,
+    },
+    [DIMENSION_ID_LAST_UPDATED]: {
+        label: 'Last updated on',
+        enabled: true,
+    },
+}
+
 export const HIV_PROGRAM = {
     programName: 'HIV Case Surveillance',
     stages: {

--- a/cypress/data/index.js
+++ b/cypress/data/index.js
@@ -9,22 +9,83 @@ import { getPreviousYearStr } from '../helpers/period.js'
 
 export const ANALYTICS_PROGRAM = {
     programName: 'Analytics program',
-    //stageName: 'Stage 1 - Repeatable',
-    [DIMENSION_ID_EVENT_DATE]: 'Event date (analytics)',
-    [DIMENSION_ID_ENROLLMENT_DATE]: 'Enrollment date (analytics)',
-    [DIMENSION_ID_SCHEDULED_DATE]: 'Scheduled date (analytics)',
-    [DIMENSION_ID_INCIDENT_DATE]: 'Incident date (analytics)',
-    [DIMENSION_ID_LAST_UPDATED]: 'Last updated on',
+    stages: {
+        'Stage 1 - Repeatable': {
+            stageName: 'Stage 1 - Repeatable',
+            [DIMENSION_ID_EVENT_DATE]: {
+                label: 'Event date (analytics)',
+                enabled: true,
+            },
+            [DIMENSION_ID_ENROLLMENT_DATE]: {
+                label: 'Enrollment date (analytics)',
+                enabled: true,
+            },
+            [DIMENSION_ID_SCHEDULED_DATE]: {
+                label: 'Scheduled date (analytics)',
+                enabled: true,
+            },
+            [DIMENSION_ID_INCIDENT_DATE]: {
+                label: 'Incident date (analytics)',
+                enabled: true,
+            },
+            [DIMENSION_ID_LAST_UPDATED]: {
+                label: 'Last updated on',
+                enabled: true,
+            },
+        },
+    },
 }
 
 export const HIV_PROGRAM = {
     programName: 'HIV Case Surveillance',
-    stageName: 'Initial Case Report',
-    [DIMENSION_ID_EVENT_DATE]: 'Initial Case Report',
-    [DIMENSION_ID_ENROLLMENT_DATE]: 'Enrollment date',
-    [DIMENSION_ID_SCHEDULED_DATE]: 'Scheduled date',
-    [DIMENSION_ID_INCIDENT_DATE]: 'Incident date',
-    [DIMENSION_ID_LAST_UPDATED]: 'Last updated on',
+    stages: {
+        'No stage': {
+            stageName: 'No stage',
+            [DIMENSION_ID_EVENT_DATE]: {
+                label: 'Event date',
+                enabled: true,
+            },
+            [DIMENSION_ID_ENROLLMENT_DATE]: {
+                label: 'Enrollment date',
+                enabled: true,
+            },
+            [DIMENSION_ID_SCHEDULED_DATE]: {
+                label: 'Scheduled date',
+                enabled: false,
+            },
+            [DIMENSION_ID_INCIDENT_DATE]: {
+                label: 'Incident date',
+                enabled: false,
+            },
+            [DIMENSION_ID_LAST_UPDATED]: {
+                label: 'Last updated on',
+                enabled: true,
+            },
+        },
+        'Initial Case Report': {
+            stageName: 'Initial Case Report',
+            [DIMENSION_ID_EVENT_DATE]: {
+                label: 'Initial Case Report',
+                enabled: true,
+            },
+            [DIMENSION_ID_ENROLLMENT_DATE]: {
+                label: 'Enrollment date',
+                enabled: true,
+            },
+            [DIMENSION_ID_SCHEDULED_DATE]: {
+                label: 'Scheduled date',
+                enabled: false,
+            },
+            [DIMENSION_ID_INCIDENT_DATE]: {
+                label: 'Incident date',
+                enabled: false,
+            },
+            [DIMENSION_ID_LAST_UPDATED]: {
+                label: 'Last updated on',
+                enabled: true,
+            },
+        },
+    },
 }
 
 export const TEST_AO = {

--- a/cypress/helpers/dimensions.js
+++ b/cypress/helpers/dimensions.js
@@ -100,3 +100,6 @@ export const dimensionIsDisabled = (id) =>
         .should('be.visible')
         .and('have.css', disabledOpacity.prop, disabledOpacity.value)
         .and('have.css', disabledCursor.prop, disabledCursor.value)
+
+export const assertDimensionEnabledState = (id, expectEnabled) =>
+    expectEnabled ? dimensionIsEnabled(id) : dimensionIsDisabled(id)

--- a/cypress/integration/conditions/alphanumericConditions.cy.js
+++ b/cypress/integration/conditions/alphanumericConditions.cy.js
@@ -30,14 +30,17 @@ import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const event = ANALYTICS_PROGRAM
 const dimensionName = TEST_DIM_TEXT
-const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
 
 const setUpTable = () => {
-    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
+    selectEventProgramDimensions({
+        programName: event.programName,
+        stageName,
+        dimensions: [dimensionName],
+    })
 
     selectRelativePeriod({
-        label: periodLabel,
+        label: event.stages[stageName][DIMENSION_ID_EVENT_DATE].label,
         period: TEST_REL_PE_THIS_YEAR,
     })
 
@@ -249,7 +252,7 @@ describe('alphanumeric types', () => {
 
         it(`${type} can be used in a visualization`, () => {
             selectRelativePeriod({
-                label: periodLabel,
+                label: event.stages[stageName][DIMENSION_ID_EVENT_DATE].label,
                 period: TEST_REL_PE_THIS_YEAR,
             })
 

--- a/cypress/integration/conditions/alphanumericConditions.cy.js
+++ b/cypress/integration/conditions/alphanumericConditions.cy.js
@@ -31,16 +31,13 @@ import { EXTENDED_TIMEOUT } from '../../support/util.js'
 const event = ANALYTICS_PROGRAM
 const dimensionName = TEST_DIM_TEXT
 const stageName = 'Stage 1 - Repeatable'
+const periodLabel = event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
 const setUpTable = () => {
-    selectEventProgramDimensions({
-        programName: event.programName,
-        stageName,
-        dimensions: [dimensionName],
-    })
+    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
 
     selectRelativePeriod({
-        label: event.stages[stageName][DIMENSION_ID_EVENT_DATE].label,
+        label: periodLabel,
         period: TEST_REL_PE_THIS_YEAR,
     })
 
@@ -252,7 +249,7 @@ describe('alphanumeric types', () => {
 
         it(`${type} can be used in a visualization`, () => {
             selectRelativePeriod({
-                label: event.stages[stageName][DIMENSION_ID_EVENT_DATE].label,
+                label: periodLabel,
                 period: TEST_REL_PE_THIS_YEAR,
             })
 

--- a/cypress/integration/conditions/booleanConditions.cy.js
+++ b/cypress/integration/conditions/booleanConditions.cy.js
@@ -25,16 +25,16 @@ const currentYear = getCurrentYearStr()
 
 const event = ANALYTICS_PROGRAM
 const stageName = 'Stage 1 - Repeatable'
+const periodLabel = event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
 const setUpTable = (dimensionName) => {
     selectEventProgramDimensions({
-        programName: event.programName,
-        stageName,
+        ...event,
         dimensions: [dimensionName],
     })
 
     selectRelativePeriod({
-        label: event.stages[stageName][DIMENSION_ID_EVENT_DATE].label,
+        label: periodLabel,
         period: TEST_REL_PE_THIS_YEAR,
     })
 

--- a/cypress/integration/conditions/booleanConditions.cy.js
+++ b/cypress/integration/conditions/booleanConditions.cy.js
@@ -24,14 +24,17 @@ import { EXTENDED_TIMEOUT } from '../../support/util.js'
 const currentYear = getCurrentYearStr()
 
 const event = ANALYTICS_PROGRAM
-const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
 
 const setUpTable = (dimensionName) => {
-    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
+    selectEventProgramDimensions({
+        programName: event.programName,
+        stageName,
+        dimensions: [dimensionName],
+    })
 
     selectRelativePeriod({
-        label: periodLabel,
+        label: event.stages[stageName][DIMENSION_ID_EVENT_DATE].label,
         period: TEST_REL_PE_THIS_YEAR,
     })
 

--- a/cypress/integration/conditions/dateConditions.cy.js
+++ b/cypress/integration/conditions/dateConditions.cy.js
@@ -36,11 +36,15 @@ const previousYear = getPreviousYearStr()
 
 const event = ANALYTICS_PROGRAM
 const dimensionName = TEST_DIM_DATE
-const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
+const periodLabel = event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
 const setUpTable = () => {
-    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
+    selectEventProgramDimensions({
+        programName: event.programName,
+        stageName,
+        dimensions: [dimensionName],
+    })
 
     selectRelativePeriod({
         label: periodLabel,
@@ -298,7 +302,7 @@ describe('date types', () => {
         it(`${type} has all operators`, () => {
             cy.visit('/', EXTENDED_TIMEOUT)
 
-            selectEventProgram(ANALYTICS_PROGRAM)
+            selectEventProgram({ programName: event.programName })
             openDimension(type)
 
             cy.getBySel('button-add-condition').click()

--- a/cypress/integration/conditions/dateConditions.cy.js
+++ b/cypress/integration/conditions/dateConditions.cy.js
@@ -40,11 +40,7 @@ const stageName = 'Stage 1 - Repeatable'
 const periodLabel = event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
 const setUpTable = () => {
-    selectEventProgramDimensions({
-        programName: event.programName,
-        stageName,
-        dimensions: [dimensionName],
-    })
+    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
 
     selectRelativePeriod({
         label: periodLabel,
@@ -302,7 +298,7 @@ describe('date types', () => {
         it(`${type} has all operators`, () => {
             cy.visit('/', EXTENDED_TIMEOUT)
 
-            selectEventProgram({ programName: event.programName })
+            selectEventProgram(ANALYTICS_PROGRAM)
             openDimension(type)
 
             cy.getBySel('button-add-condition').click()

--- a/cypress/integration/conditions/numericConditions.cy.js
+++ b/cypress/integration/conditions/numericConditions.cy.js
@@ -43,8 +43,7 @@ const periodLabel = event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
 const setUpTable = (dimensionName, period) => {
     selectEventProgramDimensions({
-        programName: event.programName,
-        stageName,
+        ...event,
         dimensions: [dimensionName],
     })
 

--- a/cypress/integration/conditions/numericConditions.cy.js
+++ b/cypress/integration/conditions/numericConditions.cy.js
@@ -38,11 +38,15 @@ import { EXTENDED_TIMEOUT } from '../../support/util.js'
 const previousYear = getPreviousYearStr()
 
 const event = ANALYTICS_PROGRAM
-const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
+const periodLabel = event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
 const setUpTable = (dimensionName, period) => {
-    selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
+    selectEventProgramDimensions({
+        programName: event.programName,
+        stageName,
+        dimensions: [dimensionName],
+    })
 
     selectRelativePeriod({
         label: periodLabel,

--- a/cypress/integration/conditions/optionSetCondition.cy.js
+++ b/cypress/integration/conditions/optionSetCondition.cy.js
@@ -20,6 +20,7 @@ import {
 } from '../../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
+const stageName = 'Initial Case Report'
 describe('Option set condition', () => {
     it('Option set (program attribute) displays correctly', () => {
         const dimensionName = 'Country of birth'
@@ -27,10 +28,13 @@ describe('Option set condition', () => {
 
         cy.visit('/', EXTENDED_TIMEOUT)
 
-        selectEventProgram(HIV_PROGRAM)
+        selectEventProgram({
+            programName: HIV_PROGRAM.programName,
+            stageName: HIV_PROGRAM.stages[stageName].stageName,
+        })
 
         selectRelativePeriod({
-            label: HIV_PROGRAM[DIMENSION_ID_EVENT_DATE],
+            label: HIV_PROGRAM.stages[stageName][DIMENSION_ID_EVENT_DATE].label,
             period: TEST_REL_PE_LAST_YEAR,
         })
 
@@ -82,10 +86,13 @@ describe('Option set condition', () => {
 
         cy.visit('/', EXTENDED_TIMEOUT)
 
-        selectEventProgram(HIV_PROGRAM)
+        selectEventProgram({
+            programName: HIV_PROGRAM.programName,
+            stageName: HIV_PROGRAM.stages[stageName].stageName,
+        })
 
         selectFixedPeriod({
-            label: HIV_PROGRAM[DIMENSION_ID_EVENT_DATE],
+            label: HIV_PROGRAM.stages[stageName][DIMENSION_ID_EVENT_DATE].label,
             period: {
                 year: previousYear,
                 name: `January ${previousYear}`,

--- a/cypress/integration/conditions/orgunitCondition.cy.js
+++ b/cypress/integration/conditions/orgunitCondition.cy.js
@@ -15,8 +15,8 @@ import { expectTableToBeVisible } from '../../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const event = ANALYTICS_PROGRAM
-const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
+const periodLabel = event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
 const setUpTable = () => {
     selectEventProgram(event)

--- a/cypress/integration/conditions/unsupportedTypes.cy.js
+++ b/cypress/integration/conditions/unsupportedTypes.cy.js
@@ -16,8 +16,8 @@ import { expectTableToBeVisible } from '../../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const event = ANALYTICS_PROGRAM
-const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
+const periodLabel = event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
 const setUpTable = () => {
     selectEventProgram(event)

--- a/cypress/integration/createEvent.cy.js
+++ b/cypress/integration/createEvent.cy.js
@@ -29,7 +29,8 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
     it('creates an event line list (tracker program)', () => {
         const event = ANALYTICS_PROGRAM
         const dimensionName = TEST_DIM_TEXT
-        const periodLabel = event[DIMENSION_ID_EVENT_DATE]
+        const periodLabel =
+            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_EVENT_DATE].label
 
         // check that the time dimensions are correctly disabled and named
         dimensionIsEnabled('dimension-item-eventDate')
@@ -52,34 +53,42 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
         cy.getBySel('dimension-item-lastUpdated').contains('Last updated on')
 
         // select program
-        selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
+        selectEventProgramDimensions({
+            programName: event.programName,
+            dimensions: [dimensionName],
+        })
 
         // check that the time dimensions disabled states and names are updated correctly
 
         dimensionIsEnabled('dimension-item-eventDate')
         cy.getBySel('dimension-item-eventDate').contains(
-            event[DIMENSION_ID_EVENT_DATE]
+            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_EVENT_DATE].label
         )
 
         dimensionIsEnabled('dimension-item-enrollmentDate')
         cy.getBySel('dimension-item-enrollmentDate').contains(
-            event[DIMENSION_ID_ENROLLMENT_DATE]
+            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_ENROLLMENT_DATE]
+                .label
         )
         if (scheduleDateIsSupported) {
             dimensionIsEnabled('dimension-item-scheduledDate')
             cy.getBySel('dimension-item-scheduledDate').contains(
-                event[DIMENSION_ID_SCHEDULED_DATE]
+                event.stages['Stage 1 - Repeatable'][
+                    DIMENSION_ID_SCHEDULED_DATE
+                ].label
             )
         }
 
         dimensionIsEnabled('dimension-item-incidentDate')
         cy.getBySel('dimension-item-incidentDate').contains(
-            event[DIMENSION_ID_INCIDENT_DATE]
+            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_INCIDENT_DATE]
+                .label
         )
 
         dimensionIsEnabled('dimension-item-lastUpdated')
         cy.getBySel('dimension-item-lastUpdated').contains(
-            event[DIMENSION_ID_LAST_UPDATED]
+            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_LAST_UPDATED]
+                .label
         )
 
         selectFixedPeriod({
@@ -156,7 +165,10 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
         cy.getBySel('dimension-item-lastUpdated').contains('Last updated on')
 
         // select program
-        selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
+        selectEventProgramDimensions({
+            programName: event.programName,
+            dimensions: [dimensionName],
+        })
 
         // check that the time dimensions disabled states and names are updated correctly
 
@@ -228,7 +240,8 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
     it('moves a dimension to filter', () => {
         const event = ANALYTICS_PROGRAM
         const dimensionName = TEST_DIM_TEXT
-        const periodLabel = event[DIMENSION_ID_EVENT_DATE]
+        const periodLabel =
+            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_EVENT_DATE].label
 
         selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
 

--- a/cypress/integration/createEvent.cy.js
+++ b/cypress/integration/createEvent.cy.js
@@ -28,9 +28,10 @@ import { EXTENDED_TIMEOUT } from '../support/util.js'
 const runTests = ({ scheduleDateIsSupported } = {}) => {
     it('creates an event line list (tracker program)', () => {
         const event = ANALYTICS_PROGRAM
+        const stageName = 'Stage 1 - Repeatable'
         const dimensionName = TEST_DIM_TEXT
         const periodLabel =
-            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_EVENT_DATE].label
+            event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
         // check that the time dimensions are correctly disabled and named
         dimensionIsEnabled('dimension-item-eventDate')
@@ -62,33 +63,28 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
         dimensionIsEnabled('dimension-item-eventDate')
         cy.getBySel('dimension-item-eventDate').contains(
-            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_EVENT_DATE].label
+            event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
         )
 
         dimensionIsEnabled('dimension-item-enrollmentDate')
         cy.getBySel('dimension-item-enrollmentDate').contains(
-            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_ENROLLMENT_DATE]
-                .label
+            event.stages[stageName][DIMENSION_ID_ENROLLMENT_DATE].label
         )
         if (scheduleDateIsSupported) {
             dimensionIsEnabled('dimension-item-scheduledDate')
             cy.getBySel('dimension-item-scheduledDate').contains(
-                event.stages['Stage 1 - Repeatable'][
-                    DIMENSION_ID_SCHEDULED_DATE
-                ].label
+                event.stages[stageName][DIMENSION_ID_SCHEDULED_DATE].label
             )
         }
 
         dimensionIsEnabled('dimension-item-incidentDate')
         cy.getBySel('dimension-item-incidentDate').contains(
-            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_INCIDENT_DATE]
-                .label
+            event.stages[stageName][DIMENSION_ID_INCIDENT_DATE].label
         )
 
         dimensionIsEnabled('dimension-item-lastUpdated')
         cy.getBySel('dimension-item-lastUpdated').contains(
-            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_LAST_UPDATED]
-                .label
+            event.stages[stageName][DIMENSION_ID_LAST_UPDATED].label
         )
 
         selectFixedPeriod({
@@ -239,9 +235,10 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
     it('moves a dimension to filter', () => {
         const event = ANALYTICS_PROGRAM
+        const stageName = 'Stage 1 - Repeatable'
         const dimensionName = TEST_DIM_TEXT
         const periodLabel =
-            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_EVENT_DATE].label
+            event.stages[stageName][DIMENSION_ID_EVENT_DATE].label
 
         selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
 

--- a/cypress/integration/createEvent.cy.js
+++ b/cypress/integration/createEvent.cy.js
@@ -54,7 +54,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
         // select program
         selectEventProgramDimensions({
-            programName: event.programName,
+            ...event,
             dimensions: [dimensionName],
         })
 
@@ -166,7 +166,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
         // select program
         selectEventProgramDimensions({
-            programName: event.programName,
+            ...event,
             dimensions: [dimensionName],
         })
 

--- a/cypress/integration/download.cy.js
+++ b/cypress/integration/download.cy.js
@@ -32,7 +32,7 @@ describe('download', () => {
 
         selectEventProgram({
             programName: HIV_PROGRAM.programName,
-            stageName: HIV_PROGRAM.stageName,
+            stageName: HIV_PROGRAM.stages['Initial Case Report'].stageName,
         })
 
         clickMenubarUpdateButton()
@@ -40,7 +40,9 @@ describe('download', () => {
         downloadIsDisabled()
 
         selectRelativePeriod({
-            label: HIV_PROGRAM[DIMENSION_ID_EVENT_DATE],
+            label: HIV_PROGRAM.stages['Initial Case Report'][
+                DIMENSION_ID_EVENT_DATE
+            ].label,
             period: TEST_REL_PE_LAST_12_MONTHS,
         })
 
@@ -63,7 +65,9 @@ describe('download', () => {
         downloadIsDisabled()
 
         selectRelativePeriod({
-            label: ANALYTICS_PROGRAM[DIMENSION_ID_ENROLLMENT_DATE],
+            label: ANALYTICS_PROGRAM.stages['Stage 1 - Repeatable'][
+                DIMENSION_ID_ENROLLMENT_DATE
+            ].label,
             period: TEST_REL_PE_LAST_12_MONTHS,
         })
 

--- a/cypress/integration/download.cy.js
+++ b/cypress/integration/download.cy.js
@@ -35,7 +35,7 @@ describe('download', () => {
 
         selectEventProgram({
             programName: HIV_PROGRAM.programName,
-            stageName: HIV_PROGRAM.stages['Initial Case Report'].stageName,
+            stageName: 'Initial Case Report',
         })
 
         clickMenubarUpdateButton()
@@ -59,9 +59,7 @@ describe('download', () => {
 
         downloadIsDisabled()
 
-        selectEnrollmentProgram({
-            programName: ANALYTICS_PROGRAM.programName,
-        })
+        selectEnrollmentProgram(ANALYTICS_PROGRAM)
 
         clickMenubarUpdateButton()
 

--- a/cypress/integration/eventStatus.cy.js
+++ b/cypress/integration/eventStatus.cy.js
@@ -46,7 +46,10 @@ describe('event status', () => {
     }
 
     it(['>=39'], 'can be filtered by status SCHEDULED', () => {
-        setUpTable(event[DIMENSION_ID_SCHEDULED_DATE])
+        setUpTable(
+            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_SCHEDULED_DATE]
+                .label
+        )
 
         expectTableToMatchRows([
             'Active',
@@ -112,7 +115,10 @@ describe('event status', () => {
     })
 
     it('can be filtered by status ACTIVE', () => {
-        setUpTable(event[DIMENSION_ID_LAST_UPDATED])
+        setUpTable(
+            event.stages['Stage 1 - Repeatable'][DIMENSION_ID_LAST_UPDATED]
+                .label
+        )
 
         // TODO determine expected once 2.38analytics_dev is available
         // expectTableToMatchRows(['Active', 'Completed', 'Completed'])

--- a/cypress/integration/layoutValidation.cy.js
+++ b/cypress/integration/layoutValidation.cy.js
@@ -15,8 +15,6 @@ const openContextMenu = (id) =>
         .click()
 
 describe('layout validation', () => {
-    const eventProgram = HIV_PROGRAM
-
     it('program is required', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
 
@@ -26,7 +24,7 @@ describe('layout validation', () => {
     })
     it('stage is required', () => {
         // select a program
-        selectEventProgram({ programName: eventProgram.programName })
+        selectEventProgram({ programName: HIV_PROGRAM.programName })
 
         clickMenubarUpdateButton()
 
@@ -35,7 +33,7 @@ describe('layout validation', () => {
     it('columns is required', () => {
         // select a stage
         selectEventProgram({
-            stageName: eventProgram.stageName,
+            stageName: HIV_PROGRAM.stages['Initial Case Report'].stageName,
         })
 
         // remove org unit
@@ -71,7 +69,9 @@ describe('layout validation', () => {
     it('validation succeeds when all above are provided', () => {
         // add a time dimension to columns
         selectRelativePeriod({
-            label: eventProgram[DIMENSION_ID_EVENT_DATE],
+            label: HIV_PROGRAM.stages['Initial Case Report'][
+                DIMENSION_ID_EVENT_DATE
+            ].label,
             period: TEST_REL_PE_LAST_12_MONTHS,
         })
 

--- a/cypress/integration/layoutValidation.cy.js
+++ b/cypress/integration/layoutValidation.cy.js
@@ -15,6 +15,7 @@ const openContextMenu = (id) =>
         .click()
 
 describe('layout validation', () => {
+    const eventProgram = HIV_PROGRAM
     it('program is required', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
 
@@ -24,7 +25,7 @@ describe('layout validation', () => {
     })
     it('stage is required', () => {
         // select a program
-        selectEventProgram({ programName: HIV_PROGRAM.programName })
+        selectEventProgram({ programName: eventProgram.programName })
 
         clickMenubarUpdateButton()
 
@@ -33,7 +34,7 @@ describe('layout validation', () => {
     it('columns is required', () => {
         // select a stage
         selectEventProgram({
-            stageName: HIV_PROGRAM.stages['Initial Case Report'].stageName,
+            stageName: 'Initial Case Report',
         })
 
         // remove org unit
@@ -69,7 +70,7 @@ describe('layout validation', () => {
     it('validation succeeds when all above are provided', () => {
         // add a time dimension to columns
         selectRelativePeriod({
-            label: HIV_PROGRAM.stages['Initial Case Report'][
+            label: eventProgram.stages['Initial Case Report'][
                 DIMENSION_ID_EVENT_DATE
             ].label,
             period: TEST_REL_PE_LAST_12_MONTHS,

--- a/cypress/integration/options.cy.js
+++ b/cypress/integration/options.cy.js
@@ -93,7 +93,7 @@ describe('options', () => {
 
         //set up table
         selectEnrollmentProgramDimensions({
-            programName: ANALYTICS_PROGRAM.programName,
+            ...ANALYTICS_PROGRAM,
             dimensions: [
                 TEST_DIM_NUMBER,
                 TEST_DIM_PHONE_NUMBER,

--- a/cypress/integration/options.cy.js
+++ b/cypress/integration/options.cy.js
@@ -93,7 +93,7 @@ describe('options', () => {
 
         //set up table
         selectEnrollmentProgramDimensions({
-            ...ANALYTICS_PROGRAM,
+            programName: ANALYTICS_PROGRAM.programName,
             dimensions: [
                 TEST_DIM_NUMBER,
                 TEST_DIM_PHONE_NUMBER,
@@ -102,7 +102,9 @@ describe('options', () => {
         })
 
         selectRelativePeriod({
-            label: ANALYTICS_PROGRAM[DIMENSION_ID_ENROLLMENT_DATE],
+            label: ANALYTICS_PROGRAM.stages['Stage 1 - Repeatable'][
+                DIMENSION_ID_ENROLLMENT_DATE
+            ].label,
             period: TEST_REL_PE_THIS_YEAR,
         })
 

--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -9,28 +9,32 @@ import { HIV_PROGRAM, ANALYTICS_PROGRAM, TEST_DIM_TEXT } from '../data/index.js'
 import {
     dimensionIsDisabled,
     dimensionIsEnabled,
+    assertDimensionEnabledState,
     openDimension,
     selectEventProgram,
 } from '../helpers/dimensions.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const assertDimensionsForEventWithoutProgramSelected = (
-    scheduleDateIsSupported
-) => {
+const assertEventBasics = () => {
     dimensionIsEnabled('dimension-item-ou')
     cy.getBySel('dimension-item-ou').contains('Organisation unit')
 
     dimensionIsEnabled('dimension-item-eventStatus')
     cy.getBySel('dimension-item-eventStatus').contains('Event status')
 
-    dimensionIsDisabled('dimension-item-programStatus')
-    cy.getBySel('dimension-item-programStatus').contains('Program status')
-
     dimensionIsEnabled('dimension-item-createdBy')
     cy.getBySel('dimension-item-createdBy').contains('Created by')
 
     dimensionIsEnabled('dimension-item-lastUpdatedBy')
     cy.getBySel('dimension-item-lastUpdatedBy').contains('Last updated by')
+}
+
+const assertDimensionsForEventWithoutProgramSelected = (
+    scheduleDateIsSupported
+) => {
+    assertEventBasics()
+    dimensionIsDisabled('dimension-item-programStatus')
+    cy.getBySel('dimension-item-programStatus').contains('Program status')
 
     dimensionIsEnabled('dimension-item-eventDate')
     cy.getBySel('dimension-item-eventDate').contains('Event date')
@@ -51,55 +55,59 @@ const assertDimensionsForEventWithoutProgramSelected = (
 }
 
 const assertDimensionsForEventWithProgramSelected = (
-    event,
+    program,
+    stageName,
     scheduleDateIsSupported
 ) => {
-    dimensionIsEnabled('dimension-item-ou')
-    cy.getBySel('dimension-item-ou').contains('Organisation unit')
-
-    dimensionIsEnabled('dimension-item-eventStatus')
-    cy.getBySel('dimension-item-eventStatus').contains('Event status')
+    assertEventBasics()
 
     dimensionIsEnabled('dimension-item-programStatus')
     cy.getBySel('dimension-item-programStatus').contains('Program status')
 
-    dimensionIsEnabled('dimension-item-createdBy')
-    cy.getBySel('dimension-item-createdBy').contains('Created by')
-
-    dimensionIsEnabled('dimension-item-lastUpdatedBy')
-    cy.getBySel('dimension-item-lastUpdatedBy').contains('Last updated by')
-
-    dimensionIsEnabled('dimension-item-eventDate')
+    assertDimensionEnabledState(
+        'dimension-item-eventDate',
+        program.stages[stageName][DIMENSION_ID_EVENT_DATE].enabled
+    )
     cy.getBySel('dimension-item-eventDate').contains(
-        event[DIMENSION_ID_EVENT_DATE]
+        program.stages[stageName][DIMENSION_ID_EVENT_DATE].label
     )
 
-    dimensionIsEnabled('dimension-item-enrollmentDate')
+    assertDimensionEnabledState(
+        'dimension-item-enrollmentDate',
+        program.stages[stageName][DIMENSION_ID_ENROLLMENT_DATE].enabled
+    )
     cy.getBySel('dimension-item-enrollmentDate').contains(
-        event[DIMENSION_ID_ENROLLMENT_DATE]
+        program.stages[stageName][DIMENSION_ID_ENROLLMENT_DATE].label
     )
 
     if (scheduleDateIsSupported) {
-        dimensionIsEnabled('dimension-item-scheduledDate')
+        assertDimensionEnabledState(
+            'dimension-item-scheduledDate',
+            program.stages[stageName][DIMENSION_ID_SCHEDULED_DATE].enabled
+        )
         cy.getBySel('dimension-item-scheduledDate').contains(
-            event[DIMENSION_ID_SCHEDULED_DATE]
+            program.stages[stageName][DIMENSION_ID_SCHEDULED_DATE].label
         )
     }
 
-    dimensionIsDisabled('dimension-item-incidentDate')
+    assertDimensionEnabledState(
+        'dimension-item-incidentDate',
+        program.stages[stageName][DIMENSION_ID_INCIDENT_DATE].enabled
+    )
     cy.getBySel('dimension-item-incidentDate').contains(
-        event[DIMENSION_ID_INCIDENT_DATE]
+        program.stages[stageName][DIMENSION_ID_INCIDENT_DATE].label
     )
 
-    dimensionIsEnabled('dimension-item-lastUpdated')
+    assertDimensionEnabledState(
+        'dimension-item-lastUpdated',
+        program.stages[stageName][DIMENSION_ID_LAST_UPDATED].enabled
+    )
     cy.getBySel('dimension-item-lastUpdated').contains(
-        event[DIMENSION_ID_LAST_UPDATED]
+        program.stages[stageName][DIMENSION_ID_LAST_UPDATED].label
     )
 }
 
-const assertDimensionsForEnrollmentWithoutProgramSelected = (
-    scheduleDateIsSupported
-) => {
+const assertEnrollmentBasics = () => {
     dimensionIsEnabled('dimension-item-ou')
     cy.getBySel('dimension-item-ou').contains('Organisation unit')
 
@@ -114,6 +122,12 @@ const assertDimensionsForEnrollmentWithoutProgramSelected = (
 
     dimensionIsEnabled('dimension-item-lastUpdatedBy')
     cy.getBySel('dimension-item-lastUpdatedBy').contains('Last updated by')
+}
+
+const assertDimensionsForEnrollmentWithoutProgramSelected = (
+    scheduleDateIsSupported
+) => {
+    assertEnrollmentBasics()
 
     dimensionIsDisabled('dimension-item-eventDate')
     cy.getBySel('dimension-item-eventDate').contains('Event date')
@@ -134,67 +148,52 @@ const assertDimensionsForEnrollmentWithoutProgramSelected = (
 }
 
 const assertDimensionsForEnrollmentWithProgramSelected = (
-    enrollment,
+    program,
+    stageName,
     scheduleDateIsSupported
 ) => {
-    dimensionIsEnabled('dimension-item-ou')
-    cy.getBySel('dimension-item-ou').contains('Organisation unit')
-
-    dimensionIsDisabled('dimension-item-eventStatus')
-    cy.getBySel('dimension-item-eventStatus').contains('Event status')
-
-    dimensionIsEnabled('dimension-item-programStatus')
-    cy.getBySel('dimension-item-programStatus').contains('Program status')
-
-    dimensionIsEnabled('dimension-item-createdBy')
-    cy.getBySel('dimension-item-createdBy').contains('Created by')
-
-    dimensionIsEnabled('dimension-item-lastUpdatedBy')
-    cy.getBySel('dimension-item-lastUpdatedBy').contains('Last updated by')
+    assertEnrollmentBasics()
 
     dimensionIsDisabled('dimension-item-eventDate')
     cy.getBySel('dimension-item-eventDate').contains(
-        enrollment[DIMENSION_ID_EVENT_DATE]
+        program.stages[stageName][DIMENSION_ID_EVENT_DATE].label
     )
 
     dimensionIsEnabled('dimension-item-enrollmentDate')
     cy.getBySel('dimension-item-enrollmentDate').contains(
-        enrollment[DIMENSION_ID_ENROLLMENT_DATE]
+        program.stages[stageName][DIMENSION_ID_ENROLLMENT_DATE].label
     )
 
     if (scheduleDateIsSupported) {
         dimensionIsDisabled('dimension-item-scheduledDate')
         cy.getBySel('dimension-item-scheduledDate').contains(
-            enrollment[DIMENSION_ID_SCHEDULED_DATE]
+            program.stages[stageName][DIMENSION_ID_SCHEDULED_DATE].label
         )
     }
 
     dimensionIsDisabled('dimension-item-incidentDate')
     cy.getBySel('dimension-item-incidentDate').contains(
-        enrollment[DIMENSION_ID_INCIDENT_DATE]
+        program.stages[stageName][DIMENSION_ID_INCIDENT_DATE].label
     )
 
     dimensionIsEnabled('dimension-item-lastUpdated')
     cy.getBySel('dimension-item-lastUpdated').contains(
-        enrollment[DIMENSION_ID_LAST_UPDATED]
+        program.stages[stageName][DIMENSION_ID_LAST_UPDATED].label
     )
 }
 
 const runTests = ({ scheduleDateIsSupported } = {}) => {
     describe('event', () => {
         it('program can be selected and cleared', () => {
-            const event = HIV_PROGRAM
-            const eventDateWithoutStage = {
-                [DIMENSION_ID_EVENT_DATE]: 'Event date',
-            }
-
             cy.getBySel('accessory-sidebar').contains(
                 'Choose a program above to add program dimensions.'
             )
 
             cy.getBySel('program-clear-button').should('not.exist')
 
-            assertDimensionsForEventWithoutProgramSelected()
+            assertDimensionsForEventWithoutProgramSelected(
+                scheduleDateIsSupported
+            )
 
             // select program
 
@@ -202,7 +201,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 .contains('Choose a program')
                 .click()
 
-            cy.contains(event.programName).click()
+            cy.contains(HIV_PROGRAM.programName).click()
 
             cy.getBySel('accessory-sidebar').contains(
                 'Choose a stage above to add program dimensions.'
@@ -218,32 +217,35 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 'Clear program first to choose another'
             )
 
-            assertDimensionsForEventWithProgramSelected({
-                ...event,
-                ...eventDateWithoutStage,
-            })
+            assertDimensionsForEventWithProgramSelected(
+                HIV_PROGRAM,
+                'No stage',
+                scheduleDateIsSupported
+            )
 
             // add main and time dimensions
 
             const expectedSelectedDimensions = [
-                'Event date',
-                event[DIMENSION_ID_LAST_UPDATED],
+                HIV_PROGRAM.stages['No stage'][DIMENSION_ID_EVENT_DATE].label,
+                HIV_PROGRAM.stages['No stage'][DIMENSION_ID_LAST_UPDATED].label,
                 'Event status',
                 'Created by',
                 'Last updated by',
             ]
 
             const expectedUnselectedDimensions = [
-                event[DIMENSION_ID_ENROLLMENT_DATE],
+                HIV_PROGRAM.stages['No stage'][DIMENSION_ID_ENROLLMENT_DATE]
+                    .label,
 
                 'Program status',
             ]
 
-            if (scheduleDateIsSupported) {
-                expectedUnselectedDimensions.push(
-                    event[DIMENSION_ID_SCHEDULED_DATE]
-                )
-            }
+            // if (scheduleDateIsSupported) {
+            //     expectedUnselectedDimensions.push(
+            //         HIV_PROGRAM.stages['No stage'][DIMENSION_ID_SCHEDULED_DATE]
+            //             .label
+            //     )
+            // }
 
             expectedSelectedDimensions
                 .concat(expectedUnselectedDimensions)
@@ -272,7 +274,9 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             cy.getBySel('program-clear-button').should('not.exist')
 
-            assertDimensionsForEventWithoutProgramSelected()
+            assertDimensionsForEventWithoutProgramSelected(
+                scheduleDateIsSupported
+            )
 
             // assert dimensions in layout after program is cleared
 
@@ -292,10 +296,6 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
         })
 
         it('stage can be selected and cleared', () => {
-            const event = HIV_PROGRAM
-            const eventDateWithoutStage = {
-                [DIMENSION_ID_EVENT_DATE]: 'Event date',
-            }
             const TEST_DATA_ELEMENT = 'HIV Age at Diagnosis'
             const TEST_PROGRAM_ATTRIBUTE = 'Country of birth'
 
@@ -305,7 +305,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 .contains('Choose a program')
                 .click()
 
-            cy.contains(event.programName).click()
+            cy.contains(HIV_PROGRAM.programName).click()
 
             cy.getBySel('accessory-sidebar').contains('Stage')
 
@@ -315,7 +315,9 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             cy.getBySel('accessory-sidebar').contains('Stage').click()
 
-            cy.contains(event.stageName).click()
+            cy.contains(
+                HIV_PROGRAM.stages['Initial Case Report'].stageName
+            ).click()
 
             cy.getBySel('stage-select').find('.disabled').should('be.visible')
 
@@ -334,7 +336,11 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 .its('length')
                 .should('be.gte', 1)
 
-            assertDimensionsForEventWithProgramSelected(event)
+            assertDimensionsForEventWithProgramSelected(
+                HIV_PROGRAM,
+                'Initial Case Report',
+                scheduleDateIsSupported
+            )
 
             // add a data element
 
@@ -362,10 +368,11 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             cy.getBySel('stage-clear-button').should('not.exist')
 
-            assertDimensionsForEventWithProgramSelected({
-                ...event,
-                ...eventDateWithoutStage,
-            })
+            assertDimensionsForEventWithProgramSelected(
+                HIV_PROGRAM,
+                'No stage',
+                scheduleDateIsSupported
+            )
 
             // assert that the DE was removed but the PA remained
 
@@ -380,13 +387,11 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 .should('be.visible')
         })
         it("stage can't be cleared for event with a single stage", () => {
-            const event = ANALYTICS_PROGRAM
-
             cy.getBySel('accessory-sidebar')
                 .contains('Choose a program')
                 .click()
 
-            cy.contains(event.programName).click()
+            cy.contains(ANALYTICS_PROGRAM.programName).click()
 
             cy.getBySel('stage-select').find('.disabled').should('be.visible')
 
@@ -401,11 +406,6 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
     })
 
     describe('enrollment', () => {
-        const enrollment = {
-            ...HIV_PROGRAM,
-            [DIMENSION_ID_EVENT_DATE]: 'Event date',
-        }
-
         beforeEach(() => {
             cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
                 .contains('Input: Event')
@@ -425,15 +425,16 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             cy.getBySel('program-clear-button').should('not.exist')
 
-            assertDimensionsForEnrollmentWithoutProgramSelected()
+            assertDimensionsForEnrollmentWithoutProgramSelected(
+                scheduleDateIsSupported
+            )
 
             // select program
-
             cy.getBySel('accessory-sidebar')
                 .contains('Choose a program')
                 .click()
 
-            cy.contains(enrollment.programName).click()
+            cy.contains(HIV_PROGRAM.programName).click()
 
             cy.getBySel('program-select').find('.disabled').should('be.visible')
 
@@ -446,7 +447,11 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 .its('length')
                 .should('be.gte', 1)
 
-            assertDimensionsForEnrollmentWithProgramSelected(enrollment)
+            assertDimensionsForEnrollmentWithProgramSelected(
+                HIV_PROGRAM,
+                'No stage',
+                scheduleDateIsSupported
+            )
 
             // clear program
 
@@ -462,13 +467,15 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             cy.getBySel('program-clear-button').should('not.exist')
 
-            assertDimensionsForEnrollmentWithoutProgramSelected()
+            assertDimensionsForEnrollmentWithoutProgramSelected(
+                scheduleDateIsSupported
+            )
         })
     })
 
     describe('switching input type', () => {
-        it.only('layout is cleared when input type is changed', () => {
-            const event = ANALYTICS_PROGRAM
+        it('layout is cleared when input type is changed', () => {
+            const stageName = 'Stage 1 - Repeatable'
             const mainAndTimeDimensions = [
                 { label: 'Organisation unit', expected: true },
                 { label: 'Event status', expected: false },
@@ -476,22 +483,30 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 { label: 'Created by', expected: true },
                 { label: 'Last updated by', expected: true },
                 {
-                    label: event[DIMENSION_ID_EVENT_DATE],
+                    label: ANALYTICS_PROGRAM.stages[stageName][
+                        DIMENSION_ID_EVENT_DATE
+                    ].label,
                     labelWithoutProgram: 'Event date',
                     expected: false,
                 },
                 {
-                    label: event[DIMENSION_ID_ENROLLMENT_DATE],
+                    label: ANALYTICS_PROGRAM.stages[stageName][
+                        DIMENSION_ID_ENROLLMENT_DATE
+                    ].label,
                     labelWithoutProgram: 'Enrollment date',
                     expected: true,
                 },
                 {
-                    label: event[DIMENSION_ID_INCIDENT_DATE],
+                    label: ANALYTICS_PROGRAM.stages[stageName][
+                        DIMENSION_ID_INCIDENT_DATE
+                    ].label,
                     labelWithoutProgram: 'Incident date',
                     expected: false,
                 },
                 {
-                    label: event[DIMENSION_ID_LAST_UPDATED],
+                    label: ANALYTICS_PROGRAM.stages[stageName][
+                        DIMENSION_ID_LAST_UPDATED
+                    ].label,
                     labelWithoutProgram: 'Last updated on',
                     expected: true,
                 },
@@ -499,7 +514,9 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             if (scheduleDateIsSupported) {
                 mainAndTimeDimensions.push({
-                    label: event[DIMENSION_ID_SCHEDULED_DATE],
+                    label: ANALYTICS_PROGRAM.stages[stageName][
+                        DIMENSION_ID_SCHEDULED_DATE
+                    ].label,
                     labelWithoutProgram: 'Scheduled date',
                     expected: false,
                 })
@@ -511,7 +528,10 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 .click()
             cy.containsExact('Remove').click()
 
-            selectEventProgram(ANALYTICS_PROGRAM)
+            selectEventProgram({
+                programName: ANALYTICS_PROGRAM.programName,
+                stageName: ANALYTICS_PROGRAM.stages[stageName].stageName,
+            })
 
             //assertDimensionsForEventWithProgramSelected(event)
 
@@ -560,7 +580,9 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             // assert that dimensions are enabled/disabled correctly
 
-            assertDimensionsForEnrollmentWithoutProgramSelected()
+            assertDimensionsForEnrollmentWithoutProgramSelected(
+                scheduleDateIsSupported
+            )
         })
     })
 }

--- a/cypress/integration/repeatedEvents.cy.js
+++ b/cypress/integration/repeatedEvents.cy.js
@@ -1,5 +1,8 @@
 import { DIMENSION_ID_ENROLLMENT_DATE } from '../../src/modules/dimensionConstants.js'
-import { ANALYTICS_PROGRAM, TEST_REL_PE_LAST_YEAR } from '../data/index.js'
+import {
+    ENROLLMENT_ANALYTICS_PROGRAM,
+    TEST_REL_PE_LAST_YEAR,
+} from '../data/index.js'
 import {
     openDimension,
     selectEnrollmentProgram,
@@ -25,7 +28,7 @@ const setUpTable = ({ enrollment, dimensionName }) => {
     })
 
     selectRelativePeriod({
-        label: enrollment[DIMENSION_ID_ENROLLMENT_DATE],
+        label: enrollment[DIMENSION_ID_ENROLLMENT_DATE].label,
         period: TEST_REL_PE_LAST_YEAR,
     })
 
@@ -83,7 +86,7 @@ describe('repeated events', () => {
     })
     it('can use repetition for an enrollment program', () => {
         const dimensionName = 'Analytics - Percentage'
-        setUpTable({ enrollment: ANALYTICS_PROGRAM, dimensionName })
+        setUpTable({ enrollment: ENROLLMENT_ANALYTICS_PROGRAM, dimensionName })
 
         // initially only has 1 column and 1 row
         getTableHeaderCells().its('length').should('equal', 1)
@@ -162,7 +165,7 @@ describe('repeated events', () => {
     })
     it('repetition out of bounds returns as empty value', () => {
         const dimensionName = 'Analytics - Percentage'
-        setUpTable({ enrollment: ANALYTICS_PROGRAM, dimensionName })
+        setUpTable({ enrollment: ENROLLMENT_ANALYTICS_PROGRAM, dimensionName })
 
         // repetition 10/0 can be set successfully
         setRepetition({ dimensionName, recent: 11, oldest: 0 })
@@ -209,7 +212,7 @@ describe('repeated events', () => {
         )
     })
     it('repetition is hidden for event programs', () => {
-        selectEventProgram(ANALYTICS_PROGRAM)
+        selectEventProgram(ENROLLMENT_ANALYTICS_PROGRAM)
 
         openDimension('Analytics - Percentage')
 

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -44,7 +44,8 @@ import {
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const event = ANALYTICS_PROGRAM
-const periodLabel = event[DIMENSION_ID_EVENT_DATE]
+const periodLabel =
+    event.stages['Stage 1 - Repeatable'][DIMENSION_ID_EVENT_DATE].label
 
 const mainAndTimeDimensions = [
     { label: 'Organisation unit', value: 'PHW Phongsali' },
@@ -52,10 +53,27 @@ const mainAndTimeDimensions = [
     { label: 'Program status', value: 'Active' },
     { label: 'Created by', value: 'admin' },
     { label: 'Last updated by', value: 'admin' },
-    { label: event[DIMENSION_ID_EVENT_DATE], value: '2021-12-10' },
-    { label: event[DIMENSION_ID_ENROLLMENT_DATE], value: '2021-12-01' },
-    { label: event[DIMENSION_ID_INCIDENT_DATE], value: '2021-11-01' },
-    { label: event[DIMENSION_ID_LAST_UPDATED], value: '2022-02-18 02:20' },
+    {
+        label: event.stages['Stage 1 - Repeatable'][DIMENSION_ID_EVENT_DATE]
+            .label,
+        value: '2021-12-10',
+    },
+    {
+        label: event.stages['Stage 1 - Repeatable'][
+            DIMENSION_ID_ENROLLMENT_DATE
+        ].label,
+        value: '2021-12-01',
+    },
+    {
+        label: event.stages['Stage 1 - Repeatable'][DIMENSION_ID_INCIDENT_DATE]
+            .label,
+        value: '2021-11-01',
+    },
+    {
+        label: event.stages['Stage 1 - Repeatable'][DIMENSION_ID_LAST_UPDATED]
+            .label,
+        value: '2022-02-18 02:20',
+    },
 ]
 const programDimensions = [
     { label: TEST_DIM_AGE, value: '2021-01-01' },
@@ -86,7 +104,7 @@ const assertColumnHeaders = () => {
     const dimensionName = TEST_DIM_TEXT
 
     selectEventProgramDimensions({
-        ...event,
+        programName: event.programName,
         dimensions: [dimensionName],
     })
 
@@ -96,6 +114,7 @@ const assertColumnHeaders = () => {
 
     // add main and time dimensions
     testDimensions.forEach((label) => {
+        console.log('here')
         cy.getBySel('main-sidebar')
             .contains(label)
             .closest(`[data-test*="dimension-item"]`)
@@ -235,7 +254,9 @@ describe(['>=40'], 'table', () => {
     it('click on column header opens the dimension dialog', () => {
         // feat: https://dhis2.atlassian.net/browse/DHIS2-11192
         mainAndTimeDimensions.push({
-            label: event[DIMENSION_ID_SCHEDULED_DATE],
+            label: event.stages['Stage 1 - Repeatable'][
+                DIMENSION_ID_SCHEDULED_DATE
+            ].label,
             value: '2021-11-01',
         })
         // bug: https://dhis2.atlassian.net/browse/DHIS2-13872

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -104,7 +104,7 @@ const assertColumnHeaders = () => {
     const dimensionName = TEST_DIM_TEXT
 
     selectEventProgramDimensions({
-        programName: event.programName,
+        ...event,
         dimensions: [dimensionName],
     })
 
@@ -114,7 +114,6 @@ const assertColumnHeaders = () => {
 
     // add main and time dimensions
     testDimensions.forEach((label) => {
-        console.log('here')
         cy.getBySel('main-sidebar')
             .contains(label)
             .closest(`[data-test*="dimension-item"]`)

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -20,7 +20,6 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const event = ANALYTICS_PROGRAM
 const timeDimensions = [
     { id: DIMENSION_ID_EVENT_DATE, rowsLength: 6 },
     { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 4 },
@@ -30,8 +29,12 @@ const timeDimensions = [
 
 const assertTimeDimension = (dimension) => {
     it(`${dimension.id} shows the correct title in layout and table header`, () => {
-        selectEventProgram(event)
-        const label = event[dimension.id]
+        selectEventProgram({
+            programName: ANALYTICS_PROGRAM.programName,
+            stageName: ANALYTICS_PROGRAM.stages.stage1Repeatable.stageName,
+        })
+        const label =
+            ANALYTICS_PROGRAM.stages.stage1Repeatable[dimension.id].label
         selectRelativePeriod({ label, period: TEST_REL_PE_THIS_YEAR })
 
         clickMenubarUpdateButton()

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -31,10 +31,11 @@ const assertTimeDimension = (dimension) => {
     it(`${dimension.id} shows the correct title in layout and table header`, () => {
         selectEventProgram({
             programName: ANALYTICS_PROGRAM.programName,
-            stageName: ANALYTICS_PROGRAM.stages.stage1Repeatable.stageName,
+            stageName:
+                ANALYTICS_PROGRAM.stages['Stage 1 - Repeatable'].stageName,
         })
         const label =
-            ANALYTICS_PROGRAM.stages.stage1Repeatable[dimension.id].label
+            ANALYTICS_PROGRAM.stages['Stage 1 - Repeatable'][dimension.id].label
         selectRelativePeriod({ label, period: TEST_REL_PE_THIS_YEAR })
 
         clickMenubarUpdateButton()

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -20,6 +20,7 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
+const event = ANALYTICS_PROGRAM
 const timeDimensions = [
     { id: DIMENSION_ID_EVENT_DATE, rowsLength: 6 },
     { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 4 },
@@ -29,13 +30,8 @@ const timeDimensions = [
 
 const assertTimeDimension = (dimension) => {
     it(`${dimension.id} shows the correct title in layout and table header`, () => {
-        selectEventProgram({
-            programName: ANALYTICS_PROGRAM.programName,
-            stageName:
-                ANALYTICS_PROGRAM.stages['Stage 1 - Repeatable'].stageName,
-        })
-        const label =
-            ANALYTICS_PROGRAM.stages['Stage 1 - Repeatable'][dimension.id].label
+        selectEventProgram(event)
+        const label = event.stages['Stage 1 - Repeatable'][dimension.id].label
         selectRelativePeriod({ label, period: TEST_REL_PE_THIS_YEAR })
 
         clickMenubarUpdateButton()

--- a/cypress/integration/userDimensions.cy.js
+++ b/cypress/integration/userDimensions.cy.js
@@ -1,5 +1,8 @@
 import { DIMENSION_ID_ENROLLMENT_DATE } from '../../src/modules/dimensionConstants.js'
-import { ANALYTICS_PROGRAM, TEST_FIX_PE_DEC_LAST_YEAR } from '../data/index.js'
+import {
+    ENROLLMENT_ANALYTICS_PROGRAM,
+    TEST_FIX_PE_DEC_LAST_YEAR,
+} from '../data/index.js'
 import { selectEnrollmentProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
@@ -9,8 +12,8 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const enrollment = ANALYTICS_PROGRAM
-const periodLabel = enrollment[DIMENSION_ID_ENROLLMENT_DATE]
+const enrollment = ENROLLMENT_ANALYTICS_PROGRAM
+const periodLabel = enrollment[DIMENSION_ID_ENROLLMENT_DATE].label
 const TEST_DIMENSIONS = ['Created by', 'Last updated by']
 
 describe('user dimensions', () => {

--- a/cypress/integration/yourDimensions.cy.js
+++ b/cypress/integration/yourDimensions.cy.js
@@ -17,6 +17,10 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
+const event = HIV_PROGRAM
+const periodLabel =
+    event.stages['Initial Case Report'][DIMENSION_ID_EVENT_DATE].label
+
 describe('event', () => {
     it('Your dimensions can be used and filtered by', () => {
         const dimensionName = 'Organisation Unit Types'
@@ -25,14 +29,12 @@ describe('event', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
 
         selectEventProgram({
-            programName: HIV_PROGRAM.programName,
-            stageName: HIV_PROGRAM.stages['Initial Case Report'].stageName,
+            ...event,
+            stageName: 'Initial Case Report',
         })
 
         selectRelativePeriod({
-            label: HIV_PROGRAM.stages['Initial Case Report'][
-                DIMENSION_ID_EVENT_DATE
-            ].label,
+            label: periodLabel,
             period: TEST_REL_PE_LAST_YEAR,
         })
 

--- a/cypress/integration/yourDimensions.cy.js
+++ b/cypress/integration/yourDimensions.cy.js
@@ -17,9 +17,6 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const event = HIV_PROGRAM
-const periodLabel = event[DIMENSION_ID_EVENT_DATE]
-
 describe('event', () => {
     it('Your dimensions can be used and filtered by', () => {
         const dimensionName = 'Organisation Unit Types'
@@ -27,10 +24,15 @@ describe('event', () => {
 
         cy.visit('/', EXTENDED_TIMEOUT)
 
-        selectEventProgram(event)
+        selectEventProgram({
+            programName: HIV_PROGRAM.programName,
+            stageName: HIV_PROGRAM.stages['Initial Case Report'].stageName,
+        })
 
         selectRelativePeriod({
-            label: periodLabel,
+            label: HIV_PROGRAM.stages['Initial Case Report'][
+                DIMENSION_ID_EVENT_DATE
+            ].label,
             period: TEST_REL_PE_LAST_YEAR,
         })
 


### PR DESCRIPTION
The impetus for this refactor was to enable all the tests in programDimensions.cy.js. (there was a `.only` on one of the tests in that file). In order to get all the tests to work, the enabled/disabled state of the time dimensions for the given program/stage was needed. This triggered a restructure of ANALYTICS_PROGRAM and HIV_PROGRAM. This change caused cascading changes in other files that use those objects.

In the future we could put the other programs in use in our tests into this file.

An additional refactor could be to create functions for getting the time dimension labels and enabled state so that if the object structure changes again, it won't cause a cascading effect like this.
e.g `event.stages[stageName][DIMENSION_ID_EVENT_DATE].label` becomes `getExpectedTimeDimensionLabel` 

