### PR TITLE
fix: error when saving translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.3.3",
+        "@dhis2/analytics": "^24.3.5",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^8.4.1",
         "@dnd-kit/core": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.3.5",
+        "@dhis2/analytics": "^24.3.6",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^8.4.1",
         "@dnd-kit/core": "^5.0.3",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -129,11 +129,12 @@ const App = () => {
         systemSettings[SYSTEM_SETTINGS_DIGIT_GROUP_SEPARATOR]
 
     const onFileMenuAction = () => {
-        setAboutAOUnitRenderId(aboutAOUnitRenderId + 1)
+        showDetailsPanel && setAboutAOUnitRenderId(aboutAOUnitRenderId + 1)
     }
 
     const onInterpretationUpdate = () => {
-        setInterpretationsUnitRenderId(interpretationsUnitRenderId + 1)
+        showDetailsPanel &&
+            setInterpretationsUnitRenderId(interpretationsUnitRenderId + 1)
     }
 
     const parseLocation = (location) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,10 +2009,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24.3.3":
-  version "24.3.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.3.3.tgz#fdbfdf4890414c0a99efd12c3250227caedc3655"
-  integrity sha512-vMqOdaMilgkPvUl8xMjZRY6zly4AHr2xwKBH0yStoHhMlC3hTVkDxx/BmQ1RwyQPWMN++7HqKYF6dU+ri/XJSw==
+"@dhis2/analytics@^24.3.5":
+  version "24.3.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.3.5.tgz#85797ca02668d8697a485c17b79e048e3027f1a4"
+  integrity sha512-9stPmKkh64zjgiSVifrBcHBRmyVHEeNnwjGo6qU/kr8OIep3IOqAKYUFz+eM4+eZFaZSSXrJ6UkQ1FmZJXqq7w==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     classnames "^2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,10 +2009,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24.3.5":
-  version "24.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.3.5.tgz#85797ca02668d8697a485c17b79e048e3027f1a4"
-  integrity sha512-9stPmKkh64zjgiSVifrBcHBRmyVHEeNnwjGo6qU/kr8OIep3IOqAKYUFz+eM4+eZFaZSSXrJ6UkQ1FmZJXqq7w==
+"@dhis2/analytics@^24.3.6":
+  version "24.3.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.3.6.tgz#19d5ec2a62d1914236c9620c18d29449b38942a3"
+  integrity sha512-fPJB4crp4U9t7GJ1kpuNoPyaZoJq8+QdFO6vMhv+CpSEFJjdBNnlF6n26hfjbBwuXzC+QGB0kqo0ihjLStj9xg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     classnames "^2.3.1"


### PR DESCRIPTION
Implements [DHIS2-14145](https://dhis2.atlassian.net/browse/DHIS2-14145)

**Requires https://github.com/dhis2/analytics/pull/1379**

---

### Key features

1. fix the error on translations save
2. avoid unnecessary App re-rendering

---

### Description

Because the `renderId` is in the App state, every time it's updated the App re-renders.
If the right side panel is closed, there is no need to update the `renderId`.
This avoids an unnecessary re-render of the App component on actions in the FileMenu.

---

### Screenshots

The canceled request to `i18n`after saving the translations is gone:

<img width="489" alt="Screenshot 2022-11-17 at 11 59 34" src="https://user-images.githubusercontent.com/150978/202428988-a9cacdda-8121-4798-8079-f8a4494fab3c.png">

