### PR TITLE
feat: add ou hierarchy to options (DHIS2-2367)

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -39,6 +39,7 @@ import React, {
     useCallback,
     useReducer,
 } from 'react'
+import { getRequestOptions } from '../../modules/getRequestOptions.js'
 import {
     DISPLAY_DENSITY_COMFORTABLE,
     DISPLAY_DENSITY_COMPACT,
@@ -209,9 +210,7 @@ export const Visualization = ({
             page: FIRST_PAGE,
         })
 
-    const dimensionHeadersMap = getHeadersMap({
-        showHierarchy: visualization.showHierarchy,
-    })
+    const dimensionHeadersMap = getHeadersMap(getRequestOptions(visualization))
 
     const reverseLookupDimensionId = (dimensionId) =>
         Object.keys(dimensionHeadersMap).find(

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -25,6 +25,7 @@ import {
     DIMENSION_ID_LAST_UPDATED_BY,
     DIMENSION_IDS_TIME,
 } from '../../modules/dimensionConstants.js'
+import { getRequestOptions } from '../../modules/getRequestOptions.js'
 import { extractDimensionIdParts } from '../../modules/utils.js'
 import {
     OUTPUT_TYPE_ENROLLMENT,
@@ -91,9 +92,7 @@ const getAdaptedVisualization = (visualization) => {
     const adaptedRows = adaptDimensions(visualization[AXIS_ID_ROWS])
     const adaptedFilters = adaptDimensions(visualization[AXIS_ID_FILTERS])
 
-    const dimensionHeadersMap = getHeadersMap({
-        showHierarchy: visualization.showHierarchy,
-    })
+    const dimensionHeadersMap = getHeadersMap(getRequestOptions(visualization))
 
     const headers = [
         ...visualization[AXIS_ID_COLUMNS],

--- a/src/components/VisualizationOptions/Options/ShowHierarchy.js
+++ b/src/components/VisualizationOptions/Options/ShowHierarchy.js
@@ -1,12 +1,13 @@
 import i18n from '@dhis2/d2-i18n'
 import React from 'react'
+import { OPTION_SHOW_HIERARCHY } from '../../../modules/options.js'
 import CheckboxBaseOption from './CheckboxBaseOption.js'
 
 const ShowHierarchy = () => (
     <CheckboxBaseOption
         label={i18n.t('Display organisation unit hierarchy')}
         option={{
-            name: 'showHierarchy',
+            name: OPTION_SHOW_HIERARCHY,
         }}
     />
 )

--- a/src/modules/getRequestOptions.js
+++ b/src/modules/getRequestOptions.js
@@ -1,0 +1,17 @@
+import { getOptionsForRequest } from './options.js'
+
+export const getRequestOptions = (visualization) => {
+    const options = getOptionsForRequest().reduce((map, [option, props]) => {
+        // only add parameter if value !== default
+        if (
+            visualization[option] !== undefined &&
+            visualization[option] !== props.defaultValue
+        ) {
+            map[option] = visualization[option]
+        }
+
+        return map
+    }, {})
+
+    return options
+}

--- a/src/modules/options.js
+++ b/src/modules/options.js
@@ -8,6 +8,7 @@ export const OPTION_MEASURE_CRITERIA = 'measureCriteria'
 export const OPTION_FONT_SIZE = 'fontSize'
 export const OPTION_DIGIT_GROUP_SEPARATOR = 'digitGroupSeparator'
 export const OPTION_DISPLAY_DENSITY = 'displayDensity'
+export const OPTION_SHOW_HIERARCHY = 'showHierarchy'
 export const DISPLAY_DENSITY_COMFORTABLE = 'COMFORTABLE'
 export const DISPLAY_DENSITY_NORMAL = 'NORMAL'
 export const DISPLAY_DENSITY_COMPACT = 'COMPACT'
@@ -56,6 +57,11 @@ export const options = {
         requestable: false,
         savable: true,
     },
+    [OPTION_SHOW_HIERARCHY]: {
+        defaultValue: false,
+        requestable: true,
+        savable: true,
+    },
     // TODO: Limit the number of rows shown in the table
     // TODO: Only show the [top/bottom] x rows
 }
@@ -67,6 +73,12 @@ export const getOptionsForUi = () => {
         map[option] = props.defaultValue
         return map
     }, {})
+}
+
+export const getOptionsForRequest = () => {
+    return Object.entries(options).filter(
+        (entry) => entry[1].requestable // entry = [option, props]
+    )
 }
 
 export const getOptionsFromVisualization = (visualization) => {

--- a/src/modules/options/lineListConfig.js
+++ b/src/modules/options/lineListConfig.js
@@ -2,6 +2,7 @@ import React from 'react'
 import DigitGroupSeparator from '../../components/VisualizationOptions/Options/DigitGroupSeparator.js'
 import DisplayDensity from '../../components/VisualizationOptions/Options/DisplayDensity.js'
 import FontSize from '../../components/VisualizationOptions/Options/FontSize.js'
+import ShowHierarchy from '../../components/VisualizationOptions/Options/ShowHierarchy.js'
 import getLegendTab from './tabs/legend.js'
 import getStyleTab from './tabs/style.js'
 
@@ -13,6 +14,7 @@ export default (serverVersion) => [
                 <DisplayDensity />,
                 <FontSize />,
                 <DigitGroupSeparator />,
+                <ShowHierarchy />,
             ]),
         },
     ]),


### PR DESCRIPTION
Implements [DHIS2-2367](https://dhis2.atlassian.net/browse/DHIS2-2367)

Supersedes https://github.com/dhis2/line-listing-app/pull/266

Adds an option for "Display organisation unit hierarchy".

Uses the new `ounamehierarchy` column, ref https://github.com/dhis2/line-listing-app/pull/328.

[DHIS2-2367]: https://dhis2.atlassian.net/browse/DHIS2-2367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ