### PR TITLE
chore: force chrome browser for Cypress nightly tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -77,9 +77,9 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 18.x
 
             - name: Compute prod instance url
               id: instance-url
@@ -91,10 +91,10 @@ jobs:
                   version: ${{ matrix.versions }}
 
             - name: Run e2e tests
-              uses: cypress-io/github-action@v4
+              uses: cypress-io/github-action@v5
               with:
                   start: yarn d2-app-scripts start
-                  wait-on: http://localhost:3000
+                  wait-on: 'http://localhost:3000'
                   wait-on-timeout: 300
                   record: true
                   parallel: true
@@ -140,14 +140,14 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 18.x
 
             - name: Run e2e tests
-              uses: cypress-io/github-action@v2
+              uses: cypress-io/github-action@v5
               with:
                   start: yarn d2-app-scripts start
                   wait-on: 'http://localhost:3000'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -97,7 +97,6 @@ jobs:
                   wait-on: http://localhost:3000
                   wait-on-timeout: 300
                   record: true
-                  video: true
                   parallel: true
                   browser: chrome
                   headless: true
@@ -154,7 +153,6 @@ jobs:
                   wait-on: 'http://localhost:3000'
                   wait-on-timeout: 300
                   record: true
-                  video: true
                   parallel: true
                   browser: chrome
                   headless: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -99,7 +99,6 @@ jobs:
                   record: true
                   parallel: true
                   browser: chrome
-                  headless: true
                   group: e2e-chrome-parallel-${{ matrix.versions }}
               env:
                   CI: true
@@ -155,7 +154,6 @@ jobs:
                   record: true
                   parallel: true
                   browser: chrome
-                  headless: true
                   group: e2e-chrome-parallel-dev
               env:
                   BROWSER: none

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,14 +37,14 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 18.x
 
             - name: Run e2e tests
-              uses: cypress-io/github-action@v2
+              uses: cypress-io/github-action@v5
               with:
                   start: yarn d2-app-scripts start
                   wait-on: 'http://localhost:3000'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,6 @@ jobs:
                   record: true
                   parallel: true
                   browser: chrome
-                  headless: true
               env:
                   BROWSER: none
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,6 @@ jobs:
                   wait-on: 'http://localhost:3000'
                   wait-on-timeout: 300
                   record: true
-                  video: true
                   parallel: true
                   browser: chrome
                   headless: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,8 +50,10 @@ jobs:
                   wait-on: 'http://localhost:3000'
                   wait-on-timeout: 300
                   record: true
-                  parallel: true
                   video: true
+                  parallel: true
+                  browser: chrome
+                  headless: true
               env:
                   BROWSER: none
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Key features

1. use Chrome when running Cypress tests for proper video support

---

### Description

Electron video recording has problems.
Use Chrome instead for all test runs.

Adjusted the workflow config to remove warnings:

1. Bumped versions of the actions used in the workflow:
- actions/checkout -> v3
- actions/setup-node -> v3
- cypress-io/github-action -> v5

2. Bumped version of node to **18.x**.

3. Removed `headless` and `video` parameter that are not part of the Cypress Github action config.

4. Single quotes around the URL for `wait-on` added everywhere for consistency and to follow the examples in the action documentation.