### PR TITLE
test: add EXTENDED_TIMEOUT to all references of program-dimensions-list

### DIFF
--- a/cypress/helpers/dimensions.js
+++ b/cypress/helpers/dimensions.js
@@ -39,12 +39,14 @@ export const selectEnrollmentProgram = ({ programName, stageName }) =>
     })
 
 export const openDimension = (dimensionName) => {
-    cy.getBySel('program-dimensions-list').contains(dimensionName).click()
+    cy.getBySel('program-dimensions-list', EXTENDED_TIMEOUT)
+        .contains(dimensionName)
+        .click()
 }
 
 const clickAddRemoveDimension = (id, label) =>
     cy
-        .getBySel(id)
+        .getBySel(id, EXTENDED_TIMEOUT)
         .contains(label)
         .closest(`[data-test*="dimension-item"]`)
         .findBySelLike('item-button')

--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -403,7 +403,7 @@ const runTests = ({ scheduledDateIsSupported } = {}) => {
 
             cy.getBySel('accessory-sidebar').contains('All types')
 
-            cy.getBySel('program-dimensions-list')
+            cy.getBySel('program-dimensions-list', EXTENDED_TIMEOUT)
                 .findBySelLike('dimension-item')
                 .its('length')
                 .should('be.gte', 1)
@@ -517,7 +517,7 @@ const runTests = ({ scheduledDateIsSupported } = {}) => {
 
             cy.getBySel('accessory-sidebar').contains('All types')
 
-            cy.getBySel('program-dimensions-list')
+            cy.getBySel('program-dimensions-list', EXTENDED_TIMEOUT)
                 .findBySelLike('dimension-item')
                 .its('length')
                 .should('be.gte', 1)


### PR DESCRIPTION
Recently the nightly test run has failed due to the program dimensions list being slow and not rendering within the default 4s timeout. This extends the timeout in all places where program-dimensions-list is used to avoid flakey tests.