### PR TITLE
fix: correctly center the table spinner (DHIS2-13947, DHIS2-13946)

### DIFF
--- a/cypress/helpers/table.js
+++ b/cypress/helpers/table.js
@@ -20,7 +20,7 @@ export const expectTableToBeVisible = () =>
     getLineListTable().find('tbody').should('be.visible')
 
 export const expectTableToBeUpdated = () =>
-    cy.getBySel('line-list-loading-indicator').should(($div) => {
+    cy.getBySel('line-list-fetch-container').should(($div) => {
         const className = $div[0].className
 
         expect(className).to.not.match(/Visualization_fetching*/)

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -179,6 +179,30 @@ export const Visualization = ({
         sortDirection,
     })
 
+    const fetchContainerRef = useRef(null)
+    const dataTableHeadRef = useRef(null)
+    const dataTableFootRef = useRef(null)
+    const fetchIndicatorTop = useMemo(() => {
+        if (
+            !fetching ||
+            !fetchContainerRef?.current ||
+            !dataTableHeadRef?.current ||
+            !dataTableFootRef?.current
+        ) {
+            return 'calc(50% - 12px)'
+        }
+
+        const containerHeight = fetchContainerRef.current.clientHeight
+        const headHeight = dataTableHeadRef.current.offsetHeight
+        const footHeight = dataTableFootRef.current.offsetHeight
+        // tbody height excluding the parts hidden by scrolling
+        const visibleBodyHeight = containerHeight - headHeight - footHeight
+        // 12 px is half the loader height
+        const top = Math.round(headHeight + visibleBodyHeight / 2 - 12)
+
+        return `${top}px`
+    }, [fetching])
+
     // Reset page for new visualizations
     useEffect(() => {
         visualizationRef.current = visualization
@@ -305,11 +329,16 @@ export const Visualization = ({
     return (
         <div className={styles.pluginContainer} ref={containerCallbackRef}>
             <div
-                data-test="line-list-loading-indicator"
-                className={cx(styles.fetchIndicator, {
+                data-test="line-list-fetch-container"
+                className={cx(styles.fetchContainer, {
                     [styles.fetching]: fetching,
                 })}
+                ref={fetchContainerRef}
             >
+                <div
+                    className={styles.fetchIndicator}
+                    style={{ top: fetchIndicatorTop }}
+                />
                 <DataTable
                     scrollHeight={isInModal ? 'calc(100vh - 285px)' : '100%'}
                     scrollWidth={'100%'}
@@ -317,7 +346,7 @@ export const Visualization = ({
                     className={styles.dataTable}
                     dataTest="line-list-table"
                 >
-                    <DataTableHead>
+                    <DataTableHead ref={dataTableHeadRef}>
                         <DataTableRow>
                             {data.headers.map((header, index) =>
                                 header ? (
@@ -423,7 +452,10 @@ export const Visualization = ({
                             </DataTableRow>
                         ))}
                     </DataTableBody>
-                    <DataTableFoot className={styles.stickyFooter}>
+                    <DataTableFoot
+                        className={styles.stickyFooter}
+                        ref={dataTableFootRef}
+                    >
                         <DataTableRow>
                             <DataTableCell
                                 colSpan={colSpan}

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -11,21 +11,23 @@
     min-width: 0;
 }
 
-.fetchIndicator {
+.fetchContainer {
+    display: flex;
+    align-self: flex-start;
     position: relative;
+    height: auto;
     min-width: 0;
     max-height: 100%;
-    display: flex;
+    background-color: red;
 }
 
-.fetchIndicator.fetching::after {
+.fetchContainer.fetching > .fetchIndicator {
     content: '';
     position: absolute;
-    top: calc(50% - 24px);
-    left: calc(50% - 24px);
-    width: 48px;
-    height: 48px;
-    border-width: 6px;
+    left: calc(50% - 12px);
+    width: 24px;
+    height: 24px;
+    border-width: 3px;
     border-style: solid;
     border-color: rgba(110, 122, 138, 0.15) rgba(110, 122, 138, 0.15)
         rgb(20, 124, 215);
@@ -35,16 +37,17 @@
     animation-iteration-count: infinite;
     animation-name: rotation;
     animation-timing-function: linear;
+    z-index: 1;
 }
 
-.fetchIndicator.fetching tbody::before {
+.fetchContainer.fetching tbody::before {
     content: '';
     position: absolute;
     inset: 0px;
     background-color: rgba(255, 255, 255, 0.8);
 }
 
-.fetchIndicator :global(.tablescrollbox) {
+.fetchContainer :global(.tablescrollbox) {
     transition: max-width 200ms ease-out;
 }
 


### PR DESCRIPTION
Implements [DHIS2-13947](https://dhis2.atlassian.net/browse/DHIS2-13947) & [DHIS2-13946](https://dhis2.atlassian.net/browse/DHIS2-13946)

---

### Key features

1. Fixes spinner positioning

---

### Description

- As discussed, the horizontal alignment has remained unchanged.
- A fix in `@dhis2/ui` would be very involved, so a fix in the app was made
- I have reduced the spinner size by half, so it now fits into a single row
- I have tested vertical alignment in the main canvas, in the modal, for scrollable tables and tables with as few as one single row. In all these cases the alignment looked perfect.

---

### Note

- To test I recommend toggling the network traffic to slow 3g

---

### Screenshots


<img width="1640" alt="Screenshot 2023-09-11 at 15 05 30" src="https://github.com/dhis2/line-listing-app/assets/353236/1a66effd-5e4b-41b1-baed-f9527f86a7a3">
<img width="1636" alt="Screenshot 2023-09-11 at 15 04 00" src="https://github.com/dhis2/line-listing-app/assets/353236/75dc4db3-5101-470b-9da2-e2766b9e57a6">
<img width="1634" alt="Screenshot 2023-09-11 at 15 02 23" src="https://github.com/dhis2/line-listing-app/assets/353236/3e0db78d-0bda-47cd-8bf9-b330d43e10b5">
<img width="1632" alt="Screenshot 2023-09-11 at 14 59 25" src="https://github.com/dhis2/line-listing-app/assets/353236/03ae4e99-2723-4bf4-8d87-1da1e22a4646">


[DHIS2-13947]: https://dhis2.atlassian.net/browse/DHIS2-13947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-13946]: https://dhis2.atlassian.net/browse/DHIS2-13946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ