### PR TITLE
fix: adjust dimension item context menu placement [DHIS2-13927]

### DIFF
--- a/src/components/MainSidebar/DimensionItem/DimensionItemBase.module.css
+++ b/src/components/MainSidebar/DimensionItem/DimensionItemBase.module.css
@@ -3,7 +3,8 @@
     color: var(--colors-grey900);
     fill: var(--colors-grey800);
     display: flex;
-    padding: 2px var(--spacers-dp8);
+    justify-content: space-between;
+    padding: 2px var(--spacers-dp4) 2px var(--spacers-dp8);
     margin: 0;
     border-radius: 3px;
     cursor: pointer;


### PR DESCRIPTION
Implements [DHIS2-13927](https://dhis2.atlassian.net/browse/DHIS2-13927)

---

### Description

Adjusts position of context menu icon button in dimension items.

---

### Screenshots

**Before**:
![image](https://user-images.githubusercontent.com/33054985/210224206-627b7a2d-bbfa-415a-9a19-5c223284859f.png)

**After**:
![image](https://user-images.githubusercontent.com/33054985/210224243-5c51f89c-d7e8-46eb-8af5-8e38fdbe17bd.png)

