### PR TITLE
fix: handle options with non-unique codes across optionsets (DHIS2-15771)

### DIFF
--- a/cypress/helpers/transfer.js
+++ b/cypress/helpers/transfer.js
@@ -1,5 +1,5 @@
 import { EXTENDED_TIMEOUT } from '../support/util.js'
-import { typeInput, clearInput } from './common.js'
+import { typeInput } from './common.js'
 
 export const searchAndSelectInOptionsTransfer = (name) => {
     cy.getBySel('option-set-transfer-option', EXTENDED_TIMEOUT)

--- a/cypress/helpers/transfer.js
+++ b/cypress/helpers/transfer.js
@@ -1,5 +1,5 @@
 import { EXTENDED_TIMEOUT } from '../support/util.js'
-import { typeInput } from './common.js'
+import { typeInput, clearInput } from './common.js'
 
 export const searchAndSelectInOptionsTransfer = (name) => {
     cy.getBySel('option-set-transfer-option', EXTENDED_TIMEOUT)
@@ -17,6 +17,10 @@ export const searchAndSelectInOptionsTransfer = (name) => {
         .get('[data-test="dhis2-uicore-circularloader"]', EXTENDED_TIMEOUT)
         .should('not.exist')
 
+    selectInOptionsTransfer(name)
+}
+
+export const selectInOptionsTransfer = (name) => {
     cy.getBySel('option-set-transfer-sourceoptions')
         .containsExact(name)
         .dblclick()

--- a/cypress/integration/conditions/optionSetCondition.cy.js
+++ b/cypress/integration/conditions/optionSetCondition.cy.js
@@ -5,6 +5,7 @@ import {
     TEST_DIM_TEXT_OPTIONSET,
     TEST_REL_PE_LAST_YEAR,
 } from '../../data/index.js'
+import { goToAO } from '../../helpers/common.js'
 import {
     openDimension,
     openProgramDimensionsSidebar,
@@ -26,7 +27,10 @@ import {
     expectTableToMatchRows,
     expectTableToNotContainValue,
 } from '../../helpers/table.js'
-import { searchAndSelectInOptionsTransfer } from '../../helpers/transfer.js'
+import {
+    searchAndSelectInOptionsTransfer,
+    selectInOptionsTransfer,
+} from '../../helpers/transfer.js'
 
 describe('Option set condition', () => {
     it('Option set (number) displays correctly', () => {
@@ -134,5 +138,40 @@ describe('Option set condition', () => {
         expectTableToContainValue(filteredOptionName)
 
         expectTableToMatchRows([`${getPreviousYearStr()}-12-10`])
+    })
+
+    it('Options with same code but from different option sets display correctly', () => {
+        const testData = [
+            {
+                dimensionName: 'WHOMCH Pain medication given',
+                filteredOptionNames: ['Morphine', 'Spinal'],
+            },
+            {
+                dimensionName: 'WHOMCH Clinical impression of pre-eclampsia',
+                filteredOptionNames: [
+                    'None',
+                    'Pre-eclampsia',
+                    'Severe pre-eclampsia',
+                ],
+            },
+        ]
+
+        goToAO('C1XaMuNaeDy')
+
+        expectTableToBeVisible()
+
+        testData.forEach(({ dimensionName, filteredOptionNames }) => {
+            cy.getBySelLike('layout-chip').contains(dimensionName).click()
+
+            filteredOptionNames.forEach(selectInOptionsTransfer)
+
+            cy.getBySel('conditions-modal').contains('Update').click()
+
+            assertChipContainsText(
+                `${dimensionName}: ${filteredOptionNames.length} selected`
+            )
+
+            assertTooltipContainsEntries(filteredOptionNames)
+        })
     })
 })

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -32,6 +32,7 @@ import {
     TEST_DIM_TEXT_OPTIONSET,
     TEST_REL_PE_THIS_YEAR,
 } from '../data/index.js'
+import { goToAO } from '../helpers/common.js'
 import {
     clickAddRemoveMainDimension,
     clickAddRemoveProgramDataDimension,
@@ -236,6 +237,33 @@ const assertDimensions = () => {
     }
 }
 
+const assertOptionSetOptionLabels = () => {
+    goToAO('C1XaMuNaeDy')
+
+    expectTableToBeVisible()
+
+    getTableRows()
+        .eq(0)
+        .find('td')
+        .eq(3)
+        .invoke('text')
+        .then(($cell3Value) => expect($cell3Value).to.equal('Pre-eclampsia'))
+
+    getTableRows()
+        .eq(0)
+        .find('td')
+        .eq(4)
+        .invoke('text')
+        .then(($cell4Value) => expect($cell4Value).to.equal('Suspected'))
+
+    getTableRows()
+        .eq(0)
+        .find('td')
+        .eq(5)
+        .invoke('text')
+        .then(($cell5Value) => expect($cell5Value).to.equal('Morphine'))
+}
+
 const assertSorting = () => {
     // remove any DGS to allow numeric value comparison
     openStyleOptionsModal()
@@ -353,6 +381,9 @@ describe(['>=38', '<39'], 'table', () => {
     it('data can be sorted', () => {
         assertSorting()
     })
+    it('option set option labels show correctly', () => {
+        assertOptionSetOptionLabels()
+    })
 })
 
 describe(['>=39'], 'table', () => {
@@ -374,5 +405,8 @@ describe(['>=39'], 'table', () => {
     })
     it('data can be sorted (>=2.39)', () => {
         assertSorting()
+    })
+    it('option set option labels show correctly (>=2.39)', () => {
+        assertOptionSetOptionLabels()
     })
 })

--- a/src/components/Dialogs/Conditions/OptionSetCondition.js
+++ b/src/components/Dialogs/Conditions/OptionSetCondition.js
@@ -36,15 +36,16 @@ const OptionSetCondition = ({
     const dataTest = 'option-set'
 
     const setValues = (selected) => {
-        addMetadata(
-            state.options
-                .filter(
-                    (item) =>
-                        selected.includes(item.code) &&
-                        !selectedOptions.find((so) => so.code === item.code)
-                )
-                .reduce((acc, item) => ({ ...acc, [item.id]: item }), {})
-        )
+        addMetadata({
+            // update options in the optionSet metadata used for the lookup of the correct
+            // name from code (options for different option sets have the same code)
+            [optionSetId]: {
+                ...metadata[optionSetId],
+                options: selected.map((soCode) =>
+                    state.options.find(({ code }) => code === soCode)
+                ),
+            },
+        })
 
         onChange(`${OPERATOR_IN}:${selected.join(';') || ''}`)
     }

--- a/src/components/DownloadMenu/useDownload.js
+++ b/src/components/DownloadMenu/useDownload.js
@@ -86,12 +86,20 @@ const useDownload = (relativePeriodDate) => {
                         .withOutputType(current.outputType)
                         .withPath(path)
                         .withFormat(format)
-                        .withOutputIdScheme(idScheme)
                         .withParameters({
                             ...parameters,
                             headers,
                             paging: false,
                         })
+
+                    // fix option set option names
+                    if (idScheme === ID_SCHEME_NAME) {
+                        req = req.withParameters({
+                            dataIdScheme: idScheme,
+                        })
+                    } else {
+                        req = req.withOutputIdScheme(idScheme)
+                    }
 
                     // TODO options
                     // startDate

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -44,8 +44,21 @@ const excludedDimensions = [
     DIMENSION_ID_LAST_UPDATED_BY,
 ]
 
-const findOptionSetItem = (code, metaDataItems) =>
-    Object.values(metaDataItems).find((item) => item.code === code)
+const findOptionSetItem = (optionSetId, code, metaDataItems) => {
+    const optionSetMetaData = metaDataItems[optionSetId]
+
+    if (optionSetMetaData) {
+        const optionId = optionSetMetaData.options.find(
+            (option) => option.code === code
+        )?.id
+
+        if (optionId) {
+            return metaDataItems[optionId]
+        }
+    }
+
+    return undefined
+}
 
 const formatRowValue = (rowValue, header, metaDataItems) => {
     switch (header.valueType) {
@@ -58,7 +71,8 @@ const formatRowValue = (rowValue, header, metaDataItems) => {
             }
             if (header.optionSet) {
                 return (
-                    findOptionSetItem(rowValue, metaDataItems)?.name || rowValue
+                    findOptionSetItem(header.optionSet, rowValue, metaDataItems)
+                        ?.name || rowValue
                 )
             }
             return metaDataItems[rowValue]?.name || rowValue

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -45,7 +45,7 @@ const excludedDimensions = [
 ]
 
 const findOptionSetItem = (optionSetId, code, metaDataItems) => {
-    const optionSetMetaData = metaDataItems[optionSetId]
+    const optionSetMetaData = metaDataItems?.[optionSetId]
 
     if (optionSetMetaData) {
         const optionId = optionSetMetaData.options.find(

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -50,7 +50,7 @@ const findOptionSetItem = (optionSetId, code, metaDataItems) => {
     if (optionSetMetaData) {
         const optionId = optionSetMetaData.options.find(
             (option) => option.code === code
-        )?.id
+        )?.uid
 
         if (optionId) {
             return metaDataItems[optionId]

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -52,9 +52,7 @@ const findOptionSetItem = (optionSetId, code, metaDataItems) => {
             (option) => option.code === code
         )?.uid
 
-        if (optionId) {
-            return metaDataItems[optionId]
-        }
+        return metaDataItems[optionId]
     }
 
     return undefined

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -44,7 +44,7 @@ const excludedDimensions = [
     DIMENSION_ID_LAST_UPDATED_BY,
 ]
 
-const findOptionSetItem = (optionSetId, code, metaDataItems) => {
+const lookupOptionSetOptionMetadata = (optionSetId, code, metaDataItems) => {
     const optionSetMetaData = metaDataItems?.[optionSetId]
 
     if (optionSetMetaData) {
@@ -67,12 +67,17 @@ const formatRowValue = (rowValue, header, metaDataItems) => {
             if (!rowValue) {
                 return rowValue
             }
+
             if (header.optionSet) {
                 return (
-                    findOptionSetItem(header.optionSet, rowValue, metaDataItems)
-                        ?.name || rowValue
+                    lookupOptionSetOptionMetadata(
+                        header.optionSet,
+                        rowValue,
+                        metaDataItems
+                    )?.name || rowValue
                 )
             }
+
             return metaDataItems[rowValue]?.name || rowValue
         }
     }

--- a/src/modules/__tests__/conditions.spec.js
+++ b/src/modules/__tests__/conditions.spec.js
@@ -45,9 +45,14 @@ test('Dimension with optionSet', () => {
         condition: 'IN:5code;6code',
     }
     const metadata = {
-        '5Id': { code: '5code', name: '5' },
-        '6Id': { code: '6code', name: '6' },
+        optionsetId: {
+            options: [
+                { code: '5code', name: '5' },
+                { code: '6code', name: '6' },
+            ],
+        },
     }
+
     const dimension = {
         optionSet: 'optionsetId',
         valueType: 'NUMBER',

--- a/src/modules/conditions.js
+++ b/src/modules/conditions.js
@@ -32,6 +32,9 @@ export const parseConditionsStringToArray = (conditionsString) =>
 export const parseConditionsArrayToString = (conditionsArray) =>
     conditionsArray.join(':')
 
+export const parseCondition = (conditionItem) =>
+    conditionItem.split(':').pop().split(';')
+
 export const NULL_VALUE = 'NV'
 export const TRUE_VALUE = '1'
 export const FALSE_VALUE = '0'
@@ -167,8 +170,13 @@ const getOperatorsByValueType = (valueType) => {
     }
 }
 
-const parseCondition = (conditionItem) =>
-    conditionItem.split(':').pop().split(';')
+const lookupOptionSetOptionMetadata = (optionSetId, code, metaData) => {
+    const optionSetMetaData = metaData?.[optionSetId]
+
+    return optionSetMetaData
+        ? optionSetMetaData.options?.find((option) => option.code === code)
+        : undefined
+}
 
 export const getConditionsTexts = ({
     conditions = {},
@@ -194,9 +202,14 @@ export const getConditionsTexts = ({
 
     if (dimension.optionSet && conditionsList[0]?.startsWith(OPERATOR_IN)) {
         const items = parseCondition(conditionsList[0])
+
         const itemNames = items.map(
             (code) =>
-                Object.values(metadata).find((item) => item.code === code)?.name
+                lookupOptionSetOptionMetadata(
+                    dimension.optionSet,
+                    code,
+                    metadata
+                )?.name
         )
         return itemNames
     }


### PR DESCRIPTION
This requires a backend fix.

Fixes [DHIS2-15771](https://dhis2.atlassian.net/browse/DHIS2-15771)
Fixes [DHIS2-16181](https://dhis2.atlassian.net/browse/DHIS2-16181)

**Requires [DHIS2-15775](https://dhis2.atlassian.net/browse/DHIS2-15775)**

---

### Key features

1. lookup option set option labels correctly in the table rows
2. show the correct name in the layout chip tooltips
3. refactor how the metadata for option sets is stored in Redux

---

### Description

Options for different option sets can use the same `code`, which is what is returned in the rows in the analytics response.
The previous way of looking up the label to display in the table simply tried to find a metadata object whom `code` matches the value for the option set in the response's rows.
This cause to display the wrong label when different option sets are displayed at the same time and happen to use the same `code`.

Refer to the screenshots below.
The 3 columns are 3 different option sets, but they all use the same `code` (**1**) for their option.
The first matching `code` found in metadata items (in the analytics response) was always used regardless of the option set.

The fix is to look in metadata first for the `optionSet`, and find the matching option by `code` within the listed `options`.
Then the option's id is used to lookup the option itself in metadata and from there the `name` is extracted and used in the table.

The same logic needs to be applied when looking up the name to display in the layout chip tooltip for dimensions with option set where there is a specific selection (not all values).

We also need to add the metadata for the options when loading a saved visualization.
The reason here is that the table might not have all the values there are selected for the option set, and in that case the metadata from the analytics response is partial.

While working on this I realised that we don't really need to store the metadata for the single options of an option set.
Since we need them in the `options` object in the option set metadata anyway for the lookup, we can have the `name` in there as well and skip one lookup.

---

### TODO

-   [x] Cypress tests
-   [x] Update docs?
-   [x] Manual testing

---

### Known issues

-   [x] a Cypress test in `table.cy.js` is now failing due to this change. This is not a regression, it should be working once the backend fix is available.

---

### Screenshots

Table before:
![Screenshot 2023-09-04 at 14 03 38](https://github.com/dhis2/line-listing-app/assets/150978/bb6809e9-48ea-488f-9a16-2d3f3388adac)

Table after:
![Screenshot 2023-09-04 at 13 57 48](https://github.com/dhis2/line-listing-app/assets/150978/884fabbe-29ed-408f-b018-4fec9c8a8833)

Tooltip before:
Notice the names for the selected options are wrong when a different dimension with option set has also a selection and the `code` used is the same:
<img width="402" alt="Screenshot 2023-11-23 at 11 19 45" src="https://github.com/dhis2/line-listing-app/assets/150978/9f7b22ec-3f12-4cb8-8cef-ac4a2dc455a7">

<img width="813" alt="Screenshot 2023-11-23 at 11 19 51" src="https://github.com/dhis2/line-listing-app/assets/150978/d7901b1d-c6e3-44c3-be10-7049ff774021">

In this example, this selection was made first:
<img width="350" alt="Screenshot 2023-11-23 at 11 19 25" src="https://github.com/dhis2/line-listing-app/assets/150978/d73bd064-27d5-43cc-a3df-68354133b923">

Tooltip after:
Notice the Pain medication dimension has 5 options selected, but the tooltip for pre-eclampsia is correct:
<img width="627" alt="Screenshot 2023-11-23 at 11 23 08" src="https://github.com/dhis2/line-listing-app/assets/150978/c66b2ad7-cdf6-4675-b868-ab7f01a57115">


[DHIS2-15771]: https://dhis2.atlassian.net/browse/DHIS2-15771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15773]: https://dhis2.atlassian.net/browse/DHIS2-15773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-15775]: https://dhis2.atlassian.net/browse/DHIS2-15775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-16181]: https://dhis2.atlassian.net/browse/DHIS2-16181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ