### PR TITLE
chore: point e2e wf to master

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ name: 'dhis2: e2e tests'
 on:
     push:
         branches:
-            - dev
+            - master
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
     workflow_dispatch:


### PR DESCRIPTION
DO NOT MERGE

Point the e2e workflow to master as part of making master the default branch again.