### PR TITLE
test: fix flaky and outdated tests

### DIFF
--- a/cypress/integration/conditions/optionSetCondition.cy.js
+++ b/cypress/integration/conditions/optionSetCondition.cy.js
@@ -27,89 +27,59 @@ import {
 } from '../../helpers/table.js'
 import { searchAndSelectInOptionsTransfer } from '../../helpers/transfer.js'
 
-// TODO: enable for 38+ when numeric option set has been figured out
-// there was a bug in 38 showing the code instead of name
-// it's supposed to be fixed in 39, but the test fails due to the same issue
-
-const assertNumericOptionSet = ({
-    tableFilteredOptionName,
-    tableFilteredOutOptionName,
-    selectorFilteredOptionName,
-}) => {
-    const dimensionName = TEST_DIM_NUMBER_OPTIONSET
-
-    goToStartPage()
-
-    selectEventWithProgram(E2E_PROGRAM)
-
-    selectRelativePeriod({
-        label: E2E_PROGRAM[DIMENSION_ID_EVENT_DATE],
-        period: TEST_REL_PE_LAST_YEAR,
-    })
-
-    clickMenubarUpdateButton()
-
-    expectTableToBeVisible()
-
-    openDimension(dimensionName)
-
-    cy.getBySel('button-add-condition').should('not.exist')
-
-    cy.contains('Add to Columns').click()
-
-    clickMenubarUpdateButton()
-
-    expectTableToBeVisible()
-
-    expectTableToContainValue(tableFilteredOptionName)
-    expectTableToContainValue(tableFilteredOutOptionName)
-
-    cy.getBySelLike('layout-chip').contains(`${dimensionName}: all`)
-
-    openDimension(dimensionName)
-
-    searchAndSelectInOptionsTransfer(selectorFilteredOptionName)
-
-    cy.getBySel('conditions-modal').contains('Update').click()
-
-    expectTableToBeVisible()
-
-    assertChipContainsText(`${dimensionName}: 1 selected`)
-
-    assertTooltipContainsEntries([selectorFilteredOptionName])
-
-    expectTableToNotContainValue(tableFilteredOutOptionName)
-    expectTableToContainValue(tableFilteredOptionName)
-
-    expectTableToMatchRows([
-        `${getPreviousYearStr()}-12-23`,
-        `${getPreviousYearStr()}-12-22`,
-    ])
-}
-
 describe('Option set condition', () => {
-    it(['>37', '<39'], 'Option set (number) displays correctly (2.38)', () => {
-        assertNumericOptionSet({
-            tableFilteredOptionName: 'Eight',
-            tableFilteredOutOptionName: 'Four',
-            selectorFilteredOptionName: 'Eight',
-        })
-    })
+    it('Option set (number) displays correctly', () => {
+        const dimensionName = TEST_DIM_NUMBER_OPTIONSET
+        const valueToFilterBy = 'Eight'
+        const valueToFilterOut = 'Four'
 
-    it(['>38', '<40'], 'Option set (number) displays correctly (2.39)', () => {
-        assertNumericOptionSet({
-            tableFilteredOptionName: '8',
-            tableFilteredOutOptionName: '4',
-            selectorFilteredOptionName: 'Eight',
-        })
-    })
+        goToStartPage()
 
-    it(['>=40'], 'Option set (number) displays correctly (2.40+)', () => {
-        assertNumericOptionSet({
-            tableFilteredOptionName: 'Eight',
-            tableFilteredOutOptionName: 'Four',
-            selectorFilteredOptionName: 'Eight',
+        selectEventWithProgram(E2E_PROGRAM)
+
+        selectRelativePeriod({
+            label: E2E_PROGRAM[DIMENSION_ID_EVENT_DATE],
+            period: TEST_REL_PE_LAST_YEAR,
         })
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        openDimension(dimensionName)
+
+        cy.getBySel('button-add-condition').should('not.exist')
+
+        cy.contains('Add to Columns').click()
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        expectTableToContainValue(valueToFilterBy)
+        expectTableToContainValue(valueToFilterOut)
+
+        cy.getBySelLike('layout-chip').contains(`${dimensionName}: all`)
+
+        openDimension(dimensionName)
+
+        searchAndSelectInOptionsTransfer(valueToFilterBy)
+
+        cy.getBySel('conditions-modal').contains('Update').click()
+
+        expectTableToBeVisible()
+
+        assertChipContainsText(`${dimensionName}: 1 selected`)
+
+        assertTooltipContainsEntries([valueToFilterBy])
+
+        expectTableToNotContainValue(valueToFilterOut)
+        expectTableToContainValue(valueToFilterBy)
+
+        expectTableToMatchRows([
+            `${getPreviousYearStr()}-12-23`,
+            `${getPreviousYearStr()}-12-22`,
+        ])
     })
 
     it('Option set (text) displays correctly', () => {

--- a/cypress/integration/legendSet.cy.js
+++ b/cypress/integration/legendSet.cy.js
@@ -355,12 +355,22 @@ describe(['>=39'], 'Options - Legend', () => {
             label: periodLabel,
         })
 
+        cy.intercept('**/api/*/analytics/**').as('getAnalytics')
+
         selectFixedPeriod({
             label: periodLabel,
             period: {
                 year: currentYear,
                 name: `January ${currentYear}`,
             },
+        })
+        cy.wait('@getAnalytics').then(({ request }) => {
+            const url = new URL(request.url)
+
+            // verify that the request url is correct, as the response from this request has been inconsistent when running on Cypress Dashboard
+            expect(url.search).to.equal(
+                '?dimension=ou%3AUSER_ORGUNIT,jfuXZB3A1ko.BEs9h9LOIao,jfuXZB3A1ko.vjEosHW6sAB&headers=ouname,jfuXZB3A1ko.BEs9h9LOIao,jfuXZB3A1ko.vjEosHW6sAB&totalPages=false&eventDate=202301&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=jfuXZB3A1ko'
+            )
         })
 
         getTableRows() // the first row should be empty and not have the legend background color

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -316,7 +316,6 @@ const init = () => {
     cy.containsExact('Remove').click()
 }
 
-// 2.38
 describe(['>=38', '<39'], 'table', () => {
     beforeEach(init)
     it('click on column header opens the dimension dialog (2.38)', () => {
@@ -335,31 +334,9 @@ describe(['>=38', '<39'], 'table', () => {
     })
 })
 
-// 2.39
-describe(['>=39', '<40'], 'table', () => {
+describe(['>=39'], 'table', () => {
     beforeEach(init)
-    it('click on column header opens the dimension dialog (2.39)', () => {
-        assertColumnHeaders()
-    })
-    // bug: https://dhis2.atlassian.net/browse/DHIS2-13872
-    // when this is fixed in 2.39 backend, this test will fail
-    // then remove this test and merge tests for 38 and 39
-    it('dimensions display correct values in the visualization (2.39)', () => {
-        programDimensions.push({
-            label: TEST_DIM_NUMBER_OPTIONSET,
-            value: '1',
-        })
-        assertDimensions()
-    })
-    it('data can be sorted (2.39)', () => {
-        assertSorting()
-    })
-})
-
-// 2.40
-describe(['>=40'], 'table', () => {
-    beforeEach(init)
-    it('click on column header opens the dimension dialog (2.40)', () => {
+    it('click on column header opens the dimension dialog (>=2.39)', () => {
         // feat: https://dhis2.atlassian.net/browse/DHIS2-11192
         mainAndTimeDimensions.push({
             label: trackerProgram[DIMENSION_ID_SCHEDULED_DATE],
@@ -367,15 +344,14 @@ describe(['>=40'], 'table', () => {
         })
         assertColumnHeaders()
     })
-    it('dimensions display correct values in the visualization (2.40)', () => {
-        // bug:
+    it('dimensions display correct values in the visualization (>=2.39)', () => {
         programDimensions.push({
             label: TEST_DIM_NUMBER_OPTIONSET,
             value: 'One',
         })
         assertDimensions()
     })
-    it('data can be sorted (2.40)', () => {
+    it('data can be sorted (>=2.39)', () => {
         assertSorting()
     })
 })


### PR DESCRIPTION
### PART 1
Requests made by Cypress Dashboard return a different result than requests made by the same test locally and by manual testing both locally and on an instance. The suspicion is that the backend is returning an inconsistent response, e.g. sometimes `['', '11', '12']` and `['12', '11', '']` other times. To prove this theory an assert for the url has been added just before the flaky test. If that url assertion passes but the subsequent test step fails, then it's indeed the backend that is being inconsistent.

e.g. local Cypress / local manual test / instance manual test VS Cypress dashboard test.
![image](https://user-images.githubusercontent.com/12590483/224981915-0c5c2513-6534-4e79-8983-b79439321ce2.png)

![image](https://user-images.githubusercontent.com/12590483/224981942-3405e0e6-b014-4cfb-b122-6258f3542e8d.png)

### PART 2
There was an issue with 2.39 specifically where option set option `name`s (e.g. `One`) were returned as their `code` (e.g. `1`). This seems to have been fixed on the backend for 2.39 now so the special cases that were expecting the incorrect value for 2.39 were removed and consolidated into the 2.40 tests instead.