### PR TITLE
fix: reset page on update (DHIS2-13950)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,6 +75,6 @@ jobs:
               uses: slackapi/slack-github-action@v1.23.0
               with:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-                  slack-message: ':x: Line-listing-app e2e nightly build failed on branch: ${{ github.ref }} :x:'
+                  slack-message: ':x: Line-listing-app e2e nightly build <https://cloud.cypress.io/projects/m5qvjx/runs?branches=[{"label":"dev","suggested":false,"value":"dev"}]|failed>'
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -18,7 +18,7 @@ import {
 } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
 import {
     DISPLAY_DENSITY_COMFORTABLE,
     DISPLAY_DENSITY_COMPACT,
@@ -79,7 +79,18 @@ export const Visualization = ({
         }
     )
 
-    const isInModal = !!filters?.relativePeriodDate
+    const visualizationRef = useRef(visualization)
+
+    const setPage = useCallback(
+        (pageNum) =>
+            setSorting({
+                sortField,
+                sortDirection,
+                pageSize,
+                page: pageNum,
+            }),
+        [sortField, sortDirection, pageSize]
+    )
 
     const { fetching, error, data } = useAnalyticsData({
         filters,
@@ -87,10 +98,15 @@ export const Visualization = ({
         isVisualizationLoading,
         onResponsesReceived,
         pageSize,
-        page,
+        page: visualization !== visualizationRef.current ? FIRST_PAGE : page,
         sortField,
         sortDirection,
     })
+
+    useEffect(() => {
+        visualizationRef.current = visualization
+        setPage(FIRST_PAGE)
+    }, [visualization, setPage])
 
     useEffect(() => {
         if (data && visualization) {
@@ -132,14 +148,6 @@ export const Visualization = ({
             sortDirection: direction,
             pageSize,
             page: FIRST_PAGE,
-        })
-
-    const setPage = (pageNum) =>
-        setSorting({
-            sortField,
-            sortDirection,
-            pageSize,
-            page: pageNum,
         })
 
     const setPageSize = (pageSizeNum) =>
@@ -198,6 +206,8 @@ export const Visualization = ({
             <LegendKey legendSets={uniqueLegendSets} />
         </div>
     )
+
+    const isInModal = !!filters?.relativePeriodDate
 
     return (
         <div className={styles.pluginContainer}>


### PR DESCRIPTION
Implements [DHIS2-13950](https://dhis2.atlassian.net/browse/DHIS2-13950)

Resets the page to 1 for new visualizations. Stores the previous visualization in a ref and compares against the prop.

Example: we're on page 5 of a line list. If we listen to `visualization` and do `setPage` when changes, then the data hook first requests data for the new visualization with page 5, which we don't need and want to avoid. When local state for `page` is updated the data hook fires again, this time with page 1.

With this PR the first request is correct and the data engine cancels the second request because it's identical to the first one.

[DHIS2-13950]: https://dhis2.atlassian.net/browse/DHIS2-13950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ