### PR TITLE
chore: take legend-key into account when computing pagination max-width

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -126,6 +126,7 @@ export const Visualization = ({
     const visualization = useMemo(() => AO && transformVisualization(AO), [AO])
 
     const visualizationRef = useRef(visualization)
+    const legendKeyRef = useRef(null)
 
     const containerCallbackRef = useCallback((node) => {
         if (node === null) {
@@ -139,8 +140,12 @@ export const Visualization = ({
             const containerInnerWidth = node.clientWidth
             const scrollBox = node.querySelector('.tablescrollbox')
             const scrollbarWidth = scrollBox.offsetWidth - scrollBox.clientWidth
+            const legendKeyWidth =
+                legendKeyRef.current?.offsetWidth > 0
+                    ? legendKeyRef.current.offsetWidth + 4
+                    : 0
             const maxWidth = Math.max(
-                containerInnerWidth - scrollbarWidth,
+                containerInnerWidth - scrollbarWidth - legendKeyWidth,
                 PAGINATION_MIN_WIDTH
             )
 
@@ -305,6 +310,7 @@ export const Visualization = ({
         <div
             className={styles.legendKeyScrollbox}
             data-test="visualization-legend-key"
+            ref={legendKeyRef}
         >
             <LegendKey legendSets={uniqueLegendSets} />
         </div>


### PR DESCRIPTION
Fixes (another) regression in  [DHIS2-15465](https://dhis2.atlassian.net/browse/DHIS2-15465)

---

### Key features

1. Pagination is now also correct when a legend key is showing

---

### Screenshots

Before
<img width="1540" alt="Screenshot 2023-10-12 at 15 29 06" src="https://github.com/dhis2/line-listing-app/assets/353236/fcfd2892-5a9c-465c-b208-fe31280b604d">

After
<img width="1535" alt="Screenshot 2023-10-12 at 15 28 39" src="https://github.com/dhis2/line-listing-app/assets/353236/4aac9eff-97a8-4df9-8889-cafcae8f794f">


[DHIS2-15465]: https://dhis2.atlassian.net/browse/DHIS2-15465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ