### PR TITLE
feat: show ou hierarchy in line lists (DHIS2-2367)

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -51,7 +51,7 @@ import {
     getHeaderText,
 } from '../../modules/tableValues.js'
 import {
-    headersMap,
+    getHeadersMap,
     transformVisualization,
 } from '../../modules/visualization.js'
 import styles from './styles/Visualization.module.css'
@@ -209,8 +209,14 @@ export const Visualization = ({
             page: FIRST_PAGE,
         })
 
+    const dimensionHeadersMap = getHeadersMap({
+        showHierarchy: visualization.showHierarchy,
+    })
+
     const reverseLookupDimensionId = (dimensionId) =>
-        Object.keys(headersMap).find((key) => headersMap[key] === dimensionId)
+        Object.keys(dimensionHeadersMap).find(
+            (key) => dimensionHeadersMap[key] === dimensionId
+        )
 
     const formatCellValue = (value, header) => {
         if (header?.valueType === VALUE_TYPE_URL) {

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -29,7 +29,7 @@ import { extractDimensionIdParts } from '../../modules/utils.js'
 import {
     OUTPUT_TYPE_ENROLLMENT,
     OUTPUT_TYPE_EVENT,
-    headersMap,
+    getHeadersMap,
 } from '../../modules/visualization.js'
 
 const analyticsApiEndpointMap = {
@@ -91,13 +91,17 @@ const getAdaptedVisualization = (visualization) => {
     const adaptedRows = adaptDimensions(visualization[AXIS_ID_ROWS])
     const adaptedFilters = adaptDimensions(visualization[AXIS_ID_FILTERS])
 
+    const dimensionHeadersMap = getHeadersMap({
+        showHierarchy: visualization.showHierarchy,
+    })
+
     const headers = [
         ...visualization[AXIS_ID_COLUMNS],
         ...visualization[AXIS_ID_ROWS],
     ].map(({ dimension, programStage, repetition }) => {
         const headerId = programStage?.id
             ? `${programStage.id}.${dimension}`
-            : headersMap[dimension] || dimension
+            : dimensionHeadersMap[dimension] || dimension
 
         if (repetition?.indexes?.length) {
             return repetition.indexes.map((index) =>

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -54,6 +54,16 @@ export const headersMap = {
     [DIMENSION_ID_LAST_UPDATED]: 'lastupdated',
 }
 
+export const getHeadersMap = ({ showHierarchy }) => {
+    const map = Object.assign({}, headersMap)
+
+    if (showHierarchy) {
+        map[DIMENSION_ID_ORGUNIT] = 'ounamehierarchy'
+    }
+
+    return map
+}
+
 export const outputTypeTimeDimensionMap = {
     [OUTPUT_TYPE_EVENT]: DIMENSION_ID_EVENT_DATE,
     [OUTPUT_TYPE_ENROLLMENT]: DIMENSION_ID_ENROLLMENT_DATE,


### PR DESCRIPTION
Implements a part of [DHIS2-2367](https://dhis2.atlassian.net/browse/DHIS2-2367)

We're already mapping dimensions <-> headers, e.g. the `ou` dimension is using the `ouname` header by default. With this PR, the `ou` dimension will use the `ounamehierarchy` header instead when the `showHierarchy` option is enabled. Had to change this in two places. Made a function for it in the module to keep the knowledge about dimension-to-header mapping in one place.

Sorting on this column worked out of the box.

The base for this PR should probably be `feat/DHIS2-2367-ou-hierarchy` / https://github.com/dhis2/line-listing-app/pull/266.

No cypress tests added as there's no way to turn on the hierarchy in this PR.

[DHIS2-2367]: https://dhis2.atlassian.net/browse/DHIS2-2367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ