### PR TITLE
fix: clear repetition when changing input type (DHIS2-14219)

### DIFF
--- a/cypress/integration/repeatedEvents.cy.js
+++ b/cypress/integration/repeatedEvents.cy.js
@@ -1,10 +1,14 @@
-import { DIMENSION_ID_ENROLLMENT_DATE } from '../../src/modules/dimensionConstants.js'
+import {
+    DIMENSION_ID_ENROLLMENT_DATE,
+    DIMENSION_ID_EVENT_DATE,
+} from '../../src/modules/dimensionConstants.js'
 import { E2E_PROGRAM, TEST_REL_PE_LAST_YEAR } from '../data/index.js'
 import {
     openDimension,
     selectEnrollmentProgram,
     selectEnrollmentProgramDimensions,
     selectEventWithProgram,
+    selectEventWithProgramDimensions,
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
@@ -143,6 +147,24 @@ describe('repeated events', () => {
             3,
             'E2E - Percentage - Stage 1 - Repeatable (most recent)'
         )
+
+        // switch back to event, check that repetition is cleared
+        selectEventWithProgramDimensions({
+            ...E2E_PROGRAM,
+            dimensions: [dimensionName],
+        })
+
+        selectRelativePeriod({
+            label: E2E_PROGRAM[DIMENSION_ID_EVENT_DATE],
+            period: TEST_REL_PE_LAST_YEAR,
+        })
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        // no repetition in header
+        expectHeaderToContainExact(0, dimensionName)
     })
     it('repetition out of bounds returns as empty value', () => {
         const dimensionName = 'E2E - Percentage'

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -32,6 +32,7 @@ import {
     SET_UI_CONDITIONS,
     SET_UI_REPETITION,
     REMOVE_UI_REPETITION,
+    CLEAR_UI_REPETITION,
     SET_UI_INPUT,
     UPDATE_UI_PROGRAM_ID,
     UPDATE_UI_PROGRAM_STAGE_ID,
@@ -136,6 +137,7 @@ export const tClearUiProgramStageDimensions =
 export const tSetUiInput = (value) => (dispatch) => {
     dispatch(acClearUiProgram())
     dispatch(tClearUiProgramRelatedDimensions(value.type))
+    dispatch(acClearUiRepetition())
     dispatch(acSetUiInput(value, getDefaultTimeDimensionsMetadata()))
 }
 
@@ -255,4 +257,8 @@ export const acSetUiRepetition = (value) => ({
 export const acRemoveUiRepetition = (value) => ({
     type: REMOVE_UI_REPETITION,
     value,
+})
+
+export const acClearUiRepetition = () => ({
+    type: CLEAR_UI_REPETITION,
 })

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -50,6 +50,7 @@ export const ADD_UI_PARENT_GRAPH_MAP = 'ADD_UI_PARENT_GRAPH_MAP'
 export const SET_UI_CONDITIONS = 'SET_UI_CONDITIONS'
 export const SET_UI_REPETITION = 'SET_UI_REPETITION'
 export const REMOVE_UI_REPETITION = 'REMOVE_UI_REPETITION'
+export const CLEAR_UI_REPETITION = 'CLEAR_UI_REPETITION'
 
 const DEFAULT_CONDITIONS = {}
 const DEFAULT_DIMENSION_CONDITIONS = {}
@@ -335,6 +336,12 @@ export default (state = EMPTY_UI, action) => {
             return {
                 ...state,
                 repetitionByDimension,
+            }
+        }
+        case CLEAR_UI_REPETITION: {
+            return {
+                ...state,
+                repetitionByDimension: EMPTY_UI.repetitionByDimension,
             }
         }
         default:


### PR DESCRIPTION
Implements [DHIS2-14219](https://dhis2.atlassian.net/browse/DHIS2-14219)

Clears the ui.repetition config when switching input. I did not want to clear it as part of clearing the program in case that becomes an issue when we support cross-program selection.