### PR TITLE
chore: only run the release-success and release-failure gh workflow jobs on release commits

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -161,7 +161,8 @@ jobs:
         if: |
             success() &&
             !cancelled()  &&
-            github.ref == 'refs/heads/master'
+            github.ref == 'refs/heads/master' &&
+            contains(github.event.head_commit.message, 'chore(release)')
         steps:
             - name: Checkout code
               uses: actions/checkout@master

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -125,7 +125,8 @@ jobs:
         if: |
             failure() &&
             !cancelled() &&
-            github.ref == 'refs/heads/master'
+            github.ref == 'refs/heads/master' &&
+            contains(github.event.head_commit.message, 'chore(release)')
         steps:
             - name: Checkout code
               uses: actions/checkout@master

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -142,13 +142,13 @@ jobs:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
                   payload: |
                       {
-                        "text": ":small_red_triangle_down: :line-listing-app: Line Listing version ${{ steps.extract_version.outputs.version }} release <https://github.com/dhis2/line-listing-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>",
+                        "text": ":small_red_triangle_down: :line-listing-app: Line Listing release <https://github.com/dhis2/line-listing-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>",
                         "blocks": [
                           {
                             "type": "section",
                             "text": {
                               "type": "mrkdwn",
-                              "text": ":small_red_triangle_down: :line-listing-app: Line Listing version ${{ steps.extract_version.outputs.version }} release <https://github.com/dhis2/line-listing-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>"
+                              "text": ":small_red_triangle_down: :line-listing-app: Line Listing release <https://github.com/dhis2/line-listing-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>"
                             }
                           }
                         ]


### PR DESCRIPTION
Currently there are release messages every time there is a push to master and the release step succeeds. But the release step succeeds even if there is no actual release (e.g chores, docs etc). Therefore, we need to check the commit message to ensure it was an actual release.