### PR TITLE
fix: plugin communication for Cypress

### DIFF
--- a/src/PluginWrapper.js
+++ b/src/PluginWrapper.js
@@ -37,7 +37,7 @@ const CacheableSectionWrapper = ({
         const listener = postRobot.on(
             'removeCachedData',
             // todo: check domain too; differs based on deployment env though
-            { window: window.top },
+            { window: window.parent },
             () => remove()
         )
 
@@ -74,14 +74,14 @@ const PluginWrapper = () => {
 
     useEffect(() => {
         postRobot
-            .send(window.top, 'getProps')
+            .send(window.parent, 'getProps')
             .then(receivePropsFromParent)
             .catch((err) => console.error(err))
 
         // Allow parent to update props
         const listener = postRobot.on(
             'newProps',
-            { window: window.top /* Todo: check domain */ },
+            { window: window.parent /* Todo: check domain */ },
             receivePropsFromParent
         )
 


### PR DESCRIPTION
### Key features

1. target the parent window for postRobot communication

---

### Description

This solves the issue of plugin communication not working in Cypress, where the app runs in an iframe and `window.top` is not the app window but some Cypress window.
`window.parent` targets the window immediately above the plugin window, which for dashboard plugins is where the dashboard app is found and the message listeners are set.
