### PR TITLE
fix: numbers with dgs space wrap on multiple lines (DHIS2-13899)

### DIFF
--- a/cypress/data/index.js
+++ b/cypress/data/index.js
@@ -40,15 +40,18 @@ export const TEST_DIM_EMAIL = 'E2E - Email'
 export const TEST_DIM_USERNAME = 'E2E - Username'
 export const TEST_DIM_URL = 'E2E - URL'
 export const TEST_DIM_PHONE_NUMBER = 'E2E - Phone number'
+export const TEST_DIM_NUMBER_OPTIONSET = 'E2E - Number (option set)'
+export const TEST_DIM_TEXT_OPTIONSET = 'E2E - Text (option set)'
 
 // numerics
 export const TEST_DIM_NUMBER = 'E2E - Number'
 export const TEST_DIM_UNIT_INTERVAL = 'E2E - Unit interval'
 export const TEST_DIM_PERCENTAGE = 'E2E - Percentage'
 export const TEST_DIM_INTEGER = 'E2E - Integer'
-export const TEST_DIM_POSITIVE_INTEGER = 'E2E - Positive Integer'
-export const TEST_DIM_NEGATIVE_INTEGER = 'E2E - Negative Integer'
-export const TEST_DIM_POSITIVE_OR_ZERO = 'E2E - Positive or Zero Integer'
+export const TEST_DIM_INTEGER_POSITIVE = 'E2E - Positive Integer'
+export const TEST_DIM_INTEGER_NEGATIVE = 'E2E - Negative Integer'
+export const TEST_DIM_INTEGER_ZERO_OR_POSITIVE =
+    'E2E - Positive or Zero Integer'
 export const TEST_DIM_WITH_PRESET = 'E2E - Number (legend set)'
 
 // booleans
@@ -67,7 +70,7 @@ export const TEST_DIM_COORDINATE = 'E2E - Coordinate'
 // special
 export const TEST_DIM_ORG_UNIT = 'E2E - Organisation unit'
 export const TEST_DIM_LEGEND_SET = 'E2E - Number (legend set)'
-export const TEST_DIM_LEGEND_SET_NEGATIVE = TEST_DIM_NEGATIVE_INTEGER
+export const TEST_DIM_LEGEND_SET_NEGATIVE = TEST_DIM_INTEGER_NEGATIVE
 
 export const TEST_REL_PE_THIS_YEAR = {
     type: 'Years',

--- a/cypress/integration/conditions/numericConditions.cy.js
+++ b/cypress/integration/conditions/numericConditions.cy.js
@@ -5,9 +5,9 @@ import {
     TEST_DIM_UNIT_INTERVAL,
     TEST_DIM_PERCENTAGE,
     TEST_DIM_INTEGER,
-    TEST_DIM_POSITIVE_INTEGER,
-    TEST_DIM_NEGATIVE_INTEGER,
-    TEST_DIM_POSITIVE_OR_ZERO,
+    TEST_DIM_INTEGER_POSITIVE,
+    TEST_DIM_INTEGER_NEGATIVE,
+    TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
     TEST_REL_PE_THIS_YEAR,
     TEST_REL_PE_LAST_YEAR,
     TEST_DIM_WITH_PRESET,
@@ -232,7 +232,7 @@ describe('number conditions', () => {
 })
 
 describe('integer', () => {
-    const dimensionName = TEST_DIM_POSITIVE_OR_ZERO
+    const dimensionName = TEST_DIM_INTEGER_ZERO_OR_POSITIVE
 
     beforeEach(() => {
         goToStartPage()
@@ -386,9 +386,9 @@ describe('numeric types', () => {
         TEST_DIM_UNIT_INTERVAL,
         TEST_DIM_PERCENTAGE,
         TEST_DIM_INTEGER,
-        TEST_DIM_POSITIVE_INTEGER,
-        TEST_DIM_NEGATIVE_INTEGER,
-        TEST_DIM_POSITIVE_OR_ZERO,
+        TEST_DIM_INTEGER_POSITIVE,
+        TEST_DIM_INTEGER_NEGATIVE,
+        TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
     ]
 
     TEST_TYPES.forEach((type) => {

--- a/cypress/integration/conditions/optionSetCondition.cy.js
+++ b/cypress/integration/conditions/optionSetCondition.cy.js
@@ -1,5 +1,10 @@
 import { DIMENSION_ID_EVENT_DATE } from '../../../src/modules/dimensionConstants.js'
-import { E2E_PROGRAM, TEST_REL_PE_LAST_YEAR } from '../../data/index.js'
+import {
+    E2E_PROGRAM,
+    TEST_DIM_NUMBER_OPTIONSET,
+    TEST_DIM_TEXT_OPTIONSET,
+    TEST_REL_PE_LAST_YEAR,
+} from '../../data/index.js'
 import {
     openDimension,
     selectEventWithProgram,
@@ -31,7 +36,7 @@ const assertNumericOptionSet = ({
     tableFilteredOutOptionName,
     selectorFilteredOptionName,
 }) => {
-    const dimensionName = 'E2E - Number (option set)'
+    const dimensionName = TEST_DIM_NUMBER_OPTIONSET
 
     goToStartPage()
 
@@ -108,7 +113,7 @@ describe('Option set condition', () => {
     })
 
     it('Option set (text) displays correctly', () => {
-        const dimensionName = 'E2E - Text (option set)'
+        const dimensionName = TEST_DIM_TEXT_OPTIONSET
         const filteredOutOptionName = 'COVID 19 - Moderna'
         const filteredOptionName = 'COVID 19 - AstraZeneca'
 

--- a/cypress/integration/layout.cy.js
+++ b/cypress/integration/layout.cy.js
@@ -11,9 +11,9 @@ import {
     TEST_DIM_UNIT_INTERVAL,
     TEST_DIM_PERCENTAGE,
     TEST_DIM_INTEGER,
-    TEST_DIM_POSITIVE_INTEGER,
-    TEST_DIM_NEGATIVE_INTEGER,
-    TEST_DIM_POSITIVE_OR_ZERO,
+    TEST_DIM_INTEGER_POSITIVE,
+    TEST_DIM_INTEGER_NEGATIVE,
+    TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
     TEST_DIM_WITH_PRESET,
 } from '../data/index.js'
 import { selectEventWithProgramDimensions } from '../helpers/dimensions.js'
@@ -36,15 +36,15 @@ describe('layout', () => {
                 TEST_DIM_UNIT_INTERVAL,
                 TEST_DIM_PERCENTAGE,
                 TEST_DIM_INTEGER,
-                TEST_DIM_POSITIVE_INTEGER,
-                TEST_DIM_NEGATIVE_INTEGER,
-                TEST_DIM_POSITIVE_OR_ZERO,
+                TEST_DIM_INTEGER_POSITIVE,
+                TEST_DIM_INTEGER_NEGATIVE,
+                TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
                 TEST_DIM_WITH_PRESET,
             ],
         })
 
         cy.getBySel('columns-axis')
-            .contains(TEST_DIM_POSITIVE_INTEGER)
+            .contains(TEST_DIM_INTEGER_POSITIVE)
             .should('be.visible')
 
         cy.getBySel('layout-height-toggle').click()

--- a/cypress/integration/options.cy.js
+++ b/cypress/integration/options.cy.js
@@ -23,7 +23,7 @@ describe('options', () => {
         // assert the default density of table cell
         getTableDataCells()
             .invoke('css', 'padding')
-            .should('equal', '8px 2px 6px 6px')
+            .should('equal', '8px 6px 6px')
 
         // set to comfortable density
         clickMenubarOptionsButton()
@@ -36,7 +36,7 @@ describe('options', () => {
         // assert comfortable density
         getTableDataCells()
             .invoke('css', 'padding')
-            .should('equal', '10px 4px 8px 8px')
+            .should('equal', '10px 8px 8px')
 
         // set to compact density
         clickMenubarOptionsButton()
@@ -49,7 +49,7 @@ describe('options', () => {
         // assert compact density
         getTableDataCells()
             .invoke('css', 'padding')
-            .should('equal', '6px 2px 4px 6px')
+            .should('equal', '6px 6px 4px')
     })
 
     it('sets font size', () => {

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -16,9 +16,9 @@ import {
     TEST_DIM_NUMBER,
     TEST_DIM_PERCENTAGE,
     TEST_DIM_INTEGER,
-    TEST_DIM_POSITIVE_INTEGER,
-    TEST_DIM_NEGATIVE_INTEGER,
-    TEST_DIM_POSITIVE_OR_ZERO,
+    TEST_DIM_INTEGER_POSITIVE,
+    TEST_DIM_INTEGER_NEGATIVE,
+    TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
     TEST_DIM_YESNO,
     TEST_DIM_YESONLY,
     TEST_DIM_DATE,
@@ -28,6 +28,8 @@ import {
     TEST_DIM_ORG_UNIT,
     TEST_DIM_COORDINATE,
     TEST_DIM_LEGEND_SET,
+    TEST_DIM_NUMBER_OPTIONSET,
+    TEST_DIM_TEXT_OPTIONSET,
 } from '../data/index.js'
 import {
     selectEventWithProgram,
@@ -72,16 +74,16 @@ const programDimensions = [
     { label: TEST_DIM_EMAIL, value: 'email@address.com' },
     { label: TEST_DIM_INTEGER, value: '10' },
     { label: TEST_DIM_LONG_TEXT, value: 'Long text A' },
-    { label: TEST_DIM_NEGATIVE_INTEGER, value: '-10' },
+    { label: TEST_DIM_INTEGER_NEGATIVE, value: '-10' },
     { label: TEST_DIM_NUMBER, value: '10' },
     { label: TEST_DIM_LEGEND_SET, value: '10' },
     { label: TEST_DIM_ORG_UNIT, value: 'Ngelehun CHC' },
     { label: TEST_DIM_PERCENTAGE, value: '10' },
     { label: TEST_DIM_PHONE_NUMBER, value: '10111213' },
-    { label: TEST_DIM_POSITIVE_INTEGER, value: '10' },
-    { label: TEST_DIM_POSITIVE_OR_ZERO, value: '0' },
+    { label: TEST_DIM_INTEGER_POSITIVE, value: '10' },
+    { label: TEST_DIM_INTEGER_ZERO_OR_POSITIVE, value: '0' },
     { label: TEST_DIM_TEXT, value: 'Text A' },
-    { label: 'E2E - Text (option set)', value: 'COVID 19 - AstraZeneca' },
+    { label: TEST_DIM_TEXT_OPTIONSET, value: 'COVID 19 - AstraZeneca' },
     { label: TEST_DIM_TIME, value: '14:01' },
     { label: TEST_DIM_URL, value: 'https://debug.dhis2.org/tracker_dev/' },
     { label: TEST_DIM_USERNAME, value: 'admin' },
@@ -228,7 +230,7 @@ describe(['>=39', '<40'], 'table', () => {
     beforeEach(init)
     it('click on column header opens the dimension dialog', () => {
         programDimensions.push({
-            label: 'E2E - Number (option set)',
+            label: TEST_DIM_NUMBER_OPTIONSET,
             value: '1',
         })
         assertColumnHeaders()
@@ -248,7 +250,7 @@ describe(['>=40'], 'table', () => {
         })
         // bug: https://dhis2.atlassian.net/browse/DHIS2-13872
         programDimensions.push({
-            label: 'E2E - Number (option set)',
+            label: TEST_DIM_NUMBER_OPTIONSET,
             value: 'One',
         })
         assertColumnHeaders()

--- a/cypress/integration/value.cy.js
+++ b/cypress/integration/value.cy.js
@@ -62,7 +62,6 @@ describe('value', () => {
                 .invoke('css', 'white-space')
                 .should('equal', value)
 
-        console.log(getTableDataCells().all())
         ;[0, 1, 2, 3].forEach((index) => shouldHaveWhiteSpace(index, 'normal'))
         ;[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15].forEach((index) =>
             shouldHaveWhiteSpace(index, 'nowrap')

--- a/cypress/integration/value.cy.js
+++ b/cypress/integration/value.cy.js
@@ -20,31 +20,39 @@ import {
 import { selectEventWithProgramDimensions } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
+import { goToStartPage } from '../helpers/startScreen.js'
 import { getTableDataCells } from '../helpers/table.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 describe('value', () => {
-    beforeEach(() => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+    it('has the correct white-space css', () => {
+        goToStartPage()
+
+        const programDimensionsWithWrap = [
+            TEST_DIM_TEXT,
+            TEST_DIM_TEXT_OPTIONSET,
+            TEST_DIM_NUMBER_OPTIONSET,
+        ]
+        const programDimensionsWithoutWrap = [
+            TEST_DIM_NUMBER,
+            TEST_DIM_INTEGER,
+            TEST_DIM_INTEGER_POSITIVE,
+            TEST_DIM_INTEGER_NEGATIVE,
+            TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
+            TEST_DIM_PERCENTAGE,
+            TEST_DIM_UNIT_INTERVAL,
+            TEST_DIM_TIME,
+            TEST_DIM_DATE,
+            TEST_DIM_DATETIME,
+            TEST_DIM_PHONE_NUMBER,
+        ]
+        const programDimensions = [
+            ...programDimensionsWithWrap,
+            ...programDimensionsWithoutWrap,
+        ]
 
         selectEventWithProgramDimensions({
             programName: E2E_PROGRAM.programName,
-            dimensions: [
-                TEST_DIM_TEXT,
-                TEST_DIM_TEXT_OPTIONSET,
-                TEST_DIM_NUMBER_OPTIONSET,
-                TEST_DIM_NUMBER,
-                TEST_DIM_INTEGER,
-                TEST_DIM_INTEGER_POSITIVE,
-                TEST_DIM_INTEGER_NEGATIVE,
-                TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
-                TEST_DIM_PERCENTAGE,
-                TEST_DIM_UNIT_INTERVAL,
-                TEST_DIM_TIME,
-                TEST_DIM_DATE,
-                TEST_DIM_DATETIME,
-                TEST_DIM_PHONE_NUMBER,
-            ],
+            dimensions: programDimensions,
         })
 
         selectRelativePeriod({
@@ -53,18 +61,24 @@ describe('value', () => {
         })
 
         clickMenubarUpdateButton()
-    })
 
-    it('has the correct white-space css', () => {
         const shouldHaveWhiteSpace = (index, value) =>
             getTableDataCells()
                 .eq(index)
                 .invoke('css', 'white-space')
                 .should('equal', value)
 
-        ;[0, 1, 2, 3].forEach((index) => shouldHaveWhiteSpace(index, 'normal'))
-        ;[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15].forEach((index) =>
-            shouldHaveWhiteSpace(index, 'nowrap')
+        const dimensions = [
+            'Organisation unit name',
+            ...programDimensions,
+            E2E_PROGRAM[DIMENSION_ID_EVENT_DATE],
+        ]
+
+        programDimensionsWithWrap.forEach((dim) =>
+            shouldHaveWhiteSpace(dimensions.indexOf(dim), 'normal')
+        )
+        programDimensionsWithoutWrap.forEach((dim) =>
+            shouldHaveWhiteSpace(dimensions.indexOf(dim), 'nowrap')
         )
     })
 })

--- a/cypress/integration/value.cy.js
+++ b/cypress/integration/value.cy.js
@@ -1,0 +1,71 @@
+import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js'
+import {
+    E2E_PROGRAM,
+    TEST_DIM_TEXT,
+    TEST_DIM_TEXT_OPTIONSET,
+    TEST_DIM_NUMBER_OPTIONSET,
+    TEST_DIM_NUMBER,
+    TEST_DIM_INTEGER,
+    TEST_DIM_INTEGER_POSITIVE,
+    TEST_DIM_INTEGER_NEGATIVE,
+    TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
+    TEST_DIM_PERCENTAGE,
+    TEST_DIM_UNIT_INTERVAL,
+    TEST_DIM_TIME,
+    TEST_DIM_DATE,
+    TEST_DIM_DATETIME,
+    TEST_DIM_PHONE_NUMBER,
+    TEST_REL_PE_LAST_12_MONTHS,
+} from '../data/index.js'
+import { selectEventWithProgramDimensions } from '../helpers/dimensions.js'
+import { clickMenubarUpdateButton } from '../helpers/menubar.js'
+import { selectRelativePeriod } from '../helpers/period.js'
+import { getTableDataCells } from '../helpers/table.js'
+import { EXTENDED_TIMEOUT } from '../support/util.js'
+
+describe('value', () => {
+    beforeEach(() => {
+        cy.visit('/', EXTENDED_TIMEOUT)
+
+        selectEventWithProgramDimensions({
+            programName: E2E_PROGRAM.programName,
+            dimensions: [
+                TEST_DIM_TEXT,
+                TEST_DIM_TEXT_OPTIONSET,
+                TEST_DIM_NUMBER_OPTIONSET,
+                TEST_DIM_NUMBER,
+                TEST_DIM_INTEGER,
+                TEST_DIM_INTEGER_POSITIVE,
+                TEST_DIM_INTEGER_NEGATIVE,
+                TEST_DIM_INTEGER_ZERO_OR_POSITIVE,
+                TEST_DIM_PERCENTAGE,
+                TEST_DIM_UNIT_INTERVAL,
+                TEST_DIM_TIME,
+                TEST_DIM_DATE,
+                TEST_DIM_DATETIME,
+                TEST_DIM_PHONE_NUMBER,
+            ],
+        })
+
+        selectRelativePeriod({
+            label: E2E_PROGRAM[DIMENSION_ID_EVENT_DATE],
+            period: TEST_REL_PE_LAST_12_MONTHS,
+        })
+
+        clickMenubarUpdateButton()
+    })
+
+    it('has the correct white-space css', () => {
+        const shouldHaveWhiteSpace = (index, value) =>
+            getTableDataCells()
+                .eq(index)
+                .invoke('css', 'white-space')
+                .should('equal', value)
+
+        console.log(getTableDataCells().all())
+        ;[0, 1, 2, 3].forEach((index) => shouldHaveWhiteSpace(index, 'normal'))
+        ;[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15].forEach((index) =>
+            shouldHaveWhiteSpace(index, 'nowrap')
+        )
+    })
+})

--- a/cypress/integration/value.cy.js
+++ b/cypress/integration/value.cy.js
@@ -23,10 +23,14 @@ import { selectRelativePeriod } from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import { getTableDataCells } from '../helpers/table.js'
 
+const shouldHaveWhiteSpace = (index, value) =>
+    getTableDataCells()
+        .eq(index)
+        .invoke('css', 'white-space')
+        .should('equal', value)
+
 describe('value', () => {
     it('has the correct white-space css', () => {
-        goToStartPage()
-
         const programDimensionsWithWrap = [
             TEST_DIM_TEXT,
             TEST_DIM_TEXT_OPTIONSET,
@@ -50,6 +54,8 @@ describe('value', () => {
             ...programDimensionsWithoutWrap,
         ]
 
+        goToStartPage()
+
         selectEventWithProgramDimensions({
             programName: E2E_PROGRAM.programName,
             dimensions: programDimensions,
@@ -61,12 +67,6 @@ describe('value', () => {
         })
 
         clickMenubarUpdateButton()
-
-        const shouldHaveWhiteSpace = (index, value) =>
-            getTableDataCells()
-                .eq(index)
-                .invoke('css', 'white-space')
-                .should('equal', value)
 
         const dimensions = [
             'Organisation unit name',

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -3,6 +3,17 @@ import {
     LegendKey,
     LEGEND_DISPLAY_STYLE_FILL,
     LEGEND_DISPLAY_STYLE_TEXT,
+    VALUE_TYPE_NUMBER,
+    VALUE_TYPE_INTEGER,
+    VALUE_TYPE_INTEGER_POSITIVE,
+    VALUE_TYPE_INTEGER_NEGATIVE,
+    VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE,
+    VALUE_TYPE_PERCENTAGE,
+    VALUE_TYPE_UNIT_INTERVAL,
+    VALUE_TYPE_TIME,
+    VALUE_TYPE_DATE,
+    VALUE_TYPE_DATETIME,
+    VALUE_TYPE_PHONE_NUMBER,
     VALUE_TYPE_URL,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
@@ -165,6 +176,21 @@ export const Visualization = ({
         }
     }
 
+    const cellValueShouldNotWrap = (header) =>
+        [
+            VALUE_TYPE_NUMBER,
+            VALUE_TYPE_INTEGER,
+            VALUE_TYPE_INTEGER_POSITIVE,
+            VALUE_TYPE_INTEGER_NEGATIVE,
+            VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE,
+            VALUE_TYPE_PERCENTAGE,
+            VALUE_TYPE_UNIT_INTERVAL,
+            VALUE_TYPE_TIME,
+            VALUE_TYPE_DATE,
+            VALUE_TYPE_DATETIME,
+            VALUE_TYPE_PHONE_NUMBER,
+        ].includes(header.valueType) && !header.optionSet
+
     const formatCellHeader = (header) => {
         const headerText = getHeaderText(header)
 
@@ -267,6 +293,10 @@ export const Visualization = ({
                                             sizeClass,
                                             {
                                                 [styles.emptyCell]: !value,
+                                                [styles.nowrap]:
+                                                    cellValueShouldNotWrap(
+                                                        data.headers[index]
+                                                    ),
                                             },
                                             'bordered'
                                         )}

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -83,7 +83,7 @@
     padding: 8px 4px 6px 8px;
 }
 .dataTable .headerCell.sizeNormal {
-    padding: 4px 2px 2px 6px;
+    padding: 4px 4px 2px 6px;
 }
 .dataTable .headerCell.sizeCompact {
     padding: 3px 1px 1px 6px;
@@ -106,7 +106,7 @@
     padding: 10px 4px 8px 8px;
 }
 .dataTable .cell.sizeNormal {
-    padding: 8px 2px 6px 6px;
+    padding: 8px 6px 6px 6px;
 }
 .dataTable .cell.sizeCompact {
     padding: 6px 2px 4px 6px;
@@ -115,6 +115,10 @@
 /* Empty cell */
 .dataTable .emptyCell::after {
     content: '\00a0';
+}
+
+.dataTable .cell.nowrap {
+    white-space: nowrap;
 }
 
 /* Sizes for the table footer */

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -103,10 +103,10 @@
     line-height: 12px;
 }
 .dataTable .cell.sizeComfortable {
-    padding: 10px 8px 8px 8px;
+    padding: 10px 8px 8px;
 }
 .dataTable .cell.sizeNormal {
-    padding: 8px 6px 6px 6px;
+    padding: 8px 6px 6px;
 }
 .dataTable .cell.sizeCompact {
     padding: 6px 6px 4px 6px;

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -109,7 +109,7 @@
     padding: 8px 6px 6px;
 }
 .dataTable .cell.sizeCompact {
-    padding: 6px 6px 4px 6px;
+    padding: 6px 6px 4px;
 }
 
 /* Empty cell */

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -86,7 +86,7 @@
     padding: 4px 4px 2px 6px;
 }
 .dataTable .headerCell.sizeCompact {
-    padding: 3px 1px 1px 6px;
+    padding: 3px 2px 1px 6px;
 }
 
 /* Table body cells in various sizes */
@@ -103,13 +103,13 @@
     line-height: 12px;
 }
 .dataTable .cell.sizeComfortable {
-    padding: 10px 4px 8px 8px;
+    padding: 10px 8px 8px 8px;
 }
 .dataTable .cell.sizeNormal {
     padding: 8px 6px 6px 6px;
 }
 .dataTable .cell.sizeCompact {
-    padding: 6px 2px 4px 6px;
+    padding: 6px 6px 4px 6px;
 }
 
 /* Empty cell */


### PR DESCRIPTION
Implements [DHIS2-13899](https://dhis2.atlassian.net/browse/DHIS2-13899)

- Adds `white-space: nowrap` to cells according to ticket description.
- Adds a few test dims.
- Renames a few test dims to match value type name.
- Makes a very small change to display density (right padding) due to the nowrap css, very rarly visible to the user (ref https://dhis2.atlassian.net/browse/DHIS2-14303)

- [x] Add cypress test

Before:
![Screenshot from 2022-12-29 11-37-26](https://user-images.githubusercontent.com/1010094/209939699-f2ae7bb1-811b-4555-ba37-521d99261847.png)

After:
![Screenshot from 2022-12-29 11-37-22](https://user-images.githubusercontent.com/1010094/209939724-98a7bd61-28e6-48d7-8b85-f0fcbfd81c2d.png)
