### PR TITLE
test: updates for new year

### DIFF
--- a/cypress/data/index.js
+++ b/cypress/data/index.js
@@ -82,11 +82,6 @@ export const TEST_REL_PE_LAST_YEAR = {
     name: 'Last year',
 }
 
-export const TEST_REL_PE_LAST_12_MONTHS = {
-    //type: 'Months',
-    name: 'Last 12 months',
-}
-
 export const TEST_FIX_PE_DEC_LAST_YEAR = {
     //type: 'Monthly',
     year: `${getPreviousYearStr()}`,

--- a/cypress/integration/conditions/alphanumericConditions.cy.js
+++ b/cypress/integration/conditions/alphanumericConditions.cy.js
@@ -20,7 +20,10 @@ import {
     assertTooltipContainsEntries,
 } from '../../helpers/layout.js'
 import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
-import { selectRelativePeriod } from '../../helpers/period.js'
+import {
+    getCurrentYearStr,
+    selectRelativePeriod,
+} from '../../helpers/period.js'
 import { goToStartPage } from '../../helpers/startScreen.js'
 import {
     expectTableToBeVisible,
@@ -32,6 +35,7 @@ const event = E2E_PROGRAM
 const dimensionName = TEST_DIM_TEXT
 const periodLabel = event[DIMENSION_ID_EVENT_DATE]
 const stageName = 'Stage 1 - Repeatable'
+const currentYear = getCurrentYearStr()
 
 const setUpTable = () => {
     selectEventWithProgramDimensions({ ...event, dimensions: [dimensionName] })
@@ -102,8 +106,8 @@ describe('text conditions', () => {
             LONG_TEXT,
             '9000000',
             'Text A-2',
-            '2022-03-01',
-            '2022-02-01',
+            `${currentYear}-03-01`, // empty row, use value in date column
+            `${currentYear}-02-01`, // empty row, use value in date column
             'Text E',
         ])
 
@@ -157,7 +161,11 @@ describe('text conditions', () => {
             },
         ])
 
-        expectTableToMatchRows(['2022-03-01', '2022-02-01', '9000000'])
+        expectTableToMatchRows([
+            `${currentYear}-03-01`, // empty row, use value in date column
+            `${currentYear}-02-01`, // empty row, use value in date column
+            '9000000',
+        ])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -174,7 +182,7 @@ describe('text conditions', () => {
             },
         ])
 
-        expectTableToMatchRows(['2022-03-01', '2022-02-01'])
+        expectTableToMatchRows([`${currentYear}-03-01`, `${currentYear}-02-01`]) // empty row, use value in date column
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 

--- a/cypress/integration/conditions/dateConditions.cy.js
+++ b/cypress/integration/conditions/dateConditions.cy.js
@@ -4,8 +4,8 @@ import {
     TEST_DIM_DATETIME,
     TEST_DIM_DATE,
     TEST_DIM_TIME,
-    TEST_REL_PE_LAST_12_MONTHS,
     TEST_REL_PE_THIS_YEAR,
+    TEST_FIX_PE_DEC_LAST_YEAR,
 } from '../../data/index.js'
 import {
     openDimension,
@@ -20,7 +20,6 @@ import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
 import {
     selectRelativePeriod,
     getPreviousYearStr,
-    getCurrentYearStr,
     unselectAllPeriods,
     selectFixedPeriod,
 } from '../../helpers/period.js'
@@ -31,7 +30,6 @@ import {
     expectTableToMatchRows,
 } from '../../helpers/table.js'
 
-const currentYear = getCurrentYearStr()
 const previousYear = getPreviousYearStr()
 
 const trackerProgram = E2E_PROGRAM
@@ -45,9 +43,9 @@ const setUpTable = () => {
         dimensions: [dimensionName],
     })
 
-    selectRelativePeriod({
+    selectFixedPeriod({
         label: periodLabel,
-        period: TEST_REL_PE_LAST_12_MONTHS,
+        period: TEST_FIX_PE_DEC_LAST_YEAR,
     })
 
     clickMenubarUpdateButton()
@@ -77,7 +75,7 @@ describe('date conditions (Date)', () => {
     })
 
     it('exactly', () => {
-        const TEST_DATE = `${previousYear}-12-01`
+        const TEST_DATE = '1991-05-21'
 
         addConditions([
             {
@@ -94,25 +92,7 @@ describe('date conditions (Date)', () => {
     })
 
     it('is not', () => {
-        unselectAllPeriods({
-            label: periodLabel,
-        })
-        selectFixedPeriod({
-            label: periodLabel,
-            period: {
-                year: currentYear,
-                name: `January ${currentYear}`,
-            },
-        })
-        selectFixedPeriod({
-            label: periodLabel,
-            period: {
-                year: currentYear,
-                name: `February ${currentYear}`,
-            },
-        })
-
-        const TEST_DATE = `${currentYear}-01-02`
+        const TEST_DATE = '1991-05-20'
 
         addConditions([
             {
@@ -121,7 +101,7 @@ describe('date conditions (Date)', () => {
             },
         ])
 
-        expectTableToMatchRows([`${currentYear}-01-01`, `${currentYear}-02-01`])
+        expectTableToMatchRows(['1991-05-21', '1991-12-01', '1991-12-02'])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -129,7 +109,7 @@ describe('date conditions (Date)', () => {
     })
 
     it('after', () => {
-        const TEST_DATE = `${previousYear}-12-02`
+        const TEST_DATE = '1991-05-21'
 
         addConditions([
             {
@@ -138,7 +118,7 @@ describe('date conditions (Date)', () => {
             },
         ])
 
-        expectTableToMatchRows([`${currentYear}-01-01`, `${currentYear}-01-03`])
+        expectTableToMatchRows(['1991-12-01', '1991-12-02'])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -146,7 +126,7 @@ describe('date conditions (Date)', () => {
     })
 
     it('after or including', () => {
-        const TEST_DATE = `${previousYear}-12-02`
+        const TEST_DATE = '1991-05-21'
 
         addConditions([
             {
@@ -155,11 +135,7 @@ describe('date conditions (Date)', () => {
             },
         ])
 
-        expectTableToMatchRows([
-            `${previousYear}-12-11`,
-            `${currentYear}-01-01`,
-            `${currentYear}-01-03`,
-        ])
+        expectTableToMatchRows(['1991-05-21', '1991-12-01', '1991-12-02'])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -170,7 +146,7 @@ describe('date conditions (Date)', () => {
     })
 
     it('before', () => {
-        const TEST_DATE = `${previousYear}-12-02`
+        const TEST_DATE = '1991-12-02'
 
         addConditions([
             {
@@ -179,14 +155,7 @@ describe('date conditions (Date)', () => {
             },
         ])
 
-        expectTableToMatchRows([
-            `${previousYear}-12-10`,
-            `${previousYear}-12-22`,
-            `${previousYear}-12-23`,
-            `${currentYear}-04-19`,
-            `${currentYear}-02-01`,
-            `${currentYear}-03-01`,
-        ])
+        expectTableToMatchRows(['1991-05-20', '1991-05-21', '1991-12-01'])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -194,7 +163,7 @@ describe('date conditions (Date)', () => {
     })
 
     it('before or including', () => {
-        const TEST_DATE = `${previousYear}-12-02`
+        const TEST_DATE = '1991-05-21'
 
         addConditions([
             {
@@ -203,15 +172,7 @@ describe('date conditions (Date)', () => {
             },
         ])
 
-        expectTableToMatchRows([
-            `${previousYear}-12-11`,
-            `${previousYear}-12-10`,
-            `${previousYear}-12-22`,
-            `${previousYear}-12-23`,
-            `${currentYear}-04-19`,
-            `${currentYear}-02-01`,
-            `${currentYear}-03-01`,
-        ])
+        expectTableToMatchRows(['1991-05-20', '1991-05-21'])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -222,13 +183,24 @@ describe('date conditions (Date)', () => {
     })
 
     it('is empty / null', () => {
+        unselectAllPeriods({ label: periodLabel })
+
+        selectFixedPeriod({
+            label: periodLabel,
+            period: {
+                type: 'Yearly',
+                year: previousYear,
+                name: previousYear,
+            },
+        })
+
         addConditions([
             {
                 conditionName: 'is empty / null',
             },
         ])
 
-        expectTableToMatchRows([`${currentYear}-01-01`, `${currentYear}-03-01`])
+        expectTableToMatchRows([`${previousYear}-01-02`])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -236,6 +208,17 @@ describe('date conditions (Date)', () => {
     })
 
     it('is not empty / not null', () => {
+        unselectAllPeriods({ label: periodLabel })
+
+        selectFixedPeriod({
+            label: periodLabel,
+            period: {
+                type: 'Yearly',
+                year: previousYear,
+                name: previousYear,
+            },
+        })
+
         addConditions([
             {
                 conditionName: 'is not empty / not null',
@@ -243,15 +226,12 @@ describe('date conditions (Date)', () => {
         ])
 
         expectTableToMatchRows([
-            `${previousYear}-12-11`,
-            `${previousYear}-12-10`,
-            `${previousYear}-12-22`,
-            `${previousYear}-12-23`,
-            `${currentYear}-04-19`,
-            `${currentYear}-01-01`,
-            `${currentYear}-01-03`,
-            `${currentYear}-02-01`,
-            `${currentYear}-03-01`,
+            '1990-07-17',
+            '1990-11-12',
+            '1991-12-01',
+            '1991-12-02',
+            '1991-05-20',
+            '1991-05-21',
         ])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
@@ -260,8 +240,8 @@ describe('date conditions (Date)', () => {
     })
 
     it('2 conditions: after + before or including', () => {
-        const TEST_DATE_BFI = `${previousYear}-12-02`
-        const TEST_DATE_AFT = `${previousYear}-12-01`
+        const TEST_DATE_AFT = '1991-05-20'
+        const TEST_DATE_BFI = '1991-12-01'
 
         addConditions([
             {
@@ -274,7 +254,7 @@ describe('date conditions (Date)', () => {
             },
         ])
 
-        expectTableToMatchRows([`${previousYear}-12-11`])
+        expectTableToMatchRows(['1991-05-21', '1991-12-01'])
 
         assertChipContainsText(`${dimensionName}: 2 conditions`)
 

--- a/cypress/integration/conditions/numericConditions.cy.js
+++ b/cypress/integration/conditions/numericConditions.cy.js
@@ -24,6 +24,7 @@ import {
 import { clickMenubarUpdateButton } from '../../helpers/menubar.js'
 import {
     getPreviousYearStr,
+    getCurrentYearStr,
     selectRelativePeriod,
 } from '../../helpers/period.js'
 import { goToStartPage } from '../../helpers/startScreen.js'
@@ -36,6 +37,7 @@ import {
 } from '../../helpers/table.js'
 
 const previousYear = getPreviousYearStr()
+const currentYear = getCurrentYearStr()
 
 const event = E2E_PROGRAM
 const periodLabel = event[DIMENSION_ID_EVENT_DATE]
@@ -163,7 +165,7 @@ describe('number conditions', () => {
         expectTableToMatchRows([
             '3.7',
             '11',
-            '2022-01-01', // the empty row
+            `${currentYear}-01-01`, // empty row, use value in date column
             '2 000 000',
             '5 557 779 990',
             '5 123 123',

--- a/cypress/integration/download.cy.js
+++ b/cypress/integration/download.cy.js
@@ -2,7 +2,7 @@ import {
     DIMENSION_ID_ENROLLMENT_DATE,
     DIMENSION_ID_EVENT_DATE,
 } from '../../src/modules/dimensionConstants.js'
-import { E2E_PROGRAM, TEST_REL_PE_LAST_12_MONTHS } from '../data/index.js'
+import { E2E_PROGRAM, TEST_REL_PE_LAST_YEAR } from '../data/index.js'
 import {
     selectEnrollmentProgram,
     selectEventWithProgram,
@@ -41,7 +41,7 @@ describe('download', () => {
 
         selectRelativePeriod({
             label: E2E_PROGRAM[DIMENSION_ID_EVENT_DATE],
-            period: TEST_REL_PE_LAST_12_MONTHS,
+            period: TEST_REL_PE_LAST_YEAR,
         })
 
         clickMenubarUpdateButton()
@@ -64,7 +64,7 @@ describe('download', () => {
 
         selectRelativePeriod({
             label: E2E_PROGRAM[DIMENSION_ID_ENROLLMENT_DATE],
-            period: TEST_REL_PE_LAST_12_MONTHS,
+            period: TEST_REL_PE_LAST_YEAR,
         })
 
         clickMenubarUpdateButton()

--- a/cypress/integration/eventStatus.cy.js
+++ b/cypress/integration/eventStatus.cy.js
@@ -1,15 +1,15 @@
 import {
     DIMENSION_ID_SCHEDULED_DATE,
-    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_EVENT_DATE,
 } from '../../src/modules/dimensionConstants.js'
-import { E2E_PROGRAM, TEST_REL_PE_THIS_YEAR } from '../data/index.js'
+import { E2E_PROGRAM } from '../data/index.js'
 import { selectEventWithProgram } from '../helpers/dimensions.js'
 import {
     assertChipContainsText,
     assertTooltipContainsEntries,
 } from '../helpers/layout.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
-import { selectRelativePeriod, getCurrentYearStr } from '../helpers/period.js'
+import { getCurrentYearStr, selectFixedPeriod } from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableHeaderCells,
@@ -17,19 +17,16 @@ import {
     expectTableToMatchRows,
 } from '../helpers/table.js'
 
+const currentYear = getCurrentYearStr()
+
 describe('event status', () => {
     const event = E2E_PROGRAM
     const dimensionName = 'Event status'
 
-    const setUpTable = (periodLabel) => {
+    const setUpTable = () => {
         goToStartPage()
 
         selectEventWithProgram(event)
-
-        selectRelativePeriod({
-            label: periodLabel,
-            period: TEST_REL_PE_THIS_YEAR,
-        })
 
         cy.getBySel('main-sidebar')
             .contains(dimensionName)
@@ -39,22 +36,52 @@ describe('event status', () => {
             .click()
 
         cy.contains('Add to Columns').click()
+    }
+
+    it(['>=39'], 'can be filtered by status SCHEDULED', () => {
+        setUpTable()
+
+        selectFixedPeriod({
+            label: event[DIMENSION_ID_SCHEDULED_DATE],
+            period: {
+                year: currentYear,
+                name: `January ${currentYear}`,
+            },
+        })
+
+        selectFixedPeriod({
+            label: event[DIMENSION_ID_SCHEDULED_DATE],
+            period: {
+                year: currentYear,
+                name: `February ${currentYear}`,
+            },
+        })
+
+        selectFixedPeriod({
+            label: event[DIMENSION_ID_SCHEDULED_DATE],
+            period: {
+                year: currentYear,
+                name: `December ${currentYear}`,
+            },
+        })
 
         clickMenubarUpdateButton()
 
         expectTableToBeVisible()
-    }
-
-    it(['>=39'], 'can be filtered by status SCHEDULED', () => {
-        setUpTable(event[DIMENSION_ID_SCHEDULED_DATE])
 
         expectTableToMatchRows([
             'Completed',
-            'Completed',
-            'Completed',
-            'Completed',
-            'Completed',
             'Active',
+            'Completed',
+            'Completed',
+            'Scheduled',
+        ])
+        expectTableToMatchRows([
+            `${currentYear}-01-03`,
+            `${currentYear}-02-01`,
+            `${currentYear}-01-01`,
+            `${currentYear}-01-01`,
+            `${currentYear}-12-25`,
         ])
 
         getTableHeaderCells().contains(dimensionName).should('be.visible')
@@ -78,7 +105,8 @@ describe('event status', () => {
 
         expectTableToBeVisible()
 
-        expectTableToMatchRows([`${getCurrentYearStr()}-02-01`])
+        expectTableToMatchRows([`${currentYear}-02-01`])
+        expectTableToMatchRows(['Active'])
 
         assertChipContainsText(`${dimensionName}: 1 selected`)
 
@@ -98,9 +126,8 @@ describe('event status', () => {
 
         expectTableToBeVisible()
 
-        expectTableToMatchRows([`${getCurrentYearStr()}-02-01`])
-
-        expectTableToMatchRows(['Active'])
+        expectTableToMatchRows([`${currentYear}-02-01`, `${currentYear}-12-25`])
+        expectTableToMatchRows(['Active', 'Scheduled'])
 
         assertChipContainsText(`${dimensionName}: 2 selected`)
 
@@ -108,9 +135,42 @@ describe('event status', () => {
     })
 
     it('can be filtered by status ACTIVE', () => {
-        setUpTable(event[DIMENSION_ID_LAST_UPDATED])
+        setUpTable()
 
-        // TODO determine expected once 2.38analytics_dev is available
+        selectFixedPeriod({
+            label: event[DIMENSION_ID_EVENT_DATE],
+            period: {
+                year: currentYear,
+                name: `January ${currentYear}`,
+            },
+        })
+
+        selectFixedPeriod({
+            label: event[DIMENSION_ID_EVENT_DATE],
+            period: {
+                year: currentYear,
+                name: `February ${currentYear}`,
+            },
+        })
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        expectTableToMatchRows([
+            'Completed',
+            'Active',
+            'Completed',
+            'Completed',
+        ])
+        expectTableToMatchRows([
+            `${currentYear}-01-03`,
+            `${currentYear}-02-01`,
+            `${currentYear}-01-01`,
+            `${currentYear}-01-01`,
+        ])
+
+        // TODO: determine expected once 2.38analytics_dev is available
         // expectTableToMatchRows(['Active', 'Completed', 'Completed'])
 
         getTableHeaderCells().contains(dimensionName).should('be.visible')
@@ -134,7 +194,8 @@ describe('event status', () => {
 
         expectTableToBeVisible()
 
-        expectTableToMatchRows([`${getCurrentYearStr()}-11-18`])
+        expectTableToMatchRows([`${currentYear}-02-01`])
+        expectTableToMatchRows(['Active'])
 
         assertChipContainsText(`${dimensionName}: 1 selected`)
 

--- a/cypress/integration/eventStatus.cy.js
+++ b/cypress/integration/eventStatus.cy.js
@@ -38,7 +38,8 @@ describe('event status', () => {
         cy.contains('Add to Columns').click()
     }
 
-    it(['>=39'], 'can be filtered by status SCHEDULED', () => {
+    // FIXME: Skipped as it's blocked by this backend bug: https://dhis2.atlassian.net/browse/DHIS2-14442
+    it.skip(['>=39'], 'can be filtered by status SCHEDULED', () => {
         setUpTable()
 
         selectFixedPeriod({

--- a/cypress/integration/layoutValidation.cy.js
+++ b/cypress/integration/layoutValidation.cy.js
@@ -1,5 +1,5 @@
 import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js'
-import { CHILD_PROGRAM, TEST_REL_PE_LAST_12_MONTHS } from '../data/index.js'
+import { CHILD_PROGRAM, TEST_REL_PE_LAST_YEAR } from '../data/index.js'
 import { selectEventWithProgram } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
 import { selectRelativePeriod } from '../helpers/period.js'
@@ -72,7 +72,7 @@ describe('layout validation', () => {
         // add a time dimension to columns
         selectRelativePeriod({
             label: trackerProgram[DIMENSION_ID_EVENT_DATE],
-            period: TEST_REL_PE_LAST_12_MONTHS,
+            period: TEST_REL_PE_LAST_YEAR,
         })
 
         clickMenubarUpdateButton()

--- a/cypress/integration/legendSet.cy.js
+++ b/cypress/integration/legendSet.cy.js
@@ -363,8 +363,8 @@ describe(['>=39'], 'Options - Legend', () => {
             },
         })
 
-        getTableRows()
-            .eq(1)
+        getTableRows() // the first row should be empty and not have the legend background color
+            .eq(0)
             .find('td')
             .eq(2)
             .should('have.css', 'background-color', defaultBackgroundColor)
@@ -372,8 +372,8 @@ describe(['>=39'], 'Options - Legend', () => {
             .invoke('trim')
             .should('equal', '')
 
-        getTableRows()
-            .eq(2)
+        getTableRows() // the second row should not be empty and have the legend background color
+            .eq(1)
             .find('td')
             .eq(2)
             .should('not.have.css', 'background-color', defaultBackgroundColor)

--- a/cypress/integration/options.cy.js
+++ b/cypress/integration/options.cy.js
@@ -1,20 +1,21 @@
-import { DIMENSION_ID_ENROLLMENT_DATE } from '../../src/modules/dimensionConstants.js'
+import { DIMENSION_ID_EVENT_DATE } from '../../src/modules/dimensionConstants.js'
 import {
     E2E_PROGRAM,
     TEST_AO,
     TEST_DIM_PHONE_NUMBER,
     TEST_DIM_INTEGER,
-    TEST_REL_PE_THIS_YEAR,
 } from '../data/index.js'
 import { goToAO } from '../helpers/common.js'
-import { selectEnrollmentProgramDimensions } from '../helpers/dimensions.js'
+import { selectEventWithProgramDimensions } from '../helpers/dimensions.js'
 import {
     clickMenubarOptionsButton,
     clickMenubarUpdateButton,
 } from '../helpers/menubar.js'
-import { selectRelativePeriod } from '../helpers/period.js'
+import { getCurrentYearStr, selectFixedPeriod } from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import { getTableDataCells, getTableRows } from '../helpers/table.js'
+
+const currentYear = getCurrentYearStr()
 
 describe('options', () => {
     it('sets display density', () => {
@@ -96,14 +97,17 @@ describe('options', () => {
         goToStartPage()
 
         // set up table
-        selectEnrollmentProgramDimensions({
+        selectEventWithProgramDimensions({
             ...E2E_PROGRAM,
             dimensions: [TEST_DIM_PHONE_NUMBER, TEST_DIM_INTEGER],
         })
 
-        selectRelativePeriod({
-            label: E2E_PROGRAM[DIMENSION_ID_ENROLLMENT_DATE],
-            period: TEST_REL_PE_THIS_YEAR,
+        selectFixedPeriod({
+            label: E2E_PROGRAM[DIMENSION_ID_EVENT_DATE],
+            period: {
+                year: currentYear,
+                name: `April ${currentYear}`,
+            },
         })
 
         clickMenubarUpdateButton()

--- a/cypress/integration/repeatedEvents.cy.js
+++ b/cypress/integration/repeatedEvents.cy.js
@@ -211,7 +211,7 @@ describe('repeated events', () => {
         getRepeatedEventsTab().should('not.exist')
     })
     it('repetition is not disabled after loading a saved vis with cross-stage data element', () => {
-        goToAO('Y6N29ifTfn2')
+        goToAO('WrIV7ZoYECj')
 
         cy.getBySel('visualization-title').contains(
             'E2E: Enrollment - Last 12 months - Hemoglobin (repeated)'

--- a/cypress/integration/repeatedEvents.cy.js
+++ b/cypress/integration/repeatedEvents.cy.js
@@ -214,7 +214,7 @@ describe('repeated events', () => {
         goToAO('WrIV7ZoYECj')
 
         cy.getBySel('visualization-title').contains(
-            'E2E: Enrollment - Last 12 months - Hemoglobin (repeated)'
+            'E2E: Enrollment - Hemoglobin (repeated)'
         )
 
         cy.getBySel('columns-axis').contains('WHOMCH Hemoglobin value').click()

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -36,7 +36,11 @@ import {
     selectEventWithProgramDimensions,
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
-import { selectFixedPeriod, getPreviousYearStr } from '../helpers/period.js'
+import {
+    selectFixedPeriod,
+    getPreviousYearStr,
+    getCurrentYearStr,
+} from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableRows,
@@ -48,6 +52,8 @@ import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const trackerProgram = E2E_PROGRAM
 const periodLabel = trackerProgram[DIMENSION_ID_EVENT_DATE]
+const currentYear = getCurrentYearStr()
+const previousYear = getPreviousYearStr()
 
 const mainAndTimeDimensions = [
     { label: 'Organisation unit', value: 'Baoma Station CHP' },
@@ -55,22 +61,28 @@ const mainAndTimeDimensions = [
     { label: 'Program status', value: 'Active' },
     { label: 'Created by', value: 'Traore, John (admin)' },
     { label: 'Last updated by', value: 'Traore, John (admin)' },
-    { label: trackerProgram[DIMENSION_ID_EVENT_DATE], value: '2021-12-10' },
+    {
+        label: trackerProgram[DIMENSION_ID_EVENT_DATE],
+        value: `${previousYear}-12-10`,
+    },
     {
         label: trackerProgram[DIMENSION_ID_ENROLLMENT_DATE],
-        value: '2022-01-18',
+        value: `${currentYear}-01-18`,
     },
-    { label: trackerProgram[DIMENSION_ID_INCIDENT_DATE], value: '2022-01-10' },
+    {
+        label: trackerProgram[DIMENSION_ID_INCIDENT_DATE],
+        value: `${currentYear}-01-10`,
+    },
     {
         label: trackerProgram[DIMENSION_ID_LAST_UPDATED],
-        value: '2022-11-18 03:19',
+        value: `${currentYear}-01-04 02:04`,
     },
 ]
 const programDimensions = [
-    { label: TEST_DIM_AGE, value: '2021-01-01' },
+    { label: TEST_DIM_AGE, value: '1991-01-01' },
     { label: TEST_DIM_COORDINATE, value: '[-0.090380,51.538034]' },
-    { label: TEST_DIM_DATE, value: '2021-12-01' },
-    { label: TEST_DIM_DATETIME, value: '2021-12-01 12:00' },
+    { label: TEST_DIM_DATE, value: '1991-12-01' },
+    { label: TEST_DIM_DATETIME, value: '1991-12-01 12:00' },
     { label: TEST_DIM_EMAIL, value: 'email@address.com' },
     { label: TEST_DIM_INTEGER, value: '10' },
     { label: TEST_DIM_LONG_TEXT, value: 'Long text A' },
@@ -246,7 +258,7 @@ describe(['>=40'], 'table', () => {
         // feat: https://dhis2.atlassian.net/browse/DHIS2-11192
         mainAndTimeDimensions.push({
             label: trackerProgram[DIMENSION_ID_SCHEDULED_DATE],
-            value: '2021-12-10',
+            value: `${previousYear}-12-10`,
         })
         // bug: https://dhis2.atlassian.net/browse/DHIS2-13872
         programDimensions.push({

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -75,7 +75,7 @@ const mainAndTimeDimensions = [
     },
     {
         label: trackerProgram[DIMENSION_ID_LAST_UPDATED],
-        value: `${currentYear}-01-04 02:04`,
+        value: '2023-01-04 02:04',
     },
 ]
 const programDimensions = [

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -25,7 +25,7 @@ const timeDimensions = [
     { id: DIMENSION_ID_EVENT_DATE, rowsLength: 7 },
     { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 12 },
     { id: DIMENSION_ID_INCIDENT_DATE, rowsLength: 12 },
-    { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 14 },
+    { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 11 },
 ]
 
 const assertTimeDimension = (dimension) => {

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -21,12 +21,15 @@ import {
 } from '../helpers/table.js'
 
 const trackerProgram = E2E_PROGRAM
+
+// Note: The rowsLengths needs to be updated when events are changed or added to the database
 const timeDimensions = [
     { id: DIMENSION_ID_EVENT_DATE, rowsLength: 7 },
-    { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 12 },
-    { id: DIMENSION_ID_INCIDENT_DATE, rowsLength: 12 },
-    { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 11 },
+    { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 13 },
+    { id: DIMENSION_ID_INCIDENT_DATE, rowsLength: 13 },
+    { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 12 },
 ]
+const scheduleDateDimension = { id: DIMENSION_ID_SCHEDULED_DATE, rowsLength: 7 }
 
 const assertTimeDimension = (dimension) => {
     it(`${dimension.id} shows the correct title in layout and table header`, () => {
@@ -70,11 +73,9 @@ describe(['>=39'], 'time dimensions', () => {
         goToStartPage()
     })
 
-    timeDimensions
-        .concat([{ id: DIMENSION_ID_SCHEDULED_DATE, rowsLength: 6 }])
-        .forEach((dimension) => {
-            assertTimeDimension(dimension)
-        })
+    timeDimensions.concat([scheduleDateDimension]).forEach((dimension) => {
+        assertTimeDimension(dimension)
+    })
 
     it('scheduled date disabled state is set based on stage setting ', () => {
         const scheduleDateHasTooltip = (tooltip) => {

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -22,15 +22,6 @@ import {
 
 const trackerProgram = E2E_PROGRAM
 
-// Note: The rowsLengths needs to be updated when events are changed or added to the database
-const timeDimensions = [
-    { id: DIMENSION_ID_EVENT_DATE, rowsLength: 7 },
-    { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 13 },
-    { id: DIMENSION_ID_INCIDENT_DATE, rowsLength: 13 },
-    { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 12 },
-]
-const scheduleDateDimension = { id: DIMENSION_ID_SCHEDULED_DATE, rowsLength: 7 }
-
 const assertTimeDimension = (dimension) => {
     it(`${dimension.id} shows the correct title in layout and table header`, () => {
         selectEventWithProgram(trackerProgram)
@@ -63,6 +54,14 @@ describe(['>37', '<39'], 'time dimensions', () => {
         goToStartPage()
     })
 
+    // Note: The rowsLengths needs to be updated when events are changed or added to the database
+    const timeDimensions = [
+        { id: DIMENSION_ID_EVENT_DATE, rowsLength: 7 },
+        { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 12 },
+        { id: DIMENSION_ID_INCIDENT_DATE, rowsLength: 12 },
+        { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 11 },
+    ]
+
     timeDimensions.forEach((dimension) => {
         assertTimeDimension(dimension)
     })
@@ -73,7 +72,16 @@ describe(['>=39'], 'time dimensions', () => {
         goToStartPage()
     })
 
-    timeDimensions.concat([scheduleDateDimension]).forEach((dimension) => {
+    // Note: The rowsLengths needs to be updated when events are changed or added to the database
+    const timeDimensions = [
+        { id: DIMENSION_ID_EVENT_DATE, rowsLength: 7 },
+        { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 13 },
+        { id: DIMENSION_ID_INCIDENT_DATE, rowsLength: 13 },
+        { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 12 },
+        { id: DIMENSION_ID_SCHEDULED_DATE, rowsLength: 7 },
+    ]
+
+    timeDimensions.forEach((dimension) => {
         assertTimeDimension(dimension)
     })
 

--- a/cypress/integration/value.cy.js
+++ b/cypress/integration/value.cy.js
@@ -15,7 +15,7 @@ import {
     TEST_DIM_DATE,
     TEST_DIM_DATETIME,
     TEST_DIM_PHONE_NUMBER,
-    TEST_REL_PE_LAST_12_MONTHS,
+    TEST_REL_PE_LAST_YEAR,
 } from '../data/index.js'
 import { selectEventWithProgramDimensions } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
@@ -63,7 +63,7 @@ describe('value', () => {
 
         selectRelativePeriod({
             label: E2E_PROGRAM[DIMENSION_ID_EVENT_DATE],
-            period: TEST_REL_PE_LAST_12_MONTHS,
+            period: TEST_REL_PE_LAST_YEAR,
         })
 
         clickMenubarUpdateButton()


### PR DESCRIPTION
1. Removes all hardcoded references to 2021 and 2022 (replaced by "previous year" and "current year")
2. Removes all references to "Last 12 months" (as this will change over the course of the year)
3. Updates `AGE`, `DATE` and `DATETIME` values from `202x` to `199x` (clear distinction between these data values and actual periods that are bumped each new year)
5. A new `scheduled` event was added to the database for testing
   a. Fixed the test for scheduled events, but it's now skipped due to a backend bug, [DHIS2-14442](https://dhis2.atlassian.net/browse/DHIS2-14442)
   b.  Test were updated in various places to account for the new event

[DHIS2-14442]: https://dhis2.atlassian.net/browse/DHIS2-14442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ