### PR TITLE
fix: cypress - wait for options request to complete

### DIFF
--- a/cypress/helpers/transfer.js
+++ b/cypress/helpers/transfer.js
@@ -3,9 +3,7 @@ import { typeInput } from './common.js'
 
 export const searchAndSelectInTransfer = (name) => {
     const searchRegex = new RegExp(encodeURI(name))
-    cy.intercept('GET', searchRegex).as(
-        'fetchOptions'
-    )
+    cy.intercept('GET', searchRegex).as('fetchOptions')
     typeInput('option-set-left-header-filter-input-field', name)
     cy.wait('@fetchOptions').its('response.statusCode').should('eq', 200)
 

--- a/cypress/helpers/transfer.js
+++ b/cypress/helpers/transfer.js
@@ -2,7 +2,12 @@ import { EXTENDED_TIMEOUT } from '../support/util.js'
 import { typeInput } from './common.js'
 
 export const searchAndSelectInTransfer = (name) => {
+    const searchRegex = new RegExp(encodeURI(name))
+    cy.intercept('GET', searchRegex).as(
+        'fetchOptions'
+    )
     typeInput('option-set-left-header-filter-input-field', name)
+    cy.wait('@fetchOptions').its('response.statusCode').should('eq', 200)
 
     cy.getBySel('option-set-left-header-filter-input-field')
         .find('input')


### PR DESCRIPTION
This test keeps breaking.

Ensure that the options request is complete before trying to select from the source list