### PR TITLE
fix: pass stage for plain data source download (DHIS2-14082)

### DIFF
--- a/src/components/DownloadMenu/useDownloadMenu.js
+++ b/src/components/DownloadMenu/useDownloadMenu.js
@@ -83,6 +83,7 @@ const useDownloadMenu = (relativePeriodDate) => {
                         // Perhaps the 2nd arg `passFilterAsDimension` should be false for the advanced submenu?
                         .fromVisualization(adaptedVisualization, true)
                         .withProgram(current.program.id)
+                        .withStage(current.programStage?.id)
                         .withOutputType(current.outputType)
                         .withPath(path)
                         .withFormat(format)


### PR DESCRIPTION
Implements [DHIS2-14082](https://dhis2.atlassian.net/browse/DHIS2-14082)

Makes sure `programStage` is passed when defined to plain data source download.