### PR TITLE
test: use test.e2e instances for Cypress testing

### DIFF
--- a/.github/workflows/e2e-prod.yml
+++ b/.github/workflows/e2e-prod.yml
@@ -26,9 +26,9 @@ on:
                 required: true
 
 env:
-    BASE_URL_INSTANCES: https://debug.dhis2.org
-    NAME_PATTERN_PROD_INSTANCES: '{version}'
-    NAME_PATTERN_DEV_INSTANCE: dev
+    BASE_URL_INSTANCES: https://test.e2e.dhis2.org
+    NAME_PATTERN_PROD_INSTANCES: 'analytics-{version}'
+    NAME_PATTERN_DEV_INSTANCE: analytics-dev
 
 concurrency:
     group: e2e-prod-${{ github.workflow}}-${{ github.ref }}


### PR DESCRIPTION

### Key features

1. restore test.e2e instances for Cypress testing

---

### Description

Now that test.e2e instances are working again, use those instead of debug
