### PR TITLE
test: log server url

### DIFF
--- a/cypress/helpers/common.js
+++ b/cypress/helpers/common.js
@@ -1,3 +1,6 @@
+import { EXTENDED_TIMEOUT } from '../support/util.js'
+import { expectRouteToEqual } from './route.js'
+
 export const typeInput = (target, text) =>
     cy.getBySelLike(target).find('input').type(text)
 
@@ -8,3 +11,9 @@ export const typeTextarea = (target, text) =>
 
 export const clearTextarea = (target) =>
     cy.getBySel(target).find('textarea').clear()
+
+export const goToAO = (id) => {
+    cy.visit(`#/${id}`, EXTENDED_TIMEOUT).log(Cypress.env('dhis2BaseUrl'))
+    expectRouteToEqual(id)
+    cy.getBySel('visualization-title', EXTENDED_TIMEOUT).should('be.visible')
+}

--- a/cypress/helpers/route.js
+++ b/cypress/helpers/route.js
@@ -4,3 +4,8 @@ export const expectRouteToBeEmpty = () =>
     cy
         .location()
         .should((loc) => expect(getRouteFromHash(loc.hash)).to.have.length(0))
+
+export const expectRouteToEqual = (id) =>
+    cy
+        .location()
+        .should((loc) => expect(getRouteFromHash(loc.hash)).to.equal(id))

--- a/cypress/helpers/startScreen.js
+++ b/cypress/helpers/startScreen.js
@@ -1,8 +1,10 @@
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-export const goToStartPage = () => {
+export const goToStartPage = (skipEval) => {
     cy.visit('/', EXTENDED_TIMEOUT).log(Cypress.env('dhis2BaseUrl'))
-    expectStartScreenToBeVisible()
+    if (!skipEval) {
+        expectStartScreenToBeVisible()
+    }
 }
 
 export const expectStartScreenToBeVisible = () =>

--- a/cypress/helpers/startScreen.js
+++ b/cypress/helpers/startScreen.js
@@ -1,7 +1,7 @@
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 export const goToStartPage = () => {
-    cy.visit('')
+    cy.visit('/', EXTENDED_TIMEOUT).log(Cypress.env('dhis2BaseUrl'))
     expectStartScreenToBeVisible()
 }
 

--- a/cypress/integration/conditions/alphanumericConditions.cy.js
+++ b/cypress/integration/conditions/alphanumericConditions.cy.js
@@ -21,12 +21,12 @@ import {
 } from '../../helpers/layout.js'
 import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
 import { selectRelativePeriod } from '../../helpers/period.js'
+import { goToStartPage } from '../../helpers/startScreen.js'
 import {
     expectTableToBeVisible,
     expectTableToContainHeader,
     expectTableToMatchRows,
 } from '../../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const event = E2E_PROGRAM
 const dimensionName = TEST_DIM_TEXT
@@ -77,7 +77,7 @@ describe('text conditions', () => {
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
 
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable()
     })
 
@@ -237,7 +237,7 @@ describe('alphanumeric types', () => {
 
     TEST_TYPES.forEach((type) => {
         it(`${type} has all operators`, () => {
-            cy.visit('/', EXTENDED_TIMEOUT)
+            goToStartPage()
 
             selectEventWithProgram(E2E_PROGRAM)
             openDimension(type)

--- a/cypress/integration/conditions/booleanConditions.cy.js
+++ b/cypress/integration/conditions/booleanConditions.cy.js
@@ -15,11 +15,11 @@ import {
     selectRelativePeriod,
     getCurrentYearStr,
 } from '../../helpers/period.js'
+import { goToStartPage } from '../../helpers/startScreen.js'
 import {
     expectTableToBeVisible,
     expectTableToMatchRows,
 } from '../../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const currentYear = getCurrentYearStr()
 
@@ -55,7 +55,7 @@ describe('boolean conditions - Yes/NA', () => {
     const dimensionName = TEST_DIM_YESONLY
 
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable(dimensionName)
     })
 
@@ -109,7 +109,7 @@ describe('boolean conditions - Yes/No/NA', () => {
     const dimensionName = TEST_DIM_YESNO
 
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable(dimensionName)
     })
 

--- a/cypress/integration/conditions/dateConditions.cy.js
+++ b/cypress/integration/conditions/dateConditions.cy.js
@@ -24,12 +24,12 @@ import {
     unselectAllPeriods,
     selectFixedPeriod,
 } from '../../helpers/period.js'
+import { goToStartPage } from '../../helpers/startScreen.js'
 import {
     expectTableToBeVisible,
     expectTableToContainHeader,
     expectTableToMatchRows,
 } from '../../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const currentYear = getCurrentYearStr()
 const previousYear = getPreviousYearStr()
@@ -72,7 +72,7 @@ const addConditions = (conditions) => {
 
 describe('date conditions (Date)', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable()
     })
 
@@ -302,7 +302,7 @@ describe('date types', () => {
 
     TEST_TYPES.forEach((type) => {
         it(`${type} has all operators`, () => {
-            cy.visit('/', EXTENDED_TIMEOUT)
+            goToStartPage()
 
             selectEventWithProgram(E2E_PROGRAM)
             openDimension(type)

--- a/cypress/integration/conditions/numericConditions.cy.js
+++ b/cypress/integration/conditions/numericConditions.cy.js
@@ -26,6 +26,7 @@ import {
     getPreviousYearStr,
     selectRelativePeriod,
 } from '../../helpers/period.js'
+import { goToStartPage } from '../../helpers/startScreen.js'
 import {
     expectTableToBeVisible,
     expectTableToContainHeader,
@@ -33,7 +34,6 @@ import {
     getTableDataCells,
     getTableRows,
 } from '../../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const previousYear = getPreviousYearStr()
 
@@ -75,7 +75,7 @@ describe('number conditions', () => {
     const dimensionName = TEST_DIM_NUMBER
 
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable(dimensionName, TEST_REL_PE_THIS_YEAR)
     })
 
@@ -235,7 +235,7 @@ describe('integer', () => {
     const dimensionName = TEST_DIM_POSITIVE_OR_ZERO
 
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable(dimensionName, TEST_REL_PE_LAST_YEAR)
     })
 
@@ -304,7 +304,7 @@ describe('preset options', () => {
     }
 
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram(E2E_PROGRAM)
         openDimension(dimensionName)
@@ -393,7 +393,7 @@ describe('numeric types', () => {
 
     TEST_TYPES.forEach((type) => {
         it(`${type} has all operators`, () => {
-            cy.visit('/', EXTENDED_TIMEOUT)
+            goToStartPage()
 
             selectEventWithProgram(E2E_PROGRAM)
             openDimension(type)

--- a/cypress/integration/conditions/optionSetCondition.cy.js
+++ b/cypress/integration/conditions/optionSetCondition.cy.js
@@ -13,6 +13,7 @@ import {
     selectRelativePeriod,
     getPreviousYearStr,
 } from '../../helpers/period.js'
+import { goToStartPage } from '../../helpers/startScreen.js'
 import {
     expectTableToBeVisible,
     expectTableToContainValue,
@@ -20,7 +21,6 @@ import {
     expectTableToNotContainValue,
 } from '../../helpers/table.js'
 import { searchAndSelectInOptionsTransfer } from '../../helpers/transfer.js'
-import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 // TODO: enable for 38+ when numeric option set has been figured out
 // there was a bug in 38 showing the code instead of name
@@ -33,7 +33,7 @@ const assertNumericOptionSet = ({
 }) => {
     const dimensionName = 'E2E - Number (option set)'
 
-    cy.visit('/', EXTENDED_TIMEOUT)
+    goToStartPage()
 
     selectEventWithProgram(E2E_PROGRAM)
 
@@ -112,7 +112,7 @@ describe('Option set condition', () => {
         const filteredOutOptionName = 'COVID 19 - Moderna'
         const filteredOptionName = 'COVID 19 - AstraZeneca'
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram(E2E_PROGRAM)
 

--- a/cypress/integration/conditions/orgunitCondition.cy.js
+++ b/cypress/integration/conditions/orgunitCondition.cy.js
@@ -14,8 +14,8 @@ import {
 } from '../../helpers/layout.js'
 import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
 import { selectRelativePeriod } from '../../helpers/period.js'
+import { goToStartPage } from '../../helpers/startScreen.js'
 import { expectTableToBeVisible } from '../../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const trackerProgram = E2E_PROGRAM
 const periodLabel = trackerProgram[DIMENSION_ID_EVENT_DATE]
@@ -39,7 +39,7 @@ describe('Org unit condition', () => {
     const orgUnitName = 'Koinadugu'
 
     it('Organisation unit displays correctly', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         setUpTable()
 

--- a/cypress/integration/conditions/unsupportedTypes.cy.js
+++ b/cypress/integration/conditions/unsupportedTypes.cy.js
@@ -15,8 +15,8 @@ import {
 } from '../../helpers/layout.js'
 import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
 import { selectRelativePeriod } from '../../helpers/period.js'
+import { goToStartPage } from '../../helpers/startScreen.js'
 import { expectTableToBeVisible } from '../../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 const event = E2E_PROGRAM
 const periodLabel = event[DIMENSION_ID_EVENT_DATE]
@@ -37,7 +37,7 @@ const setUpTable = () => {
 
 describe('unsupported types', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable()
     })
 
@@ -48,7 +48,7 @@ describe('unsupported types', () => {
 
     TEST_TYPES.forEach((type) => {
         it(`${type.name} displays correctly`, () => {
-            cy.visit('/', EXTENDED_TIMEOUT)
+            goToStartPage()
 
             selectEventWithProgram(E2E_PROGRAM)
 

--- a/cypress/integration/createEnrollment.cy.js
+++ b/cypress/integration/createEnrollment.cy.js
@@ -17,6 +17,7 @@ import {
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableRows,
     getTableHeaderCells,
@@ -169,7 +170,7 @@ const runTests = () => {
 
 describe(['>=39'], 'enrollment', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable({ scheduleDateIsSupported: true })
     })
     runTests()
@@ -177,7 +178,7 @@ describe(['>=39'], 'enrollment', () => {
 
 describe(['<39'], 'enrollment', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         setUpTable()
     })
     runTests()

--- a/cypress/integration/createEvent.cy.js
+++ b/cypress/integration/createEvent.cy.js
@@ -18,6 +18,7 @@ import {
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod, selectRelativePeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableRows,
     getTableHeaderCells,
@@ -290,7 +291,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
 describe(['>=39'], 'event', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
     })
     runTests({ scheduleDateIsSupported: true })
@@ -298,7 +299,7 @@ describe(['>=39'], 'event', () => {
 
 describe(['<39'], 'event', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
     })
     runTests()

--- a/cypress/integration/download.cy.js
+++ b/cypress/integration/download.cy.js
@@ -9,6 +9,7 @@ import {
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const downloadIsEnabled = () =>
@@ -25,7 +26,7 @@ const downloadIsDisabled = () =>
 
 describe('download', () => {
     it('download button enables when required dimensions are selected (event)', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         downloadIsDisabled()
 
@@ -49,7 +50,7 @@ describe('download', () => {
     })
 
     it('download button enables when required dimensions are selected (enrollment)', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         downloadIsDisabled()
 

--- a/cypress/integration/eventStatus.cy.js
+++ b/cypress/integration/eventStatus.cy.js
@@ -10,19 +10,19 @@ import {
 } from '../helpers/layout.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod, getCurrentYearStr } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableHeaderCells,
     expectTableToBeVisible,
     expectTableToMatchRows,
 } from '../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 describe('event status', () => {
     const event = E2E_PROGRAM
     const dimensionName = 'Event status'
 
     const setUpTable = (periodLabel) => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram(event)
 

--- a/cypress/integration/fileMenu.cy.js
+++ b/cypress/integration/fileMenu.cy.js
@@ -1,8 +1,9 @@
 import { TEST_REL_PE_LAST_YEAR } from '../data/index.js'
-import { typeInput } from '../helpers/common.js'
+import { goToAO, typeInput } from '../helpers/common.js'
 import { selectEventWithProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod, unselectAllPeriods } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { expectTableToBeVisible } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
@@ -81,7 +82,7 @@ const deleteVisualization = () => {
 
 describe('file menu', () => {
     it('reflects "empty" state', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         assertDownloadIsDisabled()
 
@@ -89,7 +90,7 @@ describe('file menu', () => {
     })
 
     it('reflects "unsaved, no program" state', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         clickMenubarUpdateButton()
 
@@ -99,7 +100,7 @@ describe('file menu', () => {
     })
 
     it('reflects "unsaved, valid: save" state', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram({
             programName: 'Child Programme',
@@ -115,7 +116,7 @@ describe('file menu', () => {
     })
 
     it('reflects "unsaved, valid: data" state', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram({
             programName: 'Child Programme',
@@ -137,7 +138,7 @@ describe('file menu', () => {
     })
 
     it('reflects "saved, valid: save" state', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram({
             programName: 'Child Programme',
@@ -160,7 +161,7 @@ describe('file menu', () => {
     })
 
     it('reflects "saved, valid: data" state', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram({
             programName: 'Child Programme',
@@ -191,7 +192,7 @@ describe('file menu', () => {
     })
 
     it('reflects "dirty" state', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram({
             programName: 'Child Programme',
@@ -264,7 +265,7 @@ describe('file menu', () => {
     })
 
     it('reflects "saved" and "dirty" state (legacy: do not allow saving)', () => {
-        cy.visit('/#/TIuOzZ0ID0V', EXTENDED_TIMEOUT)
+        goToAO('TIuOzZ0ID0V')
 
         cy.getBySel('visualization-title').contains(
             'Inpatient: Cases 5 to 15 years this year (case)'

--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -16,6 +16,7 @@ import {
     clickMenubarUpdateButton,
 } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const TEST_CANCEL_LABEL = 'Cancel'
@@ -32,7 +33,7 @@ describe('interpretations', () => {
     // Use the `beforeEach` hook to ensure the visualisation is being created after the login takes place
     beforeEach(() => {
         if (!created) {
-            cy.visit('/', EXTENDED_TIMEOUT)
+            goToStartPage()
             cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
 
             const trackerProgram = E2E_PROGRAM

--- a/cypress/integration/layout.cy.js
+++ b/cypress/integration/layout.cy.js
@@ -17,11 +17,11 @@ import {
     TEST_DIM_WITH_PRESET,
 } from '../data/index.js'
 import { selectEventWithProgramDimensions } from '../helpers/dimensions.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 
 describe('layout', () => {
     it('expansion caret can be toggled', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         selectEventWithProgramDimensions({
             ...E2E_PROGRAM,
             dimensions: [

--- a/cypress/integration/layoutValidation.cy.js
+++ b/cypress/integration/layoutValidation.cy.js
@@ -3,8 +3,8 @@ import { CHILD_PROGRAM, TEST_REL_PE_LAST_12_MONTHS } from '../data/index.js'
 import { selectEventWithProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { expectTableToBeVisible } from '../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const openContextMenu = (id) =>
     cy
@@ -18,7 +18,7 @@ describe('layout validation', () => {
     const trackerProgram = CHILD_PROGRAM
 
     it('program is required', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         clickMenubarUpdateButton()
 

--- a/cypress/integration/legendSet.cy.js
+++ b/cypress/integration/legendSet.cy.js
@@ -27,6 +27,7 @@ import {
     unselectAllPeriods,
 } from '../helpers/period.js'
 import { expectRouteToBeEmpty } from '../helpers/route.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     expectAOTitleToContain,
     expectLegendKeyToMatchLegendSets,
@@ -84,7 +85,7 @@ describe(['>=39'], 'Options - Legend', () => {
             })
 
     it('no legend is applied by default', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram(E2E_PROGRAM)
 

--- a/cypress/integration/new.cy.js
+++ b/cypress/integration/new.cy.js
@@ -3,6 +3,7 @@ import { E2E_PROGRAM, TEST_FIX_PE_DEC_LAST_YEAR } from '../data/index.js'
 import { selectEventWithProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { expectTableToBeVisible, getTableRows } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
@@ -11,7 +12,7 @@ const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 
 describe('new', () => {
     it('creates a new line list', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         cy.getBySelLike('layout-chip', EXTENDED_TIMEOUT).contains(
             `Organisation unit: 1 selected`

--- a/cypress/integration/options.cy.js
+++ b/cypress/integration/options.cy.js
@@ -6,18 +6,19 @@ import {
     TEST_DIM_INTEGER,
     TEST_REL_PE_THIS_YEAR,
 } from '../data/index.js'
+import { goToAO } from '../helpers/common.js'
 import { selectEnrollmentProgramDimensions } from '../helpers/dimensions.js'
 import {
     clickMenubarOptionsButton,
     clickMenubarUpdateButton,
 } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { getTableDataCells, getTableRows } from '../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 describe('options', () => {
     it('sets display density', () => {
-        cy.visit(`#/${TEST_AO.id}`, EXTENDED_TIMEOUT)
+        goToAO(TEST_AO.id)
 
         // assert the default density of table cell
         getTableDataCells()
@@ -54,7 +55,7 @@ describe('options', () => {
     it('sets font size', () => {
         const REGULAR_FONT_SIZE = 12
 
-        cy.visit(`#/${TEST_AO.id}`, EXTENDED_TIMEOUT)
+        goToAO(TEST_AO.id)
 
         // assert the font size of table cell
         getTableDataCells()
@@ -92,7 +93,7 @@ describe('options', () => {
     })
 
     it('sets digit group separator', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         // set up table
         selectEnrollmentProgramDimensions({

--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -12,6 +12,7 @@ import {
     openDimension,
     selectEventWithProgram,
 } from '../helpers/dimensions.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const assertDimensionsForEventWithoutProgramSelected = (
@@ -567,7 +568,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
 describe(['>=39'], 'program dimensions', () => {
     beforeEach(() => {
-        cy.visit('/')
+        goToStartPage()
         cy.getBySel('main-sidebar', EXTENDED_TIMEOUT).should('be.visible')
         cy.getBySel('main-sidebar').contains('Program dimensions').click()
     })
@@ -577,7 +578,7 @@ describe(['>=39'], 'program dimensions', () => {
 
 describe(['<39'], 'program dimensions', () => {
     beforeEach(() => {
-        cy.visit('/')
+        goToStartPage()
         cy.getBySel('main-sidebar', EXTENDED_TIMEOUT).should('be.visible')
         cy.getBySel('main-sidebar').contains('Program dimensions').click()
     })

--- a/cypress/integration/repeatedEvents.cy.js
+++ b/cypress/integration/repeatedEvents.cy.js
@@ -3,6 +3,7 @@ import {
     DIMENSION_ID_EVENT_DATE,
 } from '../../src/modules/dimensionConstants.js'
 import { E2E_PROGRAM, TEST_REL_PE_LAST_YEAR } from '../data/index.js'
+import { goToAO } from '../helpers/common.js'
 import {
     openDimension,
     selectEnrollmentProgram,
@@ -12,12 +13,12 @@ import {
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableHeaderCells,
     expectTableToBeVisible,
     getTableDataCells,
 } from '../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const getRepeatedEventsTab = () =>
     cy.getBySel('conditions-modal-content').contains('Repeated events')
@@ -83,7 +84,7 @@ const expectHeaderToContainExact = (index, value) =>
 
 describe('repeated events', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
     })
     it('can use repetition for enrollments', () => {
         const dimensionName = 'E2E - Percentage'
@@ -210,7 +211,7 @@ describe('repeated events', () => {
         getRepeatedEventsTab().should('not.exist')
     })
     it('repetition is not disabled after loading a saved vis with cross-stage data element', () => {
-        cy.visit('/#/Y6N29ifTfn2', EXTENDED_TIMEOUT)
+        goToAO('Y6N29ifTfn2')
 
         cy.getBySel('visualization-title').contains(
             'E2E: Enrollment - Last 12 months - Hemoglobin (repeated)'

--- a/cypress/integration/smoke.cy.js
+++ b/cypress/integration/smoke.cy.js
@@ -1,15 +1,17 @@
 import { TEST_AO } from '../data/index.js'
+import { goToAO } from '../helpers/common.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 describe('Smoke Test', () => {
     it('loads', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
         cy.contains('Getting started', EXTENDED_TIMEOUT).should('be.visible')
         cy.title().should('equal', 'Line Listing | DHIS2')
     })
 
     it('loads with visualization id', () => {
-        cy.visit(`#/${TEST_AO.id}`, EXTENDED_TIMEOUT)
+        goToAO(TEST_AO.id)
 
         cy.getBySel('visualization-title', EXTENDED_TIMEOUT)
             .should('be.visible')

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -35,6 +35,7 @@ import {
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod, getPreviousYearStr } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableRows,
     getTableHeaderCells,
@@ -213,7 +214,7 @@ const assertDimensions = () => {
 }
 
 const init = () => {
-    cy.visit('/', EXTENDED_TIMEOUT)
+    goToStartPage()
 
     // remove org unit
     cy.getBySel('layout-chip-ou', EXTENDED_TIMEOUT)

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -13,12 +13,12 @@ import {
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableRows,
     getTableHeaderCells,
     expectTableToBeVisible,
 } from '../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const trackerProgram = E2E_PROGRAM
 const timeDimensions = [
@@ -57,7 +57,7 @@ const assertTimeDimension = (dimension) => {
 
 describe(['>37', '<39'], 'time dimensions', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
     })
 
     timeDimensions.forEach((dimension) => {
@@ -67,7 +67,7 @@ describe(['>37', '<39'], 'time dimensions', () => {
 
 describe(['>=39'], 'time dimensions', () => {
     beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
     })
 
     timeDimensions

--- a/cypress/integration/translations.cy.js
+++ b/cypress/integration/translations.cy.js
@@ -1,3 +1,4 @@
+import { goToStartPage } from '../helpers/startScreen.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const UPDATE_BUTTON_ORIGINAL = 'Update'
@@ -38,7 +39,7 @@ describe('Translations', () => {
     it('translated language display correctly in the app', () => {
         interceptLanguage()
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         cy.contains(WELCOME_MSG_TRANSLATED, EXTENDED_TIMEOUT).should(
             'be.visible'
@@ -49,7 +50,7 @@ describe('Translations', () => {
     it('translated language display correctly in an Analytics component', () => {
         interceptLanguage()
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         cy.contains(UPDATE_BUTTON_TRANSLATED, EXTENDED_TIMEOUT).should(
             'be.visible'
@@ -58,14 +59,14 @@ describe('Translations', () => {
         cy.contains(UPDATE_BUTTON_ORIGINAL).should('not.exist')
     })
     it('original language display correctly in the app', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         cy.contains(WELCOME_MSG_ORIGINAL, EXTENDED_TIMEOUT).should('be.visible')
 
         cy.contains(WELCOME_MSG_TRANSLATED).should('not.exist')
     })
     it('original language display correctly in an Analytics component', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         cy.contains(UPDATE_BUTTON_ORIGINAL, EXTENDED_TIMEOUT).should(
             'be.visible'

--- a/cypress/integration/translations.cy.js
+++ b/cypress/integration/translations.cy.js
@@ -39,7 +39,7 @@ describe('Translations', () => {
     it('translated language display correctly in the app', () => {
         interceptLanguage()
 
-        goToStartPage()
+        goToStartPage(true)
 
         cy.contains(WELCOME_MSG_TRANSLATED, EXTENDED_TIMEOUT).should(
             'be.visible'
@@ -50,7 +50,7 @@ describe('Translations', () => {
     it('translated language display correctly in an Analytics component', () => {
         interceptLanguage()
 
-        goToStartPage()
+        goToStartPage(true)
 
         cy.contains(UPDATE_BUTTON_TRANSLATED, EXTENDED_TIMEOUT).should(
             'be.visible'
@@ -59,14 +59,14 @@ describe('Translations', () => {
         cy.contains(UPDATE_BUTTON_ORIGINAL).should('not.exist')
     })
     it('original language display correctly in the app', () => {
-        goToStartPage()
+        goToStartPage(true)
 
         cy.contains(WELCOME_MSG_ORIGINAL, EXTENDED_TIMEOUT).should('be.visible')
 
         cy.contains(WELCOME_MSG_TRANSLATED).should('not.exist')
     })
     it('original language display correctly in an Analytics component', () => {
-        goToStartPage()
+        goToStartPage(true)
 
         cy.contains(UPDATE_BUTTON_ORIGINAL, EXTENDED_TIMEOUT).should(
             'be.visible'

--- a/cypress/integration/userDimensions.cy.js
+++ b/cypress/integration/userDimensions.cy.js
@@ -3,11 +3,11 @@ import { E2E_PROGRAM, TEST_FIX_PE_DEC_LAST_YEAR } from '../data/index.js'
 import { selectEnrollmentProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectFixedPeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableHeaderCells,
     expectTableToBeVisible,
 } from '../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const enrollment = E2E_PROGRAM
 const periodLabel = enrollment[DIMENSION_ID_ENROLLMENT_DATE]
@@ -17,7 +17,7 @@ describe('user dimensions', () => {
     TEST_DIMENSIONS.forEach((dimensionName) => {
         it(`${dimensionName} is added to the layout`, () => {
             // set up table
-            cy.visit('/', EXTENDED_TIMEOUT)
+            goToStartPage()
             selectEnrollmentProgram(enrollment)
             selectFixedPeriod({
                 label: periodLabel,

--- a/cypress/integration/yourDimensions.cy.js
+++ b/cypress/integration/yourDimensions.cy.js
@@ -8,6 +8,7 @@ import {
 } from '../helpers/layout.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod, getPreviousYearStr } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableHeaderCells,
     expectTableToBeVisible,
@@ -26,7 +27,7 @@ describe('event', () => {
         const filteredOutItemName = 'MCHP'
         const filteredItemName = 'CHC'
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        goToStartPage()
 
         selectEventWithProgram(trackerProgram)
 


### PR DESCRIPTION
### Key features

1. Log the server url in the beginning of each test

---

### Description

When debugging tests it's sometimes useful to know which server and instance that is being used. This is written in the cypress log, but the important part of the url is cut off due to its length (e.g. `https://test.e2e.dhis2.org/analytics-dev` displays as `https://test.e2e.dhis2...`).

All calls to `cy.visit` are now consolidated into `goToStartPage` and `goToAO(id)`, which in turn use `cy.log` to print the full url (see screenshot below of it in action).

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/208063509-6557505a-9e7f-4a87-a950-6808bcedcc6a.png)
