### PR TITLE
fix: add 2.40.0 toggle to show hierarchy option (DHIS2-2367)

### DIFF
--- a/src/modules/options/lineListConfig.js
+++ b/src/modules/options/lineListConfig.js
@@ -14,7 +14,11 @@ export default (serverVersion) => [
                 <DisplayDensity />,
                 <FontSize />,
                 <DigitGroupSeparator />,
-                <ShowHierarchy />,
+                `${serverVersion.major}.${serverVersion.minor}.${
+                    serverVersion.patch || 0
+                }` >= '2.40.0' ? (
+                    <ShowHierarchy />
+                ) : null,
             ]),
         },
     ]),


### PR DESCRIPTION
Adds a fix to [DHIS2-2367](https://dhis2.atlassian.net/browse/DHIS2-2367)

Adds a 2.40 toggle on the `Show hierarchy` option so that it won't show up in 2.38 and 2.39.


[DHIS2-2367]: https://dhis2.atlassian.net/browse/DHIS2-2367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ