### PR TITLE
test: rename visualization-title to titlebar (DHIS2-15063)

### DIFF
--- a/cypress/helpers/common.js
+++ b/cypress/helpers/common.js
@@ -15,5 +15,5 @@ export const clearTextarea = (target) =>
 export const goToAO = (id) => {
     cy.visit(`#/${id}`, EXTENDED_TIMEOUT).log(Cypress.env('dhis2BaseUrl'))
     expectRouteToEqual(id)
-    cy.getBySel('visualization-title', EXTENDED_TIMEOUT).should('be.visible')
+    cy.getBySel('titlebar', EXTENDED_TIMEOUT).should('be.visible')
 }

--- a/cypress/helpers/fileMenu.js
+++ b/cypress/helpers/fileMenu.js
@@ -42,5 +42,5 @@ export const deleteVisualization = () => {
 
     cy.getBySel('file-menu-delete-modal-delete').click()
 
-    cy.getBySel('visualization-title').should('not.exist')
+    cy.getBySel('titlebar').should('not.exist')
 }

--- a/cypress/helpers/table.js
+++ b/cypress/helpers/table.js
@@ -2,7 +2,7 @@ import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 export const expectAOTitleToContain = (value) =>
     cy
-        .getBySel('visualization-title')
+        .getBySel('titlebar')
         .should('have.length', 1)
         .and('be.visible')
         .and('contain', value)

--- a/cypress/integration/fileMenu.cy.js
+++ b/cypress/integration/fileMenu.cy.js
@@ -209,7 +209,7 @@ describe('file menu', () => {
         // "dirty, valid: data" state
         clickMenubarUpdateButton()
 
-        cy.getBySel('visualization-title').contains('Edited')
+        cy.getBySel('titlebar').contains('Edited')
         assertDownloadIsEnabled()
 
         assertFileMenuItems({
@@ -266,7 +266,7 @@ describe('file menu', () => {
     it('reflects "saved" and "dirty" state (legacy: do not allow saving)', () => {
         goToAO('TIuOzZ0ID0V')
 
-        cy.getBySel('visualization-title').contains(
+        cy.getBySel('titlebar').contains(
             'Inpatient: Cases 5 to 15 years this year (case)'
         )
 
@@ -287,7 +287,7 @@ describe('file menu', () => {
         // "dirty, valid: data" state
         clickMenubarUpdateButton()
 
-        cy.getBySel('visualization-title').contains('Edited')
+        cy.getBySel('titlebar').contains('Edited')
 
         assertDownloadIsEnabled()
 

--- a/cypress/integration/repeatedEvents.cy.js
+++ b/cypress/integration/repeatedEvents.cy.js
@@ -213,7 +213,7 @@ describe('repeated events', () => {
     it('repetition is not disabled after loading a saved vis with cross-stage data element', () => {
         goToAO('WrIV7ZoYECj')
 
-        cy.getBySel('visualization-title').contains(
+        cy.getBySel('titlebar').contains(
             'E2E: Enrollment - Hemoglobin (repeated)'
         )
 

--- a/cypress/integration/smoke.cy.js
+++ b/cypress/integration/smoke.cy.js
@@ -13,7 +13,7 @@ describe('Smoke Test', () => {
     it('loads with visualization id', () => {
         goToAO(TEST_AO.id)
 
-        cy.getBySel('visualization-title', EXTENDED_TIMEOUT)
+        cy.getBySel('titlebar', EXTENDED_TIMEOUT)
             .should('be.visible')
             .and('contain', TEST_AO.name)
     })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -4,3 +4,11 @@ import './commands.js'
 
 enableAutoLogin()
 // enableNetworkShim()
+
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
+Cypress.on('uncaught:exception', (err) => {
+    /* returning false here prevents Cypress from failing the test */
+    if (resizeObserverLoopErrRe.test(err.message)) {
+        return false
+    }
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -7,8 +7,14 @@ enableAutoLogin()
 
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
 Cypress.on('uncaught:exception', (err) => {
-    /* returning false here prevents Cypress from failing the test */
+    // This prevents a benign error:
+    //   This error means that ResizeObserver was not able to deliver all
+    //   observations within a single animation frame. It is benign (your site
+    //   will not break).
+    //
+    // Source: https://stackoverflow.com/a/50387233/1319140
     if (resizeObserverLoopErrRe.test(err.message)) {
+        // returning false here prevents Cypress from failing the test
         return false
     }
 })

--- a/src/components/TitleBar/TitleBar.js
+++ b/src/components/TitleBar/TitleBar.js
@@ -49,7 +49,7 @@ export const TitleBar = ({ titleState, titleText }) => {
     )}`
 
     return titleText ? (
-        <div data-test="visualization-title" className={classes.titleBar}>
+        <div data-test="titlebar" className={classes.titleBar}>
             <div className={classes.buttonContainer}>
                 <ExpandedVisualizationCanvasToggle />
             </div>


### PR DESCRIPTION
Implements [DHIS2-15063](https://dhis2.atlassian.net/browse/DHIS2-15063)

---

Renames `visualization-title` to `titlebar` for consistency with other apps

Also, prevents ResizeObserver from failing the tests by utilising the check used in Dashboard - [dashboard-app/blob/dev/cypress/support/index.js#L12](https://github.com/dhis2/dashboard-app/blob/dev/cypress/support/index.js#L12)

[DHIS2-15063]: https://dhis2.atlassian.net/browse/DHIS2-15063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ