### PR TITLE
fix: use local copy of e2e-dev in nightly github workflow

### DIFF
--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -1,0 +1,73 @@
+name: 'e2e-dev'
+
+on:
+    workflow_call:
+        secrets:
+            baseurl:
+                required: true
+            username:
+                required: true
+            password:
+                required: true
+            recordkey:
+                required: true
+
+concurrency:
+    group: e2e-dev-${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    compute-dev-version:
+        if: "!github.event.push.repository.fork && (github.event.pull_request.draft == false || github.action == 'workflow_dispatch')"
+        runs-on: ubuntu-latest
+        outputs:
+            version: ${{ steps.instance-version.outputs.version }}
+        steps:
+            - name: Output dev version
+              id: instance-version
+              uses: dhis2/action-instance-version@v1
+              with:
+                  instance-url: ${{ secrets.baseurl }}
+                  username: ${{ secrets.username }}
+                  password: ${{ secrets.password }}
+
+    e2e-dev:
+        needs: compute-dev-version
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                containers: [1, 2, 3, 4]
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
+
+            - name: Run e2e tests
+              uses: cypress-io/github-action@v5
+              with:
+                  start: yarn d2-app-scripts start
+                  wait-on: 'http://localhost:3000'
+                  wait-on-timeout: 300
+                  record: true
+                  parallel: true
+                  browser: chrome
+                  group: e2e-chrome-parallel-dev
+              env:
+                  BROWSER: none
+                  CYPRESS_RECORD_KEY: ${{ secrets.recordkey }}
+                  CYPRESS_dhis2BaseUrl: ${{ secrets.baseurl }}
+                  CYPRESS_dhis2InstanceVersion: ${{ needs.compute-dev-version.outputs.version }}
+                  CYPRESS_dhis2Username: ${{ secrets.username }}
+                  CYPRESS_dhis2Password: ${{ secrets.password }}
+                  CYPRESS_networkMode: live
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ defaults:
 
 jobs:
     call-workflow-e2e-dev:
-        uses: dhis2/data-visualizer-app/.github/workflows/e2e-dev.yml@dev
+        uses: ./.github/workflows/e2e-dev.yml
         secrets:
             baseurl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_DEV }}
             username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}


### PR DESCRIPTION
Implements a fix for the nightly job, which was broken after https://github.com/dhis2/line-listing-app/pull/374 was merged.

---

### Key features

1. Will (hopefully) avoid the Cypress out-of-memory issue on CI

---

### Description

When working on https://github.com/dhis2/line-listing-app/pull/374 I tweaked a lot of things to reduce the likelyhood of seeing the `Missing browserCriClient in connectToNewSpec` error occur during the Cypress e2e test run.

One of the things I did was to start working with a local copy of the `e2e-prod` GitHub workflow. I did this because the shared version of this workflow from data-visualizer is using a pre-baked Docker container in which the error was occuring very frequently. Not using that container made the error occur less frequently.

Whilst working on https://github.com/dhis2/line-listing-app/pull/374 I never really paid much attention to the nightly workflow, and upon inspection this is also using a shared workflow from data-visualizer, and this workflow is also using a docker container.

So what I've done in this PR is:
- Create a local copy of e2e-dev which *doesn't* use a container.
- Switched to using that local workflow in the nighly workflow.
