### PR TITLE
fix: data from repeatable events shows name of DE instead of blank cell (DHIS2-15026)

### DIFF
--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -50,10 +50,17 @@ const formatRowValue = (rowValue, header, metaDataItems) => {
         case VALUE_TYPE_BOOLEAN:
         case VALUE_TYPE_TRUE_ONLY:
             return getBooleanValues()[rowValue || NULL_VALUE]
-        default:
-            return header.optionSet
-                ? findOptionSetItem(rowValue, metaDataItems)?.name || rowValue
-                : metaDataItems[rowValue]?.name || rowValue
+        default: {
+            if (!rowValue) {
+                return rowValue
+            }
+            if (header.optionSet) {
+                return (
+                    findOptionSetItem(rowValue, metaDataItems)?.name || rowValue
+                )
+            }
+            return metaDataItems[rowValue]?.name || rowValue
+        }
     }
 }
 


### PR DESCRIPTION
Implements [DHIS2-15026](https://dhis2.atlassian.net/browse/DHIS2-15026)

---

### Key features

1. Prevents empty options from return the wrong cell value

---

### Description

This prevents empty row values (options) from incorrectly returning the name of the DE instead of an empty value. This was happening as https://github.com/dhis2/line-listing-app/blob/0ed6eb9f247330e4a8b077e4bbdc64e03307eb5c/src/components/Visualization/useAnalyticsData.js#L46 would match `code` with `''`, that resulted in the name of first metadata item without a code (coincidentally the original DE) to be returned instead.

---

### TODO

-   [ ] Cypress tests

---

### Screenshots

_before (note row 2)_
![image](https://user-images.githubusercontent.com/12590483/228259270-f48b9d9b-289d-49e3-b691-b6ac10a95077.png)

_after (row 2 is now empty)_
![image](https://user-images.githubusercontent.com/12590483/228259374-dd082aa0-fcd0-4e09-9e1f-f0a5759895aa.png)
