### PR TITLE
test: reenable the program dimensions tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,6 +75,6 @@ jobs:
               uses: slackapi/slack-github-action@v1.23.0
               with:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-                  slack-message: ':x: Line-listing-app e2e nightly build failed on branch: ${{ github.ref }} :x:'
+                  slack-message: ':x: Line-listing-app e2e nightly build <https://cloud.cypress.io/projects/m5qvjx/runs?branches=[{"label":"dev","suggested":false,"value":"dev"}]|failed>'
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/cypress/integration/createEnrollment.cy.js
+++ b/cypress/integration/createEnrollment.cy.js
@@ -28,7 +28,7 @@ const enrollment = E2E_PROGRAM
 const dimensionName = TEST_DIM_TEXT
 const periodLabel = enrollment[DIMENSION_ID_ENROLLMENT_DATE]
 
-const setUpTable = ({ scheduleDateIsSupported } = {}) => {
+const setUpTable = ({ scheduledDateIsSupported } = {}) => {
     // switch to Enrollment to toggle the enabled/disabled time dimensions
     cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
         .contains('Input: Event')
@@ -43,7 +43,7 @@ const setUpTable = ({ scheduleDateIsSupported } = {}) => {
     dimensionIsEnabled('dimension-item-enrollmentDate')
     cy.getBySel('dimension-item-enrollmentDate').contains('Enrollment date')
 
-    if (scheduleDateIsSupported) {
+    if (scheduledDateIsSupported) {
         dimensionIsDisabled('dimension-item-scheduledDate')
         cy.getBySel('dimension-item-scheduledDate').contains('Scheduled date')
     }
@@ -72,7 +72,7 @@ const setUpTable = ({ scheduleDateIsSupported } = {}) => {
         enrollment[DIMENSION_ID_ENROLLMENT_DATE]
     )
 
-    if (scheduleDateIsSupported) {
+    if (scheduledDateIsSupported) {
         dimensionIsDisabled('dimension-item-scheduledDate')
         cy.getBySel('dimension-item-scheduledDate').contains(
             enrollment[DIMENSION_ID_SCHEDULED_DATE]
@@ -170,7 +170,7 @@ const runTests = () => {
 describe(['>=39'], 'enrollment', () => {
     beforeEach(() => {
         cy.visit('/', EXTENDED_TIMEOUT)
-        setUpTable({ scheduleDateIsSupported: true })
+        setUpTable({ scheduledDateIsSupported: true })
     })
     runTests()
 })

--- a/cypress/integration/createEvent.cy.js
+++ b/cypress/integration/createEvent.cy.js
@@ -25,7 +25,7 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const runTests = ({ scheduleDateIsSupported } = {}) => {
+const runTests = ({ scheduledDateIsSupported } = {}) => {
     it('creates an event line list (tracker program)', () => {
         const eventProgram = E2E_PROGRAM
         const dimensionName = TEST_DIM_TEXT
@@ -38,7 +38,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
         dimensionIsDisabled('dimension-item-enrollmentDate')
         cy.getBySel('dimension-item-enrollmentDate').contains('Enrollment date')
 
-        if (scheduleDateIsSupported) {
+        if (scheduledDateIsSupported) {
             dimensionIsDisabled('dimension-item-scheduledDate')
             cy.getBySel('dimension-item-scheduledDate').contains(
                 'Scheduled date'
@@ -67,7 +67,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
         cy.getBySel('dimension-item-enrollmentDate').contains(
             eventProgram[DIMENSION_ID_ENROLLMENT_DATE]
         )
-        if (scheduleDateIsSupported) {
+        if (scheduledDateIsSupported) {
             dimensionIsEnabled('dimension-item-scheduledDate')
             cy.getBySel('dimension-item-scheduledDate').contains(
                 eventProgram[DIMENSION_ID_SCHEDULED_DATE]
@@ -128,7 +128,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
             programName: 'Inpatient morbidity and mortality',
             [DIMENSION_ID_EVENT_DATE]: 'Report date',
             [DIMENSION_ID_ENROLLMENT_DATE]: 'Enrollment date',
-            ...(scheduleDateIsSupported
+            ...(scheduledDateIsSupported
                 ? { [DIMENSION_ID_SCHEDULED_DATE]: 'Scheduled date' }
                 : {}),
             [DIMENSION_ID_INCIDENT_DATE]: 'Date of Discharge',
@@ -144,7 +144,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
         dimensionIsDisabled('dimension-item-enrollmentDate')
         cy.getBySel('dimension-item-enrollmentDate').contains('Enrollment date')
 
-        if (scheduleDateIsSupported) {
+        if (scheduledDateIsSupported) {
             dimensionIsDisabled('dimension-item-scheduledDate')
             cy.getBySel('dimension-item-scheduledDate').contains(
                 'Scheduled date'
@@ -174,7 +174,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
         cy.getBySel('dimension-item-enrollmentDate').contains(
             eventProgram[DIMENSION_ID_ENROLLMENT_DATE]
         )
-        if (scheduleDateIsSupported) {
+        if (scheduledDateIsSupported) {
             dimensionIsDisabled('dimension-item-scheduledDate')
             cy.getBySel('dimension-item-scheduledDate').contains(
                 eventProgram[DIMENSION_ID_SCHEDULED_DATE]
@@ -293,7 +293,7 @@ describe(['>=39'], 'event', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
         cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
     })
-    runTests({ scheduleDateIsSupported: true })
+    runTests({ scheduledDateIsSupported: true })
 })
 
 describe(['<39'], 'event', () => {

--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -14,6 +14,25 @@ import {
 } from '../helpers/dimensions.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
+const TEST_PROGRAM = {
+    programName: 'WHO RMNCH Tracker',
+    noStage: {
+        [DIMENSION_ID_EVENT_DATE]: 'Event date',
+        [DIMENSION_ID_ENROLLMENT_DATE]: 'Date of first visit',
+        [DIMENSION_ID_SCHEDULED_DATE]: 'Scheduled date',
+        [DIMENSION_ID_INCIDENT_DATE]: 'Date of incident',
+        [DIMENSION_ID_LAST_UPDATED]: 'Last updated on',
+    },
+    stage: {
+        stageName: 'First antenatal care visit',
+        [DIMENSION_ID_EVENT_DATE]: 'Date of visit',
+        [DIMENSION_ID_ENROLLMENT_DATE]: 'Date of first visit',
+        [DIMENSION_ID_SCHEDULED_DATE]: 'Appointment date',
+        [DIMENSION_ID_INCIDENT_DATE]: 'Date of incident',
+        [DIMENSION_ID_LAST_UPDATED]: 'Last updated on',
+    },
+}
+
 const assertDimensionsForEventWithoutProgramSelected = (
     scheduleDateIsSupported
 ) => {
@@ -183,10 +202,7 @@ const assertDimensionsForEnrollmentWithProgramSelected = (
 const runTests = ({ scheduleDateIsSupported } = {}) => {
     describe('event', () => {
         it('program can be selected and cleared', () => {
-            const trackerProgram = E2E_PROGRAM
-            const eventDateWithoutStage = {
-                [DIMENSION_ID_EVENT_DATE]: 'Event date',
-            }
+            const trackerProgram = TEST_PROGRAM
 
             cy.getBySel('accessory-sidebar').contains(
                 'Choose a program above to add program dimensions.'
@@ -218,32 +234,22 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 'Clear program first to choose another'
             )
 
-            assertDimensionsForEventWithProgramSelected({
-                ...trackerProgram,
-                ...eventDateWithoutStage,
-            })
+            assertDimensionsForEventWithProgramSelected(trackerProgram.noStage)
 
             // add main and time dimensions
 
             const expectedSelectedDimensions = [
-                'Event date',
-                trackerProgram[DIMENSION_ID_LAST_UPDATED],
                 'Event status',
                 'Created by',
                 'Last updated by',
+                TEST_PROGRAM.noStage[DIMENSION_ID_EVENT_DATE],
+                TEST_PROGRAM.noStage[DIMENSION_ID_LAST_UPDATED],
             ]
 
             const expectedUnselectedDimensions = [
-                trackerProgram[DIMENSION_ID_ENROLLMENT_DATE],
-
                 'Program status',
+                TEST_PROGRAM.noStage[DIMENSION_ID_ENROLLMENT_DATE],
             ]
-
-            if (scheduleDateIsSupported) {
-                expectedUnselectedDimensions.push(
-                    trackerProgram[DIMENSION_ID_SCHEDULED_DATE]
-                )
-            }
 
             expectedSelectedDimensions
                 .concat(expectedUnselectedDimensions)
@@ -292,12 +298,9 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
         })
 
         it('stage can be selected and cleared', () => {
-            const trackerProgram = E2E_PROGRAM
-            const eventDateWithoutStage = {
-                [DIMENSION_ID_EVENT_DATE]: 'Event date',
-            }
-            const TEST_DATA_ELEMENT = 'HIV Age at Diagnosis'
-            const TEST_PROGRAM_ATTRIBUTE = 'Country of birth'
+            const trackerProgram = TEST_PROGRAM
+            const TEST_DATA_ELEMENT = 'WHOMCH Chronic conditions'
+            const TEST_PROGRAM_ATTRIBUTE = 'First name'
 
             // select program
 
@@ -315,7 +318,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             cy.getBySel('accessory-sidebar').contains('Stage').click()
 
-            cy.contains(trackerProgram.stageName).click()
+            cy.contains(trackerProgram.stage.stageName).click()
 
             cy.getBySel('stage-select').find('.disabled').should('be.visible')
 
@@ -334,7 +337,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 .its('length')
                 .should('be.gte', 1)
 
-            assertDimensionsForEventWithProgramSelected(trackerProgram)
+            assertDimensionsForEventWithProgramSelected(trackerProgram.stage)
 
             // add a data element
 
@@ -362,10 +365,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             cy.getBySel('stage-clear-button').should('not.exist')
 
-            assertDimensionsForEventWithProgramSelected({
-                ...trackerProgram,
-                ...eventDateWithoutStage,
-            })
+            assertDimensionsForEventWithProgramSelected(TEST_PROGRAM.noStage)
 
             // assert that the DE was removed but the PA remained
 
@@ -401,10 +401,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
     })
 
     describe('enrollment', () => {
-        const trackerProgram = {
-            ...E2E_PROGRAM,
-            [DIMENSION_ID_EVENT_DATE]: 'Event date',
-        }
+        const trackerProgram = TEST_PROGRAM
 
         beforeEach(() => {
             cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
@@ -446,7 +443,9 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 .its('length')
                 .should('be.gte', 1)
 
-            assertDimensionsForEnrollmentWithProgramSelected(trackerProgram)
+            assertDimensionsForEnrollmentWithProgramSelected(
+                trackerProgram.noStage
+            )
 
             // clear program
 
@@ -467,7 +466,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
     })
 
     describe('switching input type', () => {
-        it.only('layout is cleared when input type is changed', () => {
+        it('layout is cleared when input type is changed', () => {
             const trackerProgram = E2E_PROGRAM
             const mainAndTimeDimensions = [
                 { label: 'Organisation unit', expected: true },

--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -53,7 +53,7 @@ const TEST_PROGRAM = {
 }
 
 const assertDimensionsForEventWithoutProgramSelected = (
-    scheduleDateIsSupported
+    scheduledDateIsSupported
 ) => {
     dimensionIsEnabled('dimension-item-ou')
     cy.getBySel('dimension-item-ou').contains('Organisation unit')
@@ -76,7 +76,7 @@ const assertDimensionsForEventWithoutProgramSelected = (
     dimensionIsDisabled('dimension-item-enrollmentDate')
     cy.getBySel('dimension-item-enrollmentDate').contains('Enrollment date')
 
-    if (scheduleDateIsSupported) {
+    if (scheduledDateIsSupported) {
         dimensionIsDisabled('dimension-item-scheduledDate')
         cy.getBySel('dimension-item-scheduledDate').contains('Scheduled date')
     }
@@ -90,7 +90,7 @@ const assertDimensionsForEventWithoutProgramSelected = (
 
 const assertDimensionsForEventWithProgramSelected = (
     program,
-    scheduleDateIsSupported
+    scheduledDateIsSupported
 ) => {
     dimensionIsEnabled('dimension-item-ou')
     cy.getBySel('dimension-item-ou').contains('Organisation unit')
@@ -117,7 +117,7 @@ const assertDimensionsForEventWithProgramSelected = (
         program[DIMENSION_ID_ENROLLMENT_DATE]
     )
 
-    if (scheduleDateIsSupported) {
+    if (scheduledDateIsSupported) {
         dimensionIsDisabled('dimension-item-scheduledDate')
         cy.getBySel('dimension-item-scheduledDate').contains(
             program[DIMENSION_ID_SCHEDULED_DATE]
@@ -137,7 +137,7 @@ const assertDimensionsForEventWithProgramSelected = (
 
 const assertDimensionsForEventWithProgramAndStageSelected = (
     program,
-    scheduleDateIsSupported,
+    scheduledDateIsSupported,
     showIncidentDate
 ) => {
     dimensionIsEnabled('dimension-item-ou')
@@ -165,7 +165,7 @@ const assertDimensionsForEventWithProgramAndStageSelected = (
         program[DIMENSION_ID_ENROLLMENT_DATE]
     )
 
-    if (scheduleDateIsSupported) {
+    if (scheduledDateIsSupported) {
         dimensionIsEnabled('dimension-item-scheduledDate')
         cy.getBySel('dimension-item-scheduledDate').contains(
             program[DIMENSION_ID_SCHEDULED_DATE]
@@ -188,7 +188,7 @@ const assertDimensionsForEventWithProgramAndStageSelected = (
 }
 
 const assertDimensionsForEnrollmentWithoutProgramSelected = (
-    scheduleDateIsSupported
+    scheduledDateIsSupported
 ) => {
     dimensionIsEnabled('dimension-item-ou')
     cy.getBySel('dimension-item-ou').contains('Organisation unit')
@@ -211,7 +211,7 @@ const assertDimensionsForEnrollmentWithoutProgramSelected = (
     dimensionIsEnabled('dimension-item-enrollmentDate')
     cy.getBySel('dimension-item-enrollmentDate').contains('Enrollment date')
 
-    if (scheduleDateIsSupported) {
+    if (scheduledDateIsSupported) {
         dimensionIsDisabled('dimension-item-scheduledDate')
         cy.getBySel('dimension-item-scheduledDate').contains('Scheduled date')
     }
@@ -225,7 +225,7 @@ const assertDimensionsForEnrollmentWithoutProgramSelected = (
 
 const assertDimensionsForEnrollmentWithProgramSelected = (
     program,
-    scheduleDateIsSupported
+    scheduledDateIsSupported
 ) => {
     dimensionIsEnabled('dimension-item-ou')
     cy.getBySel('dimension-item-ou').contains('Organisation unit')
@@ -252,7 +252,7 @@ const assertDimensionsForEnrollmentWithProgramSelected = (
         program[DIMENSION_ID_ENROLLMENT_DATE]
     )
 
-    if (scheduleDateIsSupported) {
+    if (scheduledDateIsSupported) {
         dimensionIsDisabled('dimension-item-scheduledDate')
         cy.getBySel('dimension-item-scheduledDate').contains(
             program[DIMENSION_ID_SCHEDULED_DATE]
@@ -270,7 +270,7 @@ const assertDimensionsForEnrollmentWithProgramSelected = (
     )
 }
 
-const runTests = ({ scheduleDateIsSupported } = {}) => {
+const runTests = ({ scheduledDateIsSupported } = {}) => {
     describe('event', () => {
         it('program can be selected and cleared', () => {
             const trackerProgram = TEST_PROGRAM
@@ -282,7 +282,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
             cy.getBySel('program-clear-button').should('not.exist')
 
             assertDimensionsForEventWithoutProgramSelected(
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
 
             // select program
@@ -309,7 +309,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             assertDimensionsForEventWithProgramSelected(
                 trackerProgram.noStage,
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
 
             // add main and time dimensions
@@ -355,7 +355,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
             cy.getBySel('program-clear-button').should('not.exist')
 
             assertDimensionsForEventWithoutProgramSelected(
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
 
             // assert dimensions in layout after program is cleared
@@ -417,7 +417,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             assertDimensionsForEventWithProgramAndStageSelected(
                 trackerProgram.stage,
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
 
             // add a data element
@@ -448,7 +448,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             assertDimensionsForEventWithProgramSelected(
                 TEST_PROGRAM.noStage,
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
 
             // assert that the DE was removed but the PA remained
@@ -507,7 +507,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
             cy.getBySel('program-clear-button').should('not.exist')
 
             assertDimensionsForEnrollmentWithoutProgramSelected(
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
 
             // select program
@@ -531,7 +531,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             assertDimensionsForEnrollmentWithProgramSelected(
                 trackerProgram.noStage,
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
 
             // clear program
@@ -549,7 +549,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
             cy.getBySel('program-clear-button').should('not.exist')
 
             assertDimensionsForEnrollmentWithoutProgramSelected(
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
         })
     })
@@ -585,7 +585,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
                 },
             ]
 
-            if (scheduleDateIsSupported) {
+            if (scheduledDateIsSupported) {
                 mainAndTimeDimensions.push({
                     label: trackerProgram[DIMENSION_ID_SCHEDULED_DATE],
                     labelWithoutProgram: 'Scheduled date',
@@ -603,7 +603,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
 
             assertDimensionsForEventWithProgramAndStageSelected(
                 trackerProgram,
-                scheduleDateIsSupported,
+                scheduledDateIsSupported,
                 true
             )
 
@@ -653,7 +653,7 @@ const runTests = ({ scheduleDateIsSupported } = {}) => {
             // assert that dimensions are enabled/disabled correctly
 
             assertDimensionsForEnrollmentWithoutProgramSelected(
-                scheduleDateIsSupported
+                scheduledDateIsSupported
             )
         })
     })
@@ -666,7 +666,7 @@ describe(['>=39'], 'program dimensions', () => {
         cy.getBySel('main-sidebar').contains('Program dimensions').click()
     })
 
-    runTests({ scheduleDateIsSupported: true })
+    runTests({ scheduledDateIsSupported: true })
 })
 
 describe(['<39'], 'program dimensions', () => {

--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -28,7 +28,7 @@ Test data used:
         Incident date: disabled
 
 Note that scheduled date can be toggled per program stage, but thus requires a stage to be selected before being enabled.
-I.e. Schedule date works like this:
+I.e. Scheduled date works like this:
     no stage: disabled
     stage without scheduled date: disabled
     stage with scheduled date: enabled

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -77,7 +77,7 @@ describe(['>=39'], 'time dimensions', () => {
         })
 
     it('scheduled date disabled state is set based on stage setting ', () => {
-        const scheduleDateHasTooltip = (tooltip) => {
+        const scheduledDateHasTooltip = (tooltip) => {
             cy.getBySelLike('dimension-item-scheduledDate').trigger('mouseover')
             cy.getBySelLike('tooltip-content').contains(tooltip)
         }
@@ -85,7 +85,7 @@ describe(['>=39'], 'time dimensions', () => {
         // both are disabled by default
         dimensionIsDisabled('dimension-item-scheduledDate')
         dimensionIsDisabled('dimension-item-incidentDate')
-        scheduleDateHasTooltip('No program selected')
+        scheduledDateHasTooltip('No program selected')
 
         // select a program
         selectEventWithProgram({ programName: 'Child Programme' })
@@ -113,7 +113,7 @@ describe(['>=39'], 'time dimensions', () => {
         // both are disabled when the stage is cleared
         dimensionIsDisabled('dimension-item-scheduledDate')
         dimensionIsEnabled('dimension-item-incidentDate')
-        scheduleDateHasTooltip('No stage selected')
+        scheduledDateHasTooltip('No stage selected')
 
         // select a program with a stage that has hideDueDate = true
         cy.getBySel('program-clear-button').click()
@@ -128,7 +128,7 @@ describe(['>=39'], 'time dimensions', () => {
         // schedule date is disabled when a stage that hides it is selected
         dimensionIsDisabled('dimension-item-scheduledDate')
         dimensionIsDisabled('dimension-item-incidentDate')
-        scheduleDateHasTooltip('Disabled by the selected program stage')
+        scheduledDateHasTooltip('Disabled by the selected program stage')
     })
 })
 // TODO: add tests for disabling incidentDate per program, e.g. enabled for Analytics program, disabled for HIV Case Surveillance

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -102,7 +102,7 @@ describe(['>=39'], 'time dimensions', () => {
         cy.getBySel('accessory-sidebar').contains('Stage').click()
         cy.containsExact('Birth').click()
 
-        // schedule date is enabled when a stage that doesn't hide it is selected
+        // scheduled date is enabled when a stage that doesn't hide it is selected
         dimensionIsEnabled('dimension-item-scheduledDate')
 
         // incident date is still enabled, stage is not relevant
@@ -125,7 +125,7 @@ describe(['>=39'], 'time dimensions', () => {
         cy.getBySel('accessory-sidebar').contains('Stage').click()
         cy.containsExact('Case outcome').click()
 
-        // schedule date is disabled when a stage that hides it is selected
+        // scheduled date is disabled when a stage that hides it is selected
         dimensionIsDisabled('dimension-item-scheduledDate')
         dimensionIsDisabled('dimension-item-incidentDate')
         scheduledDateHasTooltip('Disabled by the selected program stage')


### PR DESCRIPTION
### Key features

1. Reenables the program dimensions tests

---

### Description

The tests in `programDimensions` were disabled due to an overlooked `.only` modifier that should've been removed before merging. As the database used for Cypress tests has changed since then, the program used in the tests didn't work. It turns out the SL database has a program called `WHO RMNCH Tracker` that aligns well with the program previously used (’HIV Case Surveillance’ in the ’analytics_dev’ database).
