### PR TITLE
fix: no need to check branch since workflow only runs on default

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,6 @@ name: 'dhis2: nightly'
 on:
     schedule:
         - cron: '20 2 * * 1-5'
-    workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
@@ -25,7 +24,6 @@ defaults:
 
 jobs:
     call-workflow-e2e-dev:
-        if: github.ref == 'refs/heads/dev'
         uses: dhis2/data-visualizer-app/.github/workflows/e2e-dev.yml@dev
         secrets:
             baseurl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_DEV }}


### PR DESCRIPTION
The nightly e2e test runs were being skipped because the workflow was checking for the dev branch even though the default branch had been switched to master.