### PR TITLE
fix: digit group separator applied to valueType TEXT data elements (DHIS2-14172)

### DIFF
--- a/cypress/integration/conditions/optionSetCondition.cy.js
+++ b/cypress/integration/conditions/optionSetCondition.cy.js
@@ -85,8 +85,8 @@ const assertNumericOptionSet = ({
 describe('Option set condition', () => {
     it(['>37', '<39'], 'Option set (number) displays correctly (2.38)', () => {
         assertNumericOptionSet({
-            tableFilteredOptionName: 'Ei ght',
-            tableFilteredOutOptionName: 'F our',
+            tableFilteredOptionName: 'Eight',
+            tableFilteredOutOptionName: 'Four',
             selectorFilteredOptionName: 'Eight',
         })
     })
@@ -101,8 +101,8 @@ describe('Option set condition', () => {
 
     it(['>=40'], 'Option set (number) displays correctly (2.40+)', () => {
         assertNumericOptionSet({
-            tableFilteredOptionName: 'Ei ght',
-            tableFilteredOutOptionName: 'F our',
+            tableFilteredOptionName: 'Eight',
+            tableFilteredOutOptionName: 'Four',
             selectorFilteredOptionName: 'Eight',
         })
     })

--- a/src/modules/__tests__/tableValues.spec.js
+++ b/src/modules/__tests__/tableValues.spec.js
@@ -5,6 +5,7 @@ import {
     VALUE_TYPE_INTEGER,
     VALUE_TYPE_USERNAME,
     VALUE_TYPE_AGE,
+    VALUE_TYPE_TEXT,
 } from '@dhis2/analytics'
 import { getFormattedCellValue, getHeaderText } from '../tableValues.js'
 
@@ -160,6 +161,38 @@ describe('getFormattedCellValue', () => {
                     visualization: { digitGroupSeparator: 'COMMA' },
                 })
             ).toEqual('2021-12-01')
+        })
+
+        test('numeric option set', () => {
+            const header = {
+                valueType: VALUE_TYPE_NUMBER,
+                optionSet: 'a1b2c3d4',
+            }
+            const value = 'Fifty-five'
+
+            expect(
+                getFormattedCellValue({
+                    header,
+                    value,
+                    visualization: { digitGroupSeparator: 'COMMA' },
+                })
+            ).toEqual('Fifty-five')
+        })
+
+        test('text option set', () => {
+            const header = {
+                valueType: VALUE_TYPE_TEXT,
+                optionSet: 'a1b2c3d4',
+            }
+            const value = 'Option five'
+
+            expect(
+                getFormattedCellValue({
+                    header,
+                    value,
+                    visualization: { digitGroupSeparator: 'COMMA' },
+                })
+            ).toEqual('Option five')
         })
     })
 

--- a/src/modules/tableValues.js
+++ b/src/modules/tableValues.js
@@ -37,10 +37,16 @@ const getFormattedCellValue = ({ value, header = {}, visualization = {} }) => {
     } else if (header?.valueType === VALUE_TYPE_AGE) {
         return value && moment(value).format('yyyy-MM-DD')
     } else {
-        return formatValue(value, header.valueType || VALUE_TYPE_TEXT, {
-            digitGroupSeparator: visualization.digitGroupSeparator,
-            skipRounding: false,
-        })
+        return formatValue(
+            value,
+            header.valueType || VALUE_TYPE_TEXT,
+            !header.optionSet
+                ? {
+                      digitGroupSeparator: visualization.digitGroupSeparator,
+                      skipRounding: false,
+                  }
+                : {}
+        )
     }
 }
 

--- a/src/modules/tableValues.js
+++ b/src/modules/tableValues.js
@@ -40,12 +40,12 @@ const getFormattedCellValue = ({ value, header = {}, visualization = {} }) => {
         return formatValue(
             value,
             header.valueType || VALUE_TYPE_TEXT,
-            !header.optionSet
-                ? {
+            header.optionSet
+                ? {}
+                : {
                       digitGroupSeparator: visualization.digitGroupSeparator,
                       skipRounding: false,
                   }
-                : {}
         )
     }
 }


### PR DESCRIPTION
Implements [DHIS2-14172](https://dhis2.atlassian.net/browse/DHIS2-14172)

---

### Key features

1. Stop applying DGS to optionSet options

---

### Description

Values that are actually options from an optionSet shouldn't have digit group separators applied to them, as those values doesn't count as being numeric. This fix prevents any value with an `optionSet` prop from getting formatted with DGS.

---

### TODO

-   [ ] Cypress tests

---

### Screenshots

_before_
![image](https://user-images.githubusercontent.com/12590483/207349782-b04e95b0-429e-46fb-af7f-afde359fd260.png)


_after_
![image](https://user-images.githubusercontent.com/12590483/207349903-beccee04-230d-4b2c-b37b-08466eda8553.png)
