### PR TITLE
chore: increase cypress default timeout for DOM activity

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -42,6 +42,7 @@ module.exports = defineConfig({
             runMode: 1,
             openMode: 0,
         },
+        defaultCommandTimeout: 15000,
     },
     env: {
         dhis2DatatestPrefix: 'dhis2-linelisting',

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -1,1 +1,1 @@
-export const EXTENDED_TIMEOUT = { timeout: 15000 }
+export const EXTENDED_TIMEOUT = { timeout: 25000 }


### PR DESCRIPTION
based on https://github.com/dhis2/maps-app/pull/2720

We seem to get random failures pretty regularly and they are often caused by slow instance. This will increase the default timeout for all DOM activity, which I hope will alleviate some of this.