### PR TITLE
fix: reset sorting when removing dimension from columns DHIS2-13948

### DIFF
--- a/cypress/helpers/table.js
+++ b/cypress/helpers/table.js
@@ -19,6 +19,13 @@ export const getTableDataCells = () =>
 export const expectTableToBeVisible = () =>
     getLineListTable().find('tbody').should('be.visible')
 
+export const expectTableToBeUpdated = () =>
+    cy.getBySel('line-list-loading-indicator').should(($div) => {
+        const className = $div[0].className
+
+        expect(className).to.not.match(/Visualization_fetching*/)
+    })
+
 export const expectTableToMatchRows = (expectedRows) => {
     getTableRows().should('have.length', expectedRows.length)
 

--- a/cypress/integration/createEnrollment.cy.js
+++ b/cypress/integration/createEnrollment.cy.js
@@ -129,8 +129,15 @@ const runTests = () => {
         // sort on enrollment date column
         getTableHeaderCells().find(`button[title*="${periodLabel}"]`).click()
 
-        // verify that the analytics request contains "asc"
-        cy.wait('@getAnalytics').its('request.url').should('include', 'asc')
+        // verify that the analytics request contains "asc" for enrollment date field
+        cy.wait('@getAnalytics').then(({ request }) => {
+            const url = new URL(request.url)
+
+            expect(url.searchParams.has('asc')).to.be.true
+            expect(url.searchParams.get('asc')).to.equal(
+                DIMENSION_ID_ENROLLMENT_DATE.toLowerCase()
+            )
+        })
 
         // move date from "Columns" to "Filter"
         cy.getBySel('columns-axis')
@@ -142,9 +149,11 @@ const runTests = () => {
 
         // verify that the analytics request does not contain "asc"
         // the sorting needs to be reset when a dimension used to sort is removed from "Columns"
-        cy.wait('@getAnalytics')
-            .its('request.url')
-            .should('not.match', /[a|de]sc/)
+        cy.wait('@getAnalytics').then(({ request }) => {
+            const url = new URL(request.url)
+
+            expect(url.searchParams.has('asc')).to.be.false
+        })
 
         // check the number of columns
         getTableHeaderCells().its('length').should('equal', 2)

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -50,6 +50,7 @@ import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableRows,
     getTableHeaderCells,
+    expectTableToBeUpdated,
     expectTableToBeVisible,
     getTableDataCells,
 } from '../helpers/table.js'
@@ -287,6 +288,8 @@ const assertSorting = () => {
     // wait for table to be sorted
     cy.wait('@getAnalyticsSortAsc')
 
+    expectTableToBeUpdated()
+
     getTableRows()
         .eq(0)
         .find('td')
@@ -311,6 +314,8 @@ const assertSorting = () => {
 
     // wait for table to be sorted
     cy.wait('@getAnalyticsSortDesc')
+
+    expectTableToBeUpdated()
 
     getTableRows()
         .eq(0)

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -346,7 +346,8 @@ const init = () => {
     cy.containsExact('Remove').click()
 }
 
-describe(['>=38', '<40'], 'table', () => {
+// TODO: set >=38 when 2.38.2 is released (creating this test for 2.38.2 is too much hassle
+describe(['>=39', '<40'], 'table', () => {
     beforeEach(init)
     it('click on column header opens the dimension dialog', () => {
         programDimensions.push({

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -346,17 +346,18 @@ const init = () => {
     cy.containsExact('Remove').click()
 }
 
-// TODO: set >=38 when 2.38.2 is released (creating this test for 2.38.2 is too much hassle
-describe(['>=39', '<40'], 'table', () => {
+// 2.38
+describe(['>=38', '<39'], 'table', () => {
     beforeEach(init)
-    it('click on column header opens the dimension dialog', () => {
-        programDimensions.push({
-            label: TEST_DIM_NUMBER_OPTIONSET,
-            value: '1',
-        })
+    it('click on column header opens the dimension dialog (2.38)', () => {
         assertColumnHeaders()
     })
-    it('dimensions display correct values in the visualization', () => {
+
+    it('dimensions display correct values in the visualization (2.38)', () => {
+        programDimensions.push({
+            label: TEST_DIM_NUMBER_OPTIONSET,
+            value: 'One',
+        })
         assertDimensions()
     })
     it('data can be sorted', () => {
@@ -364,25 +365,47 @@ describe(['>=39', '<40'], 'table', () => {
     })
 })
 
+// 2.39
+describe(['>=39', '<40'], 'table', () => {
+    beforeEach(init)
+    it('click on column header opens the dimension dialog (2.39)', () => {
+        assertColumnHeaders()
+    })
+    // bug: https://dhis2.atlassian.net/browse/DHIS2-13872
+    // when this is fixed in 2.39 backend, this test will fail
+    // then remove this test and merge tests for 38 and 39
+    it('dimensions display correct values in the visualization (2.39)', () => {
+        programDimensions.push({
+            label: TEST_DIM_NUMBER_OPTIONSET,
+            value: '1',
+        })
+        assertDimensions()
+    })
+    it('data can be sorted (2.39)', () => {
+        assertSorting()
+    })
+})
+
+// 2.40
 describe(['>=40'], 'table', () => {
     beforeEach(init)
-    it('click on column header opens the dimension dialog', () => {
+    it('click on column header opens the dimension dialog (2.40)', () => {
         // feat: https://dhis2.atlassian.net/browse/DHIS2-11192
         mainAndTimeDimensions.push({
             label: trackerProgram[DIMENSION_ID_SCHEDULED_DATE],
             value: `${previousYear}-12-10`,
         })
-        // bug: https://dhis2.atlassian.net/browse/DHIS2-13872
+        assertColumnHeaders()
+    })
+    it('dimensions display correct values in the visualization (2.40)', () => {
+        // bug:
         programDimensions.push({
             label: TEST_DIM_NUMBER_OPTIONSET,
             value: 'One',
         })
-        assertColumnHeaders()
-    })
-    it('dimensions display correct values in the visualization', () => {
         assertDimensions()
     })
-    it('data can be sorted', () => {
+    it('data can be sorted (2.40)', () => {
         assertSorting()
     })
 })

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -346,8 +346,7 @@ const init = () => {
     cy.containsExact('Remove').click()
 }
 
-// TODO: set >=38 when 2.38.2 is released (creating this test for 2.38.2 is too much hassle)
-describe(['>=39', '<40'], 'table', () => {
+describe(['>=38', '<40'], 'table', () => {
     beforeEach(init)
     it('click on column header opens the dimension dialog', () => {
         programDimensions.push({
@@ -358,6 +357,9 @@ describe(['>=39', '<40'], 'table', () => {
     })
     it('dimensions display correct values in the visualization', () => {
         assertDimensions()
+    })
+    it('data can be sorted', () => {
+        assertSorting()
     })
 })
 

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -233,9 +233,6 @@ const assertDimensions = () => {
 }
 
 const assertSorting = () => {
-    cy.intercept(/api\/\d+\/analytics(\S)*asc=/).as('getAnalyticsSortAsc')
-    cy.intercept(/api\/(\d+)\/analytics(\S)*desc=/).as('getAnalyticsSortDesc')
-
     // remove any DGS to allow numeric value comparison
     clickMenubarOptionsButton()
 
@@ -283,6 +280,8 @@ const assertSorting = () => {
 
     expectTableToBeVisible()
 
+    cy.intercept(/api\/\d+\/analytics(\S)*asc=/).as('getAnalyticsSortAsc')
+
     getTableHeaderCells().find(`button[title*="${TEST_DIM_INTEGER}"]`).click()
 
     // wait for table to be sorted
@@ -305,6 +304,8 @@ const assertSorting = () => {
                     expect($cell0Value).to.be.lessThan($cell1Value)
                 )
         )
+
+    cy.intercept(/api\/(\d+)\/analytics(\S)*desc=/).as('getAnalyticsSortDesc')
 
     getTableHeaderCells().find(`button[title*="${TEST_DIM_INTEGER}"]`).click()
 

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-11-25T12:25:46.264Z\n"
-"PO-Revision-Date: 2022-11-25T12:25:46.264Z\n"
+"POT-Creation-Date: 2023-01-20T08:48:33.330Z\n"
+"PO-Revision-Date: 2023-01-20T08:48:33.330Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -348,6 +348,9 @@ msgstr "Click a dimension to add or remove conditions."
 
 msgid "Your most viewed line lists"
 msgstr "Your most viewed line lists"
+
+msgid "Sort by {{column}}"
+msgstr "Sort by {{column}}"
 
 msgid "Rows per page"
 msgstr "Rows per page"

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -49,7 +49,10 @@ import {
 } from '../../modules/tableValues.js'
 import { headersMap } from '../../modules/visualization.js'
 import styles from './styles/Visualization.module.css'
-import { useAnalyticsData } from './useAnalyticsData.js'
+import {
+    getAdaptedVisualization,
+    useAnalyticsData,
+} from './useAnalyticsData.js'
 
 export const DEFAULT_SORT_DIRECTION = 'asc'
 export const FIRST_PAGE = 1
@@ -104,6 +107,18 @@ export const Visualization = ({
             }),
         []
     )
+
+    const { headers } = getAdaptedVisualization(visualization)
+
+    if (headers && sortField) {
+        // reset sorting if current sortField has been removed from Columns DHIS2-13948
+        if (!headers.includes(sortField)) {
+            setSorting({
+                sortField: null,
+                sortDirection: DEFAULT_SORT_DIRECTION,
+            })
+        }
+    }
 
     const { fetching, error, data } = useAnalyticsData({
         filters,

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -29,7 +29,13 @@ import {
 } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, {
+    useState,
+    useEffect,
+    useRef,
+    useCallback,
+    useReducer,
+} from 'react'
 import {
     DISPLAY_DENSITY_COMFORTABLE,
     DISPLAY_DENSITY_COMPACT,
@@ -81,26 +87,22 @@ export const Visualization = ({
     onError,
 }) => {
     const [uniqueLegendSets, setUniqueLegendSets] = useState([])
-    const [{ sortField, sortDirection, pageSize, page }, setSorting] = useState(
-        {
+    const [{ sortField, sortDirection, pageSize, page }, setSorting] =
+        useReducer((sorting, newSorting) => ({ ...sorting, ...newSorting }), {
             sortField: null,
             sortDirection: DEFAULT_SORT_DIRECTION,
             page: FIRST_PAGE,
             pageSize: PAGE_SIZE,
-        }
-    )
+        })
 
     const visualizationRef = useRef(visualization)
 
     const setPage = useCallback(
         (pageNum) =>
             setSorting({
-                sortField,
-                sortDirection,
-                pageSize,
                 page: pageNum,
             }),
-        [sortField, sortDirection, pageSize]
+        []
     )
 
     const { fetching, error, data } = useAnalyticsData({
@@ -159,14 +161,11 @@ export const Visualization = ({
         setSorting({
             sortField: name,
             sortDirection: direction,
-            pageSize,
             page: FIRST_PAGE,
         })
 
     const setPageSize = (pageSizeNum) =>
         setSorting({
-            sortField,
-            sortDirection,
             pageSize: pageSizeNum,
             page: FIRST_PAGE,
         })

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -254,6 +254,7 @@ export const Visualization = ({
     return (
         <div className={styles.pluginContainer}>
             <div
+                data-test="line-list-loading-indicator"
                 className={cx(styles.fetchIndicator, {
                     [styles.fetching]: fetching,
                 })}

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -280,6 +280,12 @@ export const Visualization = ({
                                                 ? sortDirection
                                                 : 'default'
                                         }
+                                        sortIconTitle={i18n.t(
+                                            'Sort by {{column}}',
+                                            {
+                                                column: getHeaderText(header),
+                                            }
+                                        )}
                                         className={cx(
                                             styles.headerCell,
                                             fontSizeClass,


### PR DESCRIPTION
Implements [DHIS2-13948](https://dhis2.atlassian.net/browse/DHIS2-13948)

---

### Key features

1. reset sorting in component and remove it from analytics request

---

### Description

When a column is sorted, the sort field and direction is stored in the component's local state.
If the dimension corresponding to the column is then removed from the layout or moved to filters, the sorting needs to be reset.

---

### Screenshots

Before: the `asc` parameter is still passed when the dimension is moved to filters:

<img width="423" alt="Screenshot 2023-01-18 at 15 29 07" src="https://user-images.githubusercontent.com/150978/213197806-ca7d3533-907e-437d-93cb-533b57328bc3.png">

After: the `asc` parameter is not passed:

<img width="408" alt="Screenshot 2023-01-18 at 15 29 42" src="https://user-images.githubusercontent.com/150978/213197799-95b7c0d0-1802-48ae-9b65-d25efac55722.png">

Before: the `asc` parameter is passed even when the corresponding dimension is removed from columns:

<img width="412" alt="Screenshot 2023-01-18 at 15 32 19" src="https://user-images.githubusercontent.com/150978/213198609-69000c1b-196a-49a2-a876-f59dfb2a4f5e.png">

After: the `asc` parameter is not passed:

<img width="408" alt="Screenshot 2023-01-18 at 15 32 36" src="https://user-images.githubusercontent.com/150978/213198623-90cf3d98-e39b-4219-bbc6-7f359abc765c.png">




[DHIS2-13948]: https://dhis2.atlassian.net/browse/DHIS2-13948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ