### PR TITLE
chore: update nightly failure link in bot message

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,6 +44,6 @@ jobs:
               uses: slackapi/slack-github-action@v1.23.0
               with:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-                  slack-message: ':x: Line-listing-app e2e nightly build <https://cloud.cypress.io/projects/m5qvjx/runs?branches=[{"label":"dev","suggested":false,"value":"dev"}]|failed>'
+                  slack-message: ':x: Line-listing-app e2e nightly build <https://cloud.cypress.io/projects/m5qvjx/runs?branches=[{"label":"master","suggested":false,"value":"master"}]|failed>'
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/cypress/integration/value.cy.js
+++ b/cypress/integration/value.cy.js
@@ -120,7 +120,10 @@ describe('option sets', () => {
 
         clickMenubarUpdateButton()
 
-        cy.getBySel('table-header', EXTENDED_TIMEOUT).eq(0).find('button').click()
+        cy.getBySel('table-header', EXTENDED_TIMEOUT)
+            .eq(0)
+            .find('button')
+            .click()
 
         expectTableToMatchRows([`${currentYear}-06-01`, `${currentYear}-06-28`])
 

--- a/cypress/integration/value.cy.js
+++ b/cypress/integration/value.cy.js
@@ -30,6 +30,7 @@ import {
     getTableDataCells,
     getTableRows,
 } from '../helpers/table.js'
+import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const shouldHaveWhiteSpace = (index, value) =>
     getTableDataCells()
@@ -119,7 +120,7 @@ describe('option sets', () => {
 
         clickMenubarUpdateButton()
 
-        cy.getBySel('table-header').eq(0).find('button').click()
+        cy.getBySel('table-header', EXTENDED_TIMEOUT).eq(0).find('button').click()
 
         expectTableToMatchRows([`${currentYear}-06-01`, `${currentYear}-06-28`])
 


### PR DESCRIPTION
The bot message with the link to the failure was wrong since switching from dev to master.

Also, extended timeout added to hopefully prevent this test from timing out in the future.