### PR TITLE
fix: use more specific selectors in cypress test to avoid flakiness

### DIFF
--- a/cypress/helpers/period.js
+++ b/cypress/helpers/period.js
@@ -26,7 +26,10 @@ const selectRelativePeriod = ({ label, period }) => {
             .containsExact(period.type)
             .click()
     }
-    cy.contains(period.name).dblclick()
+    cy.getBySelLike('period-dimension-transfer-sourceoptions')
+            .contains(period.name)
+            .dblclick()
+
     cy.getBySel('period-dimension-modal-action-confirm').click()
 }
 

--- a/cypress/integration/fileMenu.cy.js
+++ b/cypress/integration/fileMenu.cy.js
@@ -52,7 +52,10 @@ const assertDownloadIsDisabled = () =>
         .contains('Download')
         .should('have.attr', 'disabled')
 
-const closeFileMenu = () => cy.get('body').click(0, 0)
+const closeFileMenu = () => {
+    cy.getBySel('file-menu-toggle-layer').click()
+    cy.getBySel('file-menu-container').should('not.exist')
+}
 
 const saveVisualization = (name) => {
     cy.getBySel('menubar').contains('File').click()


### PR DESCRIPTION
dateConditions:
- there was a vis that had "Last 12 months" in the name, that was listed in the start screen behind the period selector dialog. Cypress was choosing that rather than the period option

fileMenu:
- on CI, the File menu was positioned at 0,0 in the viewport, so clicking on 0,0 didn't close the file menu. Instead, click on the cover layer to close the menu, and confirm that it's gone. I'm not sure why the File menu was positioned incorrectly.