### PR TITLE
fix: avoid crash when missing metadata for stage-element ids (DHIS2-15423)

### DIFF
--- a/i18n/es.po
+++ b/i18n/es.po
@@ -11,13 +11,14 @@
 # Enzo Nicolas Rossi <enzo@dhis2.org>, 2023
 # Sergio Valenzuela <sergio.valenzuela@ehas.org>, 2023
 # Viktor Varland <viktor@dhis2.org>, 2023
+# Janeth Cruz, 2023
 # 
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
 "POT-Creation-Date: 2023-04-19T13:36:14.629Z\n"
 "PO-Revision-Date: 2022-08-23 11:50+0000\n"
-"Last-Translator: Viktor Varland <viktor@dhis2.org>, 2023\n"
+"Last-Translator: Janeth Cruz, 2023\n"
 "Language-Team: Spanish (https://app.transifex.com/hisp-uio/teams/100509/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,7 +192,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 msgid "Levels"
-msgstr ""
+msgstr "Niveles"
 
 msgid "Groups"
 msgstr "Grupos"
@@ -203,7 +204,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 msgid "None selected"
-msgstr ""
+msgstr "Ninguno seleccionado"
 
 msgid "Showing all values for this dimension"
 msgstr ""
@@ -242,7 +243,7 @@ msgid "See data from multiple program stages in a Tracker program."
 msgstr ""
 
 msgid "Main dimensions"
-msgstr ""
+msgstr "Dimensiones principales"
 
 msgid "Input: {{type}}"
 msgstr ""
@@ -325,10 +326,10 @@ msgid "Expand visualization and hide panels"
 msgstr ""
 
 msgid "Unsaved visualization"
-msgstr ""
+msgstr "Visualización no guardada"
 
 msgid "Edited"
-msgstr ""
+msgstr "Editado"
 
 msgid "Interpretations"
 msgstr "Interpretaciones"
@@ -372,7 +373,7 @@ msgid "Update"
 msgstr "Actualizar"
 
 msgid "Getting started"
-msgstr ""
+msgstr "Comenzar"
 
 msgid ""
 "All dimensions that you can use to build visualizations are shown in the "
@@ -401,7 +402,7 @@ msgid "Page {{page}}, row {{firstItem}}-{{lastItem}}"
 msgstr ""
 
 msgid "Column sub-totals"
-msgstr ""
+msgstr "Subtotales de columna"
 
 msgid "Columns totals"
 msgstr ""
@@ -503,7 +504,7 @@ msgid "Show legend key"
 msgstr ""
 
 msgid "Add a title"
-msgstr ""
+msgstr "Añadir un título"
 
 msgid "Options"
 msgstr "Opciones"
@@ -678,7 +679,7 @@ msgid "Display"
 msgstr "Mostrar"
 
 msgid "Empty data"
-msgstr ""
+msgstr "Datos vacíos"
 
 msgid "Totals"
 msgstr "Totales"
@@ -687,7 +688,7 @@ msgid "Data"
 msgstr "Datos"
 
 msgid "Limit values"
-msgstr ""
+msgstr "Valores límite"
 
 msgid "Limit number of values"
 msgstr ""

--- a/src/components/MainSidebar/SelectedDimensionsContext.js
+++ b/src/components/MainSidebar/SelectedDimensionsContext.js
@@ -39,7 +39,7 @@ export const SelectedDimensionsProvider = ({ children }) => {
         const allSelectedIdsSet = new Set(allSelectedIds)
         const counts = allSelectedIds.reduce(
             (acc, id) => {
-                const { dimensionType } = metadata[id] || {}
+                const { dimensionType } = metadata[id] ?? {}
 
                 if (DIMENSION_TYPES_PROGRAM.has(dimensionType)) {
                     acc.program += 1

--- a/src/components/MainSidebar/SelectedDimensionsContext.js
+++ b/src/components/MainSidebar/SelectedDimensionsContext.js
@@ -39,7 +39,7 @@ export const SelectedDimensionsProvider = ({ children }) => {
         const allSelectedIdsSet = new Set(allSelectedIds)
         const counts = allSelectedIds.reduce(
             (acc, id) => {
-                const { dimensionType } = metadata[id]
+                const { dimensionType } = metadata[id] || {}
 
                 if (DIMENSION_TYPES_PROGRAM.has(dimensionType)) {
                     acc.program += 1


### PR DESCRIPTION
When loading a saved line list with multistage data elements we don't have metadata on the "stageId.elementId" format in the loaded visualization object. This causes a crash in the `SelectedDimensionsContext.js` file.

This is a hotfix and simply avoids the destructuring of a non existing object.

The proper fix would be to construct the correct metadata and add it to the metadata store based on the saved line list. With this fix we are not able to restore the dimensions in the ui if the analytics request fails.