### PR TITLE
fix: do not pre-set program stage for enrollment DHIS2-14396

### DIFF
--- a/cypress/integration/createEnrollment.cy.js
+++ b/cypress/integration/createEnrollment.cy.js
@@ -64,9 +64,7 @@ const setUpTable = ({ scheduledDateIsSupported } = {}) => {
     // check that the time dimensions disabled states and names are updated correctly
 
     dimensionIsDisabled('dimension-item-eventDate')
-    cy.getBySel('dimension-item-eventDate').contains(
-        enrollment[DIMENSION_ID_EVENT_DATE]
-    )
+    cy.getBySel('dimension-item-eventDate').contains('Event date')
 
     dimensionIsEnabled('dimension-item-enrollmentDate')
     cy.getBySel('dimension-item-enrollmentDate').contains(
@@ -75,9 +73,7 @@ const setUpTable = ({ scheduledDateIsSupported } = {}) => {
 
     if (scheduledDateIsSupported) {
         dimensionIsDisabled('dimension-item-scheduledDate')
-        cy.getBySel('dimension-item-scheduledDate').contains(
-            enrollment[DIMENSION_ID_SCHEDULED_DATE]
-        )
+        cy.getBySel('dimension-item-scheduledDate').contains('Scheduled date')
     }
 
     dimensionIsEnabled('dimension-item-incidentDate')

--- a/cypress/integration/createEnrollment.cy.js
+++ b/cypress/integration/createEnrollment.cy.js
@@ -1,9 +1,7 @@
 import {
     DIMENSION_ID_ENROLLMENT_DATE,
-    DIMENSION_ID_EVENT_DATE,
     DIMENSION_ID_INCIDENT_DATE,
     DIMENSION_ID_LAST_UPDATED,
-    DIMENSION_ID_SCHEDULED_DATE,
 } from '../../src/modules/dimensionConstants.js'
 import {
     E2E_PROGRAM,

--- a/src/components/DownloadMenu/useDownloadMenu.js
+++ b/src/components/DownloadMenu/useDownloadMenu.js
@@ -3,6 +3,7 @@ import { useConfig, useDataEngine } from '@dhis2/app-runtime'
 import { useState, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { validateLineListLayout } from '../../modules/layoutValidation.js'
+import { OUTPUT_TYPE_ENROLLMENT } from '../../modules/visualization.js'
 import { sGetCurrent } from '../../reducers/current.js'
 import {
     getAnalyticsEndpoint,
@@ -42,7 +43,6 @@ const useDownloadMenu = (relativePeriodDate) => {
                     req = req
                         .fromVisualization(adaptedVisualization)
                         .withProgram(current.program.id)
-                        .withStage(current.programStage?.id)
                         .withOutputType(current.outputType)
                         .withPath(path)
                         .withFormat(format)
@@ -83,7 +83,6 @@ const useDownloadMenu = (relativePeriodDate) => {
                         // Perhaps the 2nd arg `passFilterAsDimension` should be false for the advanced submenu?
                         .fromVisualization(adaptedVisualization, true)
                         .withProgram(current.program.id)
-                        .withStage(current.programStage?.id)
                         .withOutputType(current.outputType)
                         .withPath(path)
                         .withFormat(format)
@@ -120,6 +119,10 @@ const useDownloadMenu = (relativePeriodDate) => {
 
             // TODO add common parameters
             // if there are for both event/enrollment and PT/LL
+
+            if (current.outputType !== OUTPUT_TYPE_ENROLLMENT) {
+                req = req.withStage(current.programStage?.id)
+            }
 
             if (relativePeriodDate) {
                 req = req.withRelativePeriodDate(relativePeriodDate)

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -87,6 +87,8 @@ const ProgramDimensionsPanel = ({ visible }) => {
             const program = filteredPrograms?.find(({ id }) => id === programId)
             const stage =
                 // auto-select if a program only has a single stage
+                // and input type is Event
+                inputType === OUTPUT_TYPE_EVENT &&
                 program?.programStages.length === 1
                     ? program.programStages[0]
                     : undefined
@@ -101,7 +103,7 @@ const ProgramDimensionsPanel = ({ visible }) => {
                     userSettings[DERIVED_USER_SETTINGS_DISPLAY_NAME_PROPERTY],
             })
         }
-    }, [visible, called])
+    }, [visible, called, refetch, userSettings])
 
     useEffect(() => {
         setSearchTerm('')


### PR DESCRIPTION
Implements [DHIS2-14396](https://dhis2.atlassian.net/browse/DHIS2-14396)

---

### Key features

1. do not set program stage id for enrollments
2. remove the stage from the download request for enrollments

---

### Description

Programs with only one stage get the stage automatically selected.
This only make sense when input type is event.
For enrollments we don't pass the stage to the analytics request, this fix avoids that the stage id is stored in the Redux store.

Cypress tests have been adjusted to not look for the program in the disabled time dimension labels.
These dimensions cannot be used with Enrollment input type, so the labels does not make any difference.
It was actually wrong that those dimensions got the program in the label, as for Enrollment multiple programs can be used.

---

### Screenshots

Before, program stage id was set in Redux even for enrollments:
<img width="932" alt="Screenshot 2023-01-17 at 14 12 48" src="https://user-images.githubusercontent.com/150978/212908147-a26aef4d-8ffc-478f-b00a-5501fa46acd9.png">


After, only the program id is set:
<img width="935" alt="Screenshot 2023-01-17 at 14 13 14" src="https://user-images.githubusercontent.com/150978/212908125-37d078e4-6baa-48ac-b9b2-6c1e4939a2de.png">



[DHIS2-14396]: https://dhis2.atlassian.net/browse/DHIS2-14396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ