### PR TITLE
chore: always use headless Chrome for proper video support

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,23 +93,25 @@ jobs:
             - name: Run e2e tests
               uses: cypress-io/github-action@v4
               with:
-                  record: true
-                  video: true
-                  parallel: true
-                  group: e2e-chrome-parallel-${{ matrix.versions }}
-                  browser: chrome
                   start: yarn d2-app-scripts start
                   wait-on: http://localhost:3000
                   wait-on-timeout: 300
+                  record: true
+                  video: true
+                  parallel: true
+                  browser: chrome
+                  headless: true
+                  group: e2e-chrome-parallel-${{ matrix.versions }}
               env:
                   CI: true
+                  BROWSER: none
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CYPRESS_dhis2BaseUrl: ${{ steps.instance-url.outputs.url }}
                   CYPRESS_dhis2InstanceVersion: ${{matrix.versions}}
                   CYPRESS_dhis2Username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
                   CYPRESS_dhis2Password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
                   CYPRESS_networkMode: live
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     compute-dev-version:
         if: "!github.event.push.repository.fork && (github.event.pull_request.draft == false || github.action == 'workflow_dispatch')"
@@ -154,16 +156,18 @@ jobs:
                   record: true
                   video: true
                   parallel: true
+                  browser: chrome
+                  headless: true
                   group: e2e-chrome-parallel-dev
               env:
                   BROWSER: none
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
                   CYPRESS_dhis2BaseUrl: https://test.e2e.dhis2.org/analytics-dev
+                  CYPRESS_dhis2InstanceVersion: ${{ needs.compute-dev-version.outputs.version }}
                   CYPRESS_dhis2Username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
                   CYPRESS_dhis2Password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
-                  CYPRESS_dhis2InstanceVersion: ${{ needs.compute-dev-version.outputs.version }}
                   CYPRESS_networkMode: live
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     e2e-tests-success:
         needs: e2e-prod


### PR DESCRIPTION
### Key features

1. solve broken video recording on dev tests

---

### Description

Electron browser seem to have issues with recording videos of test failures.
Chrome on the other hand works fine.
Always use Chrome for running tests in both production and dev test groups.