### PR TITLE
chore: nightly workflow - enable manual runs and change scheduled time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,8 @@ name: 'dhis2: nightly'
 
 on:
     schedule:
-        - cron: '20 6 * * 1-5'
+        - cron: '20 5 * * 1-5'
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}


### PR DESCRIPTION
Enables manual runs ([more info](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow))

Changes the time to 5am UTC (7am CEST)