### PR TITLE
test: improve interpretations tests

### DIFF
--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -1,11 +1,23 @@
-import { TEST_AO } from '../data/index.js'
-import { clearTextarea, typeTextarea } from '../helpers/common.js'
+import {
+    DIMENSION_ID_EVENT_DATE,
+} from '../../src/modules/dimensionConstants.js'
+import {
+    ANALYTICS_PROGRAM,
+    TEST_DIM_TEXT,
+    TEST_FIX_PE_DEC_LAST_YEAR,
+} from '../data/index.js'
+import { clearTextarea, typeInput, typeTextarea } from '../helpers/common.js'
+import { selectEventProgramDimensions } from '../helpers/dimensions.js'
 import {
     expectInterpretationsButtonToBeEnabled,
     expectInterpretationFormToBeVisible,
     expectInterpretationThreadToBeVisible,
 } from '../helpers/interpretations.js'
-import { clickMenubarInterpretationsButton } from '../helpers/menubar.js'
+import {
+    clickMenubarInterpretationsButton,
+    clickMenubarUpdateButton
+} from '../helpers/menubar.js'
+import { selectFixedPeriod } from '../helpers/period.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const TEST_CANCEL_LABEL = 'Cancel'
@@ -17,9 +29,35 @@ const TEST_INTERPRETATION_TEXT_EDITED = `${TEST_INTERPRETATION_TEXT} (edited)`
 const TEST_INTERPRETATION_COMMENT_TEXT = 'Reply to test interpretation'
 
 describe('interpretations', () => {
-    it('the interpretations panel can be toggled when clicking the button in the toolbar', () => {
-        cy.visit(`#/${TEST_AO.id}`, EXTENDED_TIMEOUT)
+   before(() => {
+       cy.visit('/', EXTENDED_TIMEOUT)
+       cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
 
+        const event = ANALYTICS_PROGRAM
+        const dimensionName = TEST_DIM_TEXT
+        const periodLabel = event[DIMENSION_ID_EVENT_DATE]
+
+        selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
+
+        selectFixedPeriod({
+            label: periodLabel,
+            period: TEST_FIX_PE_DEC_LAST_YEAR,
+        })
+
+        clickMenubarUpdateButton()
+
+        // TODO extract into a helper function?
+        cy.getBySel('menubar').contains('File').click()
+
+        cy.getBySel('file-menu-container').contains('Save').click()
+
+        const AO_NAME = `INTERPRETATIONS TEST ${new Date().toLocaleString()}`
+        typeInput('file-menu-saveas-modal-name', AO_NAME)
+
+        cy.getBySel('file-menu-saveas-modal-save').click()
+    })
+
+    it('the interpretations panel can be toggled when clicking the button in the toolbar', () => {
         expectInterpretationsButtonToBeEnabled()
 
         clickMenubarInterpretationsButton()
@@ -149,5 +187,12 @@ describe('interpretations', () => {
             'not.contain',
             TEST_INTERPRETATION_TEXT_EDITED
         )
+    })
+
+    after(() => {
+        // TODO delete AO
+        cy.getBySel('menubar').contains('File').click()
+
+        cy.getBySel('file-menu-container').contains('Delete').click()
     })
 })

--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -199,9 +199,10 @@ describe('interpretations', () => {
     })
 
     after(() => {
-        // TODO delete AO
         cy.getBySel('menubar').contains('File').click()
 
         cy.getBySel('file-menu-container').contains('Delete').click()
+
+        cy.getBySel('file-menu-delete-modal-delete').contains('Delete').click()
     })
 })

--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -1,6 +1,4 @@
-import {
-    DIMENSION_ID_EVENT_DATE,
-} from '../../src/modules/dimensionConstants.js'
+import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js'
 import {
     ANALYTICS_PROGRAM,
     TEST_DIM_TEXT,
@@ -15,7 +13,7 @@ import {
 } from '../helpers/interpretations.js'
 import {
     clickMenubarInterpretationsButton,
-    clickMenubarUpdateButton
+    clickMenubarUpdateButton,
 } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
@@ -29,32 +27,43 @@ const TEST_INTERPRETATION_TEXT_EDITED = `${TEST_INTERPRETATION_TEXT} (edited)`
 const TEST_INTERPRETATION_COMMENT_TEXT = 'Reply to test interpretation'
 
 describe('interpretations', () => {
-   before(() => {
-       cy.visit('/', EXTENDED_TIMEOUT)
-       cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
+    // Use a flag to ensure the visualisation is not created multiple times
+    let created = false
+    // Use the `beforeEach` hook to ensure the visualisation is being created after the login takes place
+    beforeEach(() => {
+        if (!created) {
+            cy.visit('/', EXTENDED_TIMEOUT)
+            cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
 
-        const event = ANALYTICS_PROGRAM
-        const dimensionName = TEST_DIM_TEXT
-        const periodLabel = event[DIMENSION_ID_EVENT_DATE]
+            const event = ANALYTICS_PROGRAM
+            const dimensionName = TEST_DIM_TEXT
+            const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 
-        selectEventProgramDimensions({ ...event, dimensions: [dimensionName] })
+            selectEventProgramDimensions({
+                ...event,
+                dimensions: [dimensionName],
+            })
 
-        selectFixedPeriod({
-            label: periodLabel,
-            period: TEST_FIX_PE_DEC_LAST_YEAR,
-        })
+            selectFixedPeriod({
+                label: periodLabel,
+                period: TEST_FIX_PE_DEC_LAST_YEAR,
+            })
 
-        clickMenubarUpdateButton()
+            clickMenubarUpdateButton()
 
-        // TODO extract into a helper function?
-        cy.getBySel('menubar').contains('File').click()
+            // TODO extract into a helper function?
+            cy.getBySel('menubar').contains('File').click()
 
-        cy.getBySel('file-menu-container').contains('Save').click()
+            cy.getBySel('file-menu-container').contains('Save').click()
 
-        const AO_NAME = `INTERPRETATIONS TEST ${new Date().toLocaleString()}`
-        typeInput('file-menu-saveas-modal-name', AO_NAME)
+            const AO_NAME = `INTERPRETATIONS TEST ${new Date().toLocaleString()}`
+            typeInput('file-menu-saveas-modal-name', AO_NAME)
 
-        cy.getBySel('file-menu-saveas-modal-save').click()
+            cy.getBySel('file-menu-saveas-modal-save').click()
+
+            // Toggle to `true` to prevent re-creation
+            created = true
+        }
     })
 
     it('the interpretations panel can be toggled when clicking the button in the toolbar', () => {


### PR DESCRIPTION
### Key features

1. improve interpretations tests to avoid repeated failures

---

### Description

Because the old implementation used an existing AO, any time there is a problem on a test run (network, timeouts, etc...) and the tests don't complete, the AO is left in a "dirty" state until the DB is reset or the interpretations are manually removed from the AO.
Instead, before each test run of the interpretations tests, a new AO is created, used and deleted once the tests are completed.
