### PR TITLE
fix: saving on an empty name causes a crash (DHIS2-13835)

### DIFF
--- a/cypress/helpers/fileMenu.js
+++ b/cypress/helpers/fileMenu.js
@@ -1,0 +1,46 @@
+import { clearInput, typeInput } from './common.js'
+
+export const ITEM_NEW = 'file-menu-new'
+export const ITEM_OPEN = 'file-menu-open'
+export const ITEM_SAVE = 'file-menu-save'
+export const ITEM_SAVEAS = 'file-menu-saveas'
+export const ITEM_RENAME = 'file-menu-rename'
+export const ITEM_TRANSLATE = 'file-menu-translate'
+export const ITEM_SHARING = 'file-menu-sharing'
+export const ITEM_GETLINK = 'file-menu-getlink'
+export const ITEM_DELETE = 'file-menu-delete'
+
+export const saveVisualization = (name) => {
+    cy.getBySel('menubar').contains('File').click()
+
+    cy.getBySel(ITEM_SAVE).click()
+
+    if (name) {
+        typeInput('file-menu-saveas-modal-name-content', name)
+    }
+
+    cy.getBySel('file-menu-saveas-modal-save').click()
+}
+
+export const saveVisualizationAs = (name) => {
+    cy.getBySel('menubar').contains('File').click()
+
+    cy.getBySel(ITEM_SAVEAS).click()
+
+    if (name) {
+        clearInput('file-menu-saveas-modal-name-content')
+        typeInput('file-menu-saveas-modal-name-content', name)
+    }
+
+    cy.getBySel('file-menu-saveas-modal-save').click()
+}
+
+export const deleteVisualization = () => {
+    cy.getBySel('menubar').contains('File').click()
+
+    cy.getBySel(ITEM_DELETE).click()
+
+    cy.getBySel('file-menu-delete-modal-delete').click()
+
+    cy.getBySel('visualization-title').should('not.exist')
+}

--- a/cypress/integration/fileMenu.cy.js
+++ b/cypress/integration/fileMenu.cy.js
@@ -1,21 +1,24 @@
 import { TEST_REL_PE_LAST_YEAR } from '../data/index.js'
-import { goToAO, typeInput } from '../helpers/common.js'
+import { goToAO } from '../helpers/common.js'
 import { selectEventWithProgram } from '../helpers/dimensions.js'
+import {
+    ITEM_NEW,
+    ITEM_OPEN,
+    ITEM_SAVE,
+    ITEM_SAVEAS,
+    ITEM_RENAME,
+    ITEM_TRANSLATE,
+    ITEM_SHARING,
+    ITEM_GETLINK,
+    ITEM_DELETE,
+    saveVisualization,
+    deleteVisualization,
+} from '../helpers/fileMenu.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod, unselectAllPeriods } from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import { expectTableToBeVisible } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
-
-const ITEM_NEW = 'file-menu-new'
-const ITEM_OPEN = 'file-menu-open'
-const ITEM_SAVE = 'file-menu-save'
-const ITEM_SAVEAS = 'file-menu-saveas'
-const ITEM_RENAME = 'file-menu-rename'
-const ITEM_TRANSLATE = 'file-menu-translate'
-const ITEM_SHARING = 'file-menu-sharing'
-const ITEM_GETLINK = 'file-menu-getlink'
-const ITEM_DELETE = 'file-menu-delete'
 
 const defaultItemsMap = {
     [ITEM_NEW]: true,
@@ -56,28 +59,6 @@ const assertDownloadIsDisabled = () =>
 const closeFileMenu = () => {
     cy.getBySel('file-menu-toggle-layer').click()
     cy.getBySel('file-menu-container').should('not.exist')
-}
-
-const saveVisualization = (name) => {
-    cy.getBySel('menubar').contains('File').click()
-
-    cy.getBySel(ITEM_SAVE).click()
-
-    typeInput('file-menu-saveas-modal-name-content', name)
-
-    cy.getBySel('file-menu-saveas-modal-save').click()
-
-    cy.getBySel('visualization-title').contains(name)
-}
-
-const deleteVisualization = () => {
-    cy.getBySel(ITEM_DELETE).click()
-
-    cy.getBySel('file-menu-delete-modal-delete').click()
-
-    cy.getBySel('visualization-title').should('not.exist')
-
-    assertFileMenuItems()
 }
 
 describe('file menu', () => {
@@ -146,7 +127,9 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        saveVisualization('Cypress test "saved, valid: save" state')
+        saveVisualization(
+            `TEST ${new Date().toLocaleString()} - "saved, valid: save" state`
+        )
 
         assertDownloadIsDisabled()
 
@@ -175,7 +158,9 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        saveVisualization('Cypress test "saved, valid: data" state')
+        saveVisualization(
+            `TEST ${new Date().toLocaleString()} - "saved, valid: data" state`
+        )
 
         assertDownloadIsEnabled()
 
@@ -189,6 +174,7 @@ describe('file menu', () => {
         })
 
         deleteVisualization()
+        assertFileMenuItems()
     })
 
     it('reflects "dirty" state', () => {
@@ -206,7 +192,7 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        saveVisualization('Cypress test "dirty" state')
+        saveVisualization(`TEST ${new Date().toLocaleString()} - "dirty" state`)
 
         // "dirty, valid: data" state
         clickMenubarUpdateButton()
@@ -262,6 +248,7 @@ describe('file menu', () => {
         })
 
         deleteVisualization()
+        assertFileMenuItems()
     })
 
     it('reflects "saved" and "dirty" state (legacy: do not allow saving)', () => {

--- a/cypress/integration/fileMenu.cy.js
+++ b/cypress/integration/fileMenu.cy.js
@@ -17,7 +17,10 @@ import {
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod, unselectAllPeriods } from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
-import { expectTableToBeVisible } from '../helpers/table.js'
+import {
+    expectAOTitleToContain,
+    expectTableToBeVisible,
+} from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const defaultItemsMap = {
@@ -127,9 +130,11 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        saveVisualization(
-            `TEST ${new Date().toLocaleString()} - "saved, valid: save" state`
-        )
+        const AO_NAME = `TEST ${new Date().toLocaleString()} - "saved, valid: save" state`
+
+        saveVisualization(AO_NAME)
+
+        expectAOTitleToContain(AO_NAME)
 
         assertDownloadIsDisabled()
 
@@ -158,9 +163,11 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        saveVisualization(
-            `TEST ${new Date().toLocaleString()} - "saved, valid: data" state`
-        )
+        const AO_NAME = `TEST ${new Date().toLocaleString()} - "saved, valid: data" state`
+
+        saveVisualization(AO_NAME)
+
+        expectAOTitleToContain(AO_NAME)
 
         assertDownloadIsEnabled()
 
@@ -173,6 +180,7 @@ describe('file menu', () => {
             [ITEM_DELETE]: true,
         })
 
+        closeFileMenu()
         deleteVisualization()
         assertFileMenuItems()
     })
@@ -192,13 +200,16 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        saveVisualization(`TEST ${new Date().toLocaleString()} - "dirty" state`)
+        const AO_NAME = `TEST ${new Date().toLocaleString()} - "dirty" state`
+
+        saveVisualization(AO_NAME)
+
+        expectAOTitleToContain(AO_NAME)
 
         // "dirty, valid: data" state
         clickMenubarUpdateButton()
 
         cy.getBySel('visualization-title').contains('Edited')
-
         assertDownloadIsEnabled()
 
         assertFileMenuItems({
@@ -247,6 +258,7 @@ describe('file menu', () => {
             [ITEM_DELETE]: true,
         })
 
+        closeFileMenu()
         deleteVisualization()
         assertFileMenuItems()
     })

--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -4,8 +4,9 @@ import {
     TEST_DIM_TEXT,
     TEST_FIX_PE_DEC_LAST_YEAR,
 } from '../data/index.js'
-import { clearTextarea, typeInput, typeTextarea } from '../helpers/common.js'
+import { clearTextarea, typeTextarea } from '../helpers/common.js'
 import { selectEventWithProgramDimensions } from '../helpers/dimensions.js'
+import { deleteVisualization, saveVisualization } from '../helpers/fileMenu.js'
 import {
     expectInterpretationsButtonToBeEnabled,
     expectInterpretationFormToBeVisible,
@@ -52,15 +53,9 @@ describe('interpretations', () => {
 
             clickMenubarUpdateButton()
 
-            // TODO extract into a helper function?
-            cy.getBySel('menubar').contains('File').click()
-
-            cy.getBySel('file-menu-container').contains('Save').click()
-
-            const AO_NAME = `INTERPRETATIONS TEST ${new Date().toLocaleString()}`
-            typeInput('file-menu-saveas-modal-name', AO_NAME)
-
-            cy.getBySel('file-menu-saveas-modal-save').click()
+            saveVisualization(
+                `INTERPRETATIONS TEST ${new Date().toLocaleString()}`
+            )
 
             // Toggle to `true` to prevent re-creation
             created = true
@@ -200,10 +195,6 @@ describe('interpretations', () => {
     })
 
     after(() => {
-        cy.getBySel('menubar').contains('File').click()
-
-        cy.getBySel('file-menu-container').contains('Delete').click()
-
-        cy.getBySel('file-menu-delete-modal-delete').contains('Delete').click()
+        deleteVisualization()
     })
 })

--- a/cypress/integration/legendSet.cy.js
+++ b/cypress/integration/legendSet.cy.js
@@ -5,8 +5,8 @@ import {
     TEST_DIM_LEGEND_SET_NEGATIVE,
     TEST_REL_PE_LAST_YEAR,
 } from '../data/index.js'
-import { typeInput } from '../helpers/common.js'
 import { openDimension, selectEventWithProgram } from '../helpers/dimensions.js'
+import { deleteVisualization, saveVisualization } from '../helpers/fileMenu.js'
 import {
     clickMenubarOptionsButton,
     clickMenubarUpdateButton,
@@ -29,14 +29,13 @@ import {
 import { expectRouteToBeEmpty } from '../helpers/route.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import {
-    expectAOTitleToContain,
     expectLegendKeyToMatchLegendSets,
     expectLegendKeyToBeHidden,
     expectLegendKeyToBeVisible,
     expectTableToBeVisible,
     getTableRows,
+    expectAOTitleToContain,
 } from '../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const event = E2E_PROGRAM
 const dimensionName = TEST_DIM_LEGEND_SET
@@ -282,17 +281,9 @@ describe(['>=39'], 'Options - Legend', () => {
         assertCellsHaveDefaultColors('tr td:nth-child(1)')
     })
     it('options can be saved and loaded', () => {
-        cy.getBySel('menubar', EXTENDED_TIMEOUT).contains('File').click()
-
-        cy.getBySel('file-menu-container').contains('Save').click()
-
         const AO_NAME = `TEST ${new Date().toLocaleString()}`
-        typeInput('file-menu-saveas-modal-name', AO_NAME)
-
-        cy.getBySel('file-menu-saveas-modal-save').click()
-
+        saveVisualization(AO_NAME)
         expectAOTitleToContain(AO_NAME)
-
         expectTableToBeVisible()
 
         // affected cells have default text color and fixed background color
@@ -391,14 +382,7 @@ describe(['>=39'], 'Options - Legend', () => {
             .should('not.equal', '')
     })
     it('saved AO can be deleted', () => {
-        cy.getBySel('menubar').contains('File').click()
-
-        cy.getBySel('file-menu-container').contains('Delete').click()
-
-        cy.getBySel('file-menu-delete-modal')
-            .find('button')
-            .contains('Delete')
-            .click()
+        deleteVisualization()
 
         expectRouteToBeEmpty()
     })

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -55,7 +55,9 @@ describe('save', () => {
     it('new AO without name saves correctly', () => {
         cy.clock(cy.clock(Date.UTC(2022, 11, 29), ['Date'])) // month is 0-indexed, 11 = December
         const EXPECTED_AO_NAME_PART_1 = 'Untitled Line list visualization'
-        const EXPECTED_AO_NAME_PART_2 = '29 Dec' // locally the date is "29 Dec 2022" but on CI it's "29 Dec, 2022" with a comma, so it's split into two parts to cater for both cases
+        const EXPECTED_AO_NAME_PART_2 = '29'
+        const EXPECTED_AO_NAME_PART_3 = 'Dec'
+        const EXPECTED_AO_NAME_PART_4 = '2022' // locally the date is "29 Dec 2022" but on CI it's "Dec 29, 2022", so it's split into different parts to cater for both cases
         const UPDATED_AO_NAME = `TEST ${new Date().toLocaleString()}`
         setupTable()
 
@@ -63,12 +65,16 @@ describe('save', () => {
         saveVisualization()
         expectAOTitleToContain(EXPECTED_AO_NAME_PART_1)
         expectAOTitleToContain(EXPECTED_AO_NAME_PART_2)
+        expectAOTitleToContain(EXPECTED_AO_NAME_PART_3)
+        expectAOTitleToContain(EXPECTED_AO_NAME_PART_4)
         expectTableToBeVisible()
 
         // save as without name change
         saveVisualizationAs()
         expectAOTitleToContain(EXPECTED_AO_NAME_PART_1)
         expectAOTitleToContain(EXPECTED_AO_NAME_PART_2)
+        expectAOTitleToContain(EXPECTED_AO_NAME_PART_3)
+        expectAOTitleToContain(EXPECTED_AO_NAME_PART_4)
         expectAOTitleToContain('(copy)')
         expectTableToBeVisible()
 

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -54,18 +54,22 @@ describe('save', () => {
 
     it('new AO without name saves correctly', () => {
         cy.clock(cy.clock(Date.UTC(2022, 11, 29), ['Date'])) // month is 0-indexed, 11 = December
-        const EXPECTED_AO_NAME = 'Untitled Line list visualization, 29 Dec 2022'
+        const EXPECTED_AO_NAME_PART_1 = 'Untitled Line list visualization'
+        const EXPECTED_AO_NAME_PART_2 = '29 Dec' // locally the date is "29 Dec 2022" but on CI it's "29 Dec, 2022" with a comma, so it's split into two parts to cater for both cases
         const UPDATED_AO_NAME = `TEST ${new Date().toLocaleString()}`
         setupTable()
 
         // save without a name
         saveVisualization()
-        expectAOTitleToContain(EXPECTED_AO_NAME)
+        expectAOTitleToContain(EXPECTED_AO_NAME_PART_1)
+        expectAOTitleToContain(EXPECTED_AO_NAME_PART_2)
         expectTableToBeVisible()
 
         // save as without name change
         saveVisualizationAs()
-        expectAOTitleToContain(EXPECTED_AO_NAME + ' (copy)')
+        expectAOTitleToContain(EXPECTED_AO_NAME_PART_1)
+        expectAOTitleToContain(EXPECTED_AO_NAME_PART_2)
+        expectAOTitleToContain('(copy)')
         expectTableToBeVisible()
 
         // save as with name change

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -1,0 +1,78 @@
+import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js'
+import { E2E_PROGRAM, TEST_FIX_PE_DEC_LAST_YEAR } from '../data/index.js'
+import { selectEventWithProgram } from '../helpers/dimensions.js'
+import {
+    deleteVisualization,
+    saveVisualization,
+    saveVisualizationAs,
+} from '../helpers/fileMenu.js'
+import { clickMenubarUpdateButton } from '../helpers/menubar.js'
+import { selectFixedPeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
+import {
+    expectAOTitleToContain,
+    expectTableToBeVisible,
+} from '../helpers/table.js'
+
+const event = E2E_PROGRAM
+const periodLabel = event[DIMENSION_ID_EVENT_DATE]
+
+const setupTable = () => {
+    goToStartPage()
+    selectEventWithProgram(event)
+    selectFixedPeriod({
+        label: periodLabel,
+        period: TEST_FIX_PE_DEC_LAST_YEAR,
+    })
+    clickMenubarUpdateButton()
+    expectTableToBeVisible()
+}
+
+describe('save', () => {
+    it('new AO with name saves correctly', () => {
+        const AO_NAME = `TEST ${new Date().toLocaleString()}`
+        const UPDATED_AO_NAME = AO_NAME + ' 2'
+        setupTable()
+
+        // save with a name
+        saveVisualization(AO_NAME)
+        expectAOTitleToContain(AO_NAME)
+        expectTableToBeVisible()
+
+        // save as with name change
+        saveVisualizationAs(UPDATED_AO_NAME)
+        expectAOTitleToContain(UPDATED_AO_NAME)
+        expectTableToBeVisible()
+
+        // save as without name change
+        saveVisualizationAs()
+        expectAOTitleToContain(UPDATED_AO_NAME + ' (copy)')
+        expectTableToBeVisible()
+
+        deleteVisualization()
+    })
+
+    it('new AO without name saves correctly', () => {
+        cy.clock(cy.clock(Date.UTC(2022, 11, 29), ['Date'])) // month is 0-indexed, 11 = December
+        const EXPECTED_AO_NAME = 'Untitled Line list visualization, 29 Dec 2022'
+        const UPDATED_AO_NAME = `TEST ${new Date().toLocaleString()}`
+        setupTable()
+
+        // save without a name
+        saveVisualization()
+        expectAOTitleToContain(EXPECTED_AO_NAME)
+        expectTableToBeVisible()
+
+        // save as without name change
+        saveVisualizationAs()
+        expectAOTitleToContain(EXPECTED_AO_NAME + ' (copy)')
+        expectTableToBeVisible()
+
+        // save as with name change
+        saveVisualizationAs(UPDATED_AO_NAME)
+        expectAOTitleToContain(UPDATED_AO_NAME)
+        expectTableToBeVisible()
+
+        deleteVisualization()
+    })
+})

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.3.6",
+        "@dhis2/analytics": "^24.3.13",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^8.4.1",
         "@dnd-kit/core": "^5.0.3",

--- a/src/components/Toolbar/MenuBar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar/MenuBar.js
@@ -2,7 +2,7 @@ import {
     FileMenu,
     useCachedDataQuery,
     VIS_TYPE_LINE_LIST,
-    visTypeDisplayNames,
+    getDisplayNameByVisType,
 } from '@dhis2/analytics'
 import { useDataMutation, useAlert } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
@@ -142,7 +142,7 @@ const MenuBar = ({
             visualization.name ||
             // new visualization with no name provided in Save dialog
             i18n.t('Untitled {{visualizationType}} visualization, {{date}}', {
-                visualizationType: visTypeDisplayNames(VIS_TYPE_LINE_LIST),
+                visualizationType: getDisplayNameByVisType(VIS_TYPE_LINE_LIST),
                 date: new Date().toLocaleDateString(undefined, {
                     year: 'numeric',
                     month: 'short',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,10 +2009,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24.3.6":
-  version "24.3.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.3.6.tgz#19d5ec2a62d1914236c9620c18d29449b38942a3"
-  integrity sha512-fPJB4crp4U9t7GJ1kpuNoPyaZoJq8+QdFO6vMhv+CpSEFJjdBNnlF6n26hfjbBwuXzC+QGB0kqo0ihjLStj9xg==
+"@dhis2/analytics@^24.3.13":
+  version "24.3.13"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.3.13.tgz#b07027505a36274ad359b7449b3351d993e79c15"
+  integrity sha512-8gFu5WNfgcZqlkkYsrYq5DdTaHBGihSiV4mhIxUrVr0uDkHaYpmccwOjgxoxv++c5xusDeFYs99OqGjZJPkAMA==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     classnames "^2.3.1"


### PR DESCRIPTION
Implements [DHIS2-13835](https://dhis2.atlassian.net/browse/DHIS2-13835)

---

### Key features

1. Prevents saving without a name from crashing

---

### Description

Saving an AO without a name (i.e. empty input field) was causing the app to crash and prevented the AO from being saved. The app is supposed to fill in a name automatically, starting with "Untitled Line list visualization" + today's date.

`visTypeDisplayNames` is an object but was used as a function, which caused saving without a name to crash. Switching to the actual function `getDisplayNameByVisType` solves this.

To test this, the `saveVisualization` and `deleteVisualization` helper functions were added, which also gave cause for refactoring the other tests that were saving and/or deleting as well.

One thing to note about the tests, when an AO is saved without a name it automatically gets a name assigned, which has a date stamp at the end. However, due to different locales, this will generate different results locally (29 Dec 2022) and on CI (Dec 29, 2022). It turns out there's no easy way to set the locale in Cypress, so instead the assertion of this date was split into separate parts (29, Dec, 2022), so the order/format doesn't cause the tests to fail.

---

### TODO

-   [x] Tests?

---

### Screenshots

_"Untitled Line list visualization..." is filled in automatically_ 
![image](https://user-images.githubusercontent.com/12590483/209931592-abac7f93-1bfa-432d-8bd2-05d2348a3acd.png)

