### PR TITLE
fix: authorities is needed for the interpretation access check [DHIS2-15964]

### DIFF
--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -17,7 +17,7 @@ const query = {
     currentUser: {
         resource: 'me',
         params: {
-            fields: 'id,username,displayName~rename(name),settings',
+            fields: 'id,username,displayName~rename(name),settings,authorities',
         },
     },
     systemSettings: {


### PR DESCRIPTION
The interpretations access check needs the list of authorities