### PR TITLE
fix: filtering by stage resets the search and type filters (DHIS2-14288)

### DIFF
--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsFilter.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsFilter.js
@@ -17,7 +17,7 @@ import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
 import { sGetUiInputType } from '../../../reducers/ui.js'
 import { DimensionIcon } from '../DimensionItem/DimensionIcon.js'
 import styles from './ProgramDimensionsFilter.module.css'
-import { StageSelect } from './StageSelect.js'
+import { StageFilter } from './StageFilter.js'
 
 const SingleSelectOption = ({ label, active, value, icon, onClick }) => (
     <div
@@ -44,88 +44,82 @@ const ProgramDimensionsFilter = ({
     setSearchTerm,
     dimensionType,
     setDimensionType,
-}) => {
-    const inputType = useSelector(sGetUiInputType)
-    const showStageSelect =
-        inputType === OUTPUT_TYPE_ENROLLMENT &&
-        dimensionType === DIMENSION_TYPE_DATA_ELEMENT
-
-    return (
-        <div className={styles.container}>
-            <Input
-                value={searchTerm}
-                onChange={({ value }) => setSearchTerm(value)}
-                dense
-                type={'search'}
-                placeholder={i18n.t('Search in program')}
+    stageFilter,
+    setStageFilter,
+}) => (
+    <div className={styles.container}>
+        <Input
+            value={searchTerm}
+            onChange={({ value }) => setSearchTerm(value)}
+            dense
+            type={'search'}
+            placeholder={i18n.t('Search in program')}
+        />
+        <SingleSelect
+            prefix={i18n.t('Type')}
+            selected={dimensionType}
+            onChange={({ selected }) => setDimensionType(selected)}
+            dense
+        >
+            <SingleSelectOption
+                label={i18n.t('All types')}
+                value={DIMENSION_TYPE_ALL}
             />
-            <SingleSelect
-                prefix={i18n.t('Type')}
-                selected={dimensionType}
-                onChange={({ selected }) => setDimensionType(selected)}
-                dense
-            >
-                <SingleSelectOption
-                    label={i18n.t('All types')}
-                    value={DIMENSION_TYPE_ALL}
-                />
-                <Divider />
-                <SingleSelectOption
-                    label={i18n.t('Data element')}
-                    value={DIMENSION_TYPE_DATA_ELEMENT}
-                    icon={
-                        <DimensionIcon
-                            dimensionType={DIMENSION_TYPE_DATA_ELEMENT}
-                        />
-                    }
-                />
-                {program.programType === PROGRAM_TYPE_WITH_REGISTRATION && (
-                    <SingleSelectOption
-                        label={i18n.t('Program attribute')}
-                        value={DIMENSION_TYPE_PROGRAM_ATTRIBUTE}
-                        icon={
-                            <DimensionIcon
-                                dimensionType={DIMENSION_TYPE_PROGRAM_ATTRIBUTE}
-                            />
-                        }
+            <Divider />
+            <SingleSelectOption
+                label={i18n.t('Data element')}
+                value={DIMENSION_TYPE_DATA_ELEMENT}
+                icon={
+                    <DimensionIcon
+                        dimensionType={DIMENSION_TYPE_DATA_ELEMENT}
                     />
-                )}
+                }
+            />
+            {program.programType === PROGRAM_TYPE_WITH_REGISTRATION && (
                 <SingleSelectOption
-                    label={i18n.t('Program indicator')}
-                    value={DIMENSION_TYPE_PROGRAM_INDICATOR}
+                    label={i18n.t('Program attribute')}
+                    value={DIMENSION_TYPE_PROGRAM_ATTRIBUTE}
                     icon={
                         <DimensionIcon
-                            dimensionType={DIMENSION_TYPE_PROGRAM_INDICATOR}
+                            dimensionType={DIMENSION_TYPE_PROGRAM_ATTRIBUTE}
                         />
                     }
                 />
-                <SingleSelectOption
-                    label={i18n.t('Category')}
-                    value={DIMENSION_TYPE_CATEGORY}
-                    icon={
-                        <DimensionIcon
-                            dimensionType={DIMENSION_TYPE_CATEGORY}
-                        />
-                    }
-                />
-                <SingleSelectOption
-                    label={i18n.t('Category option group set')}
-                    value={DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET}
-                    icon={
-                        <DimensionIcon
-                            dimensionType={
-                                DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET
-                            }
-                        />
-                    }
-                />
-            </SingleSelect>
-            {showStageSelect && (
-                <StageSelect stages={program.programStages} optional />
             )}
-        </div>
-    )
-}
+            <SingleSelectOption
+                label={i18n.t('Program indicator')}
+                value={DIMENSION_TYPE_PROGRAM_INDICATOR}
+                icon={
+                    <DimensionIcon
+                        dimensionType={DIMENSION_TYPE_PROGRAM_INDICATOR}
+                    />
+                }
+            />
+            <SingleSelectOption
+                label={i18n.t('Category')}
+                value={DIMENSION_TYPE_CATEGORY}
+                icon={<DimensionIcon dimensionType={DIMENSION_TYPE_CATEGORY} />}
+            />
+            <SingleSelectOption
+                label={i18n.t('Category option group set')}
+                value={DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET}
+                icon={
+                    <DimensionIcon
+                        dimensionType={DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET}
+                    />
+                }
+            />
+        </SingleSelect>
+        {useSelector(sGetUiInputType) === OUTPUT_TYPE_ENROLLMENT &&
+            dimensionType === DIMENSION_TYPE_DATA_ELEMENT && (
+                <StageFilter
+                    stages={program.programStages}
+                    selected={stageFilter}
+                    setSelected={setStageFilter}
+                />
+            )}
+    </div>
+)
 
 ProgramDimensionsFilter.propTypes = {
     program: PropTypes.object.isRequired,
@@ -133,6 +127,8 @@ ProgramDimensionsFilter.propTypes = {
     searchTerm: PropTypes.string,
     setDimensionType: PropTypes.func,
     setSearchTerm: PropTypes.func,
+    setStageFilter: PropTypes.func,
+    stageFilter: PropTypes.string,
 }
 
 export { ProgramDimensionsFilter }

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -1,4 +1,8 @@
-import { useCachedDataQuery, DIMENSION_TYPE_ALL } from '@dhis2/analytics'
+import {
+    useCachedDataQuery,
+    DIMENSION_TYPE_ALL,
+    DIMENSION_TYPE_DATA_ELEMENT,
+} from '@dhis2/analytics'
 import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { NoticeBox, CenteredContent, CircularLoader } from '@dhis2/ui'
@@ -57,6 +61,7 @@ const ProgramDimensionsPanel = ({ visible }) => {
         lazy: true,
     })
     const [searchTerm, setSearchTerm] = useState('')
+    const [stageFilter, setStageFilter] = useState()
     const [dimensionType, setDimensionType] = useState(DIMENSION_TYPE_ALL)
     const debouncedSearchTerm = useDebounce(searchTerm)
     const filteredPrograms = data?.programs.programs.filter(
@@ -101,6 +106,7 @@ const ProgramDimensionsPanel = ({ visible }) => {
     useEffect(() => {
         setSearchTerm('')
         setDimensionType(DIMENSION_TYPE_ALL)
+        setStageFilter()
     }, [inputType, selectedProgramId, selectedStageId])
 
     if (!visible || !called) {
@@ -150,6 +156,8 @@ const ProgramDimensionsPanel = ({ visible }) => {
                         setSearchTerm={setSearchTerm}
                         dimensionType={dimensionType}
                         setDimensionType={setDimensionType}
+                        stageFilter={stageFilter}
+                        setStageFilter={setStageFilter}
                     />
                 ) : (
                     <div className={styles.helptext}>
@@ -170,7 +178,14 @@ const ProgramDimensionsPanel = ({ visible }) => {
                     program={selectedProgram}
                     dimensionType={dimensionType}
                     searchTerm={debouncedSearchTerm}
-                    stageId={selectedStageId}
+                    stageId={
+                        inputType === OUTPUT_TYPE_ENROLLMENT &&
+                        dimensionType === DIMENSION_TYPE_DATA_ELEMENT
+                            ? stageFilter
+                            : inputType === OUTPUT_TYPE_EVENT
+                            ? selectedStageId
+                            : undefined
+                    }
                 />
             )}
         </div>

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramSelect.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramSelect.js
@@ -62,7 +62,7 @@ const ProgramSelect = ({
                 )}
             </div>
             {showStageSelect && (
-                <StageSelect stages={selectedProgram.programStages} locked />
+                <StageSelect stages={selectedProgram.programStages} />
             )}
         </div>
     )

--- a/src/components/MainSidebar/ProgramDimensionsPanel/StageFilter.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/StageFilter.js
@@ -1,0 +1,39 @@
+import i18n from '@dhis2/d2-i18n'
+import { SingleSelect, SingleSelectOption } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const STAGE_ALL = 'STAGE_ALL'
+
+const StageFilter = ({ stages, selected, setSelected }) => {
+    const onChange = ({ selected: stageId }) => {
+        if (stageId === STAGE_ALL) {
+            setSelected()
+        } else {
+            setSelected(stageId)
+        }
+    }
+
+    return (
+        <SingleSelect
+            prefix={i18n.t('Stage')}
+            dense
+            selected={selected || STAGE_ALL}
+            onChange={onChange}
+            dataTest={'stage-select'}
+        >
+            <SingleSelectOption label={i18n.t('All')} value={STAGE_ALL} />
+            {stages.map(({ id, name }) => (
+                <SingleSelectOption label={name} key={id} value={id} />
+            ))}
+        </SingleSelect>
+    )
+}
+
+StageFilter.propTypes = {
+    stages: PropTypes.arrayOf(PropTypes.object).isRequired,
+    selected: PropTypes.string,
+    setSelected: PropTypes.func,
+}
+
+export { StageFilter }

--- a/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
@@ -11,27 +11,18 @@ import {
 import { sGetUiProgramStageId } from '../../../reducers/ui.js'
 import styles from './ProgramSelect.module.css'
 
-const STAGE_ALL = 'STAGE_ALL'
-
-const StageSelect = ({ locked, optional, stages }) => {
+const StageSelect = ({ stages }) => {
     const dispatch = useDispatch()
     const selectedStageId = useSelector(sGetUiProgramStageId)
     const onChange = ({ selected: stageId }) => {
-        if (stageId === STAGE_ALL) {
-            dispatch(tClearUiStage())
-        } else {
-            const stage = stages.find(({ id }) => id === stageId)
-            dispatch(tSetUiStage(stage))
-        }
+        const stage = stages.find(({ id }) => id === stageId)
+        dispatch(tSetUiStage(stage))
 
-        if (!optional && selectedStageId) {
+        if (selectedStageId) {
             dispatch(tClearUiProgramStageDimensions(selectedStageId))
         }
     }
-    const includeShowAllOption = optional && stages.length > 1
-    const canBeCleared = locked && stages.length > 1
-    const selected =
-        selectedStageId || (includeShowAllOption ? STAGE_ALL : undefined)
+    const canBeCleared = stages.length > 1
 
     const clearStage = () => {
         dispatch(tClearUiProgramStageDimensions(selectedStageId))
@@ -40,28 +31,24 @@ const StageSelect = ({ locked, optional, stages }) => {
 
     const select = (
         <SingleSelect
-            prefix={locked ? undefined : i18n.t('Stage')}
-            placeholder={locked ? i18n.t('Stage') : undefined}
+            placeholder={i18n.t('Stage')}
             dense
-            selected={selected}
+            selected={selectedStageId}
             onChange={onChange}
-            disabled={locked && !!selected}
+            disabled={!!selectedStageId}
             dataTest={'stage-select'}
         >
-            {includeShowAllOption && (
-                <SingleSelectOption label={i18n.t('All')} value={STAGE_ALL} />
-            )}
             {stages.map(({ id, name }) => (
                 <SingleSelectOption label={name} key={id} value={id} />
             ))}
         </SingleSelect>
     )
 
-    return locked ? (
+    return (
         <div className={styles.rows}>
             <div className={styles.columns}>
                 <div className={styles.stretch}>
-                    {!selected ? (
+                    {!selectedStageId ? (
                         select
                     ) : (
                         <Tooltip
@@ -77,7 +64,7 @@ const StageSelect = ({ locked, optional, stages }) => {
                         </Tooltip>
                     )}
                 </div>
-                {selected && canBeCleared && (
+                {selectedStageId && canBeCleared && (
                     <Button
                         small
                         secondary
@@ -89,15 +76,11 @@ const StageSelect = ({ locked, optional, stages }) => {
                 )}
             </div>
         </div>
-    ) : (
-        select
     )
 }
 
 StageSelect.propTypes = {
     stages: PropTypes.arrayOf(PropTypes.object).isRequired,
-    locked: PropTypes.bool,
-    optional: PropTypes.bool,
 }
 
 export { StageSelect }


### PR DESCRIPTION
Implements [DHIS2-14288](https://dhis2.atlassian.net/browse/DHIS2-14288)

---

### Key features

1. split stage selection by input type to `StageSelect` and `StageFilter`

---

### Description

There are two distinct cases for selecting a stage

1. For _input type: Event_ stage is selected together with selecting a program, which affects the whole AO
2. For _input type: Enrollment_ stage can be used as a filter when browsing data elements, which only affects the list of dimensions (comparable to searching using the text field)

The `StageSelect` component was previously used for both of these use cases, which created a bit of a mess both in the code and in the ux. There has previously been a need to stop the "false" stage (_case 2_ above) from being passed to the backend etc, which patched up some of the issues with consolidating two distinct use cases into one component. But as there's now an issue with the filter itself (see JIRA ticket for more info), it was decided to split this one component into two - `StageSelect` for _case 1_ and `StageFilter` for _case 2_.

`StageSelect` still relies on the stage id in the store (`ui.program.stage`), but `StageFilter` is now using its own local state prop (called `stageFilter` / `setStageFilter`) to create a distinct separation.

---

### TODO

- [ ] Cypress tests

---


### Screenshots

_case 1_
![image](https://user-images.githubusercontent.com/12590483/207299623-35e3aa28-39bd-4d79-825a-9c4f95c6d247.png)


_case 2_
![image](https://user-images.githubusercontent.com/12590483/207299709-524cd8e5-3767-44d3-a45b-97023fd3a1f7.png)

