### PR TITLE
test: add tests for error when renaming a saved visualization (DHIS2-16154)

### DIFF
--- a/cypress/helpers/fileMenu.js
+++ b/cypress/helpers/fileMenu.js
@@ -1,4 +1,4 @@
-import { clearInput, typeInput } from './common.js'
+import { clearInput, typeInput, clearTextarea, typeTextarea } from './common.js'
 
 export const ITEM_NEW = 'file-menu-new'
 export const ITEM_OPEN = 'file-menu-open'
@@ -49,4 +49,22 @@ export const deleteVisualization = () => {
     cy.getBySel('file-menu-delete-modal-delete').click()
 
     cy.getBySel('titlebar').should('not.exist')
+}
+
+export const renameVisualization = (name, description) => {
+    cy.getBySel('dhis2-analytics-hovermenubar').contains('File').click()
+
+    cy.getBySel(ITEM_RENAME).click()
+
+    if (name) {
+        clearInput('file-menu-rename-modal-name-content')
+        typeInput('file-menu-rename-modal-name-content', name)
+    }
+
+    if (description) {
+        clearTextarea('file-menu-rename-modal-description-content')
+        typeTextarea('file-menu-rename-modal-description-content', description)
+    }
+
+    cy.getBySel('file-menu-rename-modal-rename').click()
 }

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -59,13 +59,13 @@ describe('rename', () => {
         // rename the AO, changing name only
         renameVisualization(UPDATED_AO_NAME)
 
-        expectAOTitleToContain(AO_NAME)
         expectTableToBeVisible()
+        expectAOTitleToContain(AO_NAME)
 
         cy.reload()
 
-        expectAOTitleToContain(UPDATED_AO_NAME)
         expectTableToBeVisible()
+        expectAOTitleToContain(UPDATED_AO_NAME)
 
         deleteVisualization()
     })

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -58,7 +58,10 @@ describe('rename', () => {
 
         // rename the AO, changing name only
         renameVisualization(UPDATED_AO_NAME)
-        expectTableToBeVisible()
+
+        cy.reload()
+
+        expectAOTitleToContain(UPDATED_AO_NAME)
 
         deleteVisualization()
     })

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -59,6 +59,8 @@ describe('rename', () => {
         // rename the AO, changing name only
         renameVisualization(UPDATED_AO_NAME)
 
+        expectAOTitleToContain(AO_NAME)
+
         cy.reload()
 
         expectAOTitleToContain(UPDATED_AO_NAME)

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -56,8 +56,14 @@ describe('rename', () => {
         expectAOTitleToContain(AO_NAME)
         expectTableToBeVisible()
 
+        cy.intercept('PATCH', '**/api/*/eventVisualizations/*').as(
+            'patch-rename'
+        )
+
         // rename the AO, changing name only
         renameVisualization(UPDATED_AO_NAME)
+
+        cy.wait('@patch-rename')
 
         expectTableToBeVisible()
         expectAOTitleToContain(AO_NAME)

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -14,11 +14,15 @@ import {
 } from '../helpers/dimensions.js'
 import {
     deleteVisualization,
+    renameVisualization,
     resaveVisualization,
     saveVisualization,
     saveVisualizationAs,
 } from '../helpers/fileMenu.js'
-import { clickMenubarUpdateButton } from '../helpers/menubar.js'
+import {
+    clickMenubarUpdateButton,
+    clickMenubarInterpretationsButton,
+} from '../helpers/menubar.js'
 import { selectFixedPeriod, selectRelativePeriod } from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import {
@@ -40,6 +44,59 @@ const setupTable = () => {
     clickMenubarUpdateButton()
     expectTableToBeVisible()
 }
+
+describe('rename', () => {
+    it('replace existing name works correctly', () => {
+        const AO_NAME = `TEST RENAME ${new Date().toLocaleString()}`
+        const UPDATED_AO_NAME = AO_NAME + ' 2'
+        setupTable()
+
+        // save
+        saveVisualization(AO_NAME)
+        expectAOTitleToContain(AO_NAME)
+        expectTableToBeVisible()
+
+        // rename the AO, changing name only
+        renameVisualization(UPDATED_AO_NAME)
+        expectTableToBeVisible()
+
+        deleteVisualization()
+    })
+
+    it('add non existing description works correctly', () => {
+        const AO_NAME = `TEST RENAME ${new Date().toLocaleString()}`
+        const AO_DESC = 'with description'
+        const AO_DESC_UPDATED = AO_DESC + ' edited'
+        setupTable()
+
+        // save
+        saveVisualization(AO_NAME)
+        expectAOTitleToContain(AO_NAME)
+        expectTableToBeVisible()
+
+        // rename the AO, adding a description
+        renameVisualization(AO_NAME, AO_DESC)
+
+        clickMenubarInterpretationsButton()
+        cy.getBySel('details-panel').should('be.visible')
+        cy.getBySel('details-panel').contains(AO_DESC)
+        clickMenubarInterpretationsButton()
+
+        expectTableToBeVisible()
+
+        // rename the AO, replacing the description
+        renameVisualization(AO_NAME, AO_DESC_UPDATED)
+
+        clickMenubarInterpretationsButton()
+        cy.getBySel('details-panel').should('be.visible')
+        cy.getBySel('details-panel').contains(AO_DESC_UPDATED)
+        clickMenubarInterpretationsButton()
+
+        expectTableToBeVisible()
+
+        deleteVisualization()
+    })
+})
 
 describe('save', () => {
     it('new AO with name saves correctly', () => {

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -60,10 +60,12 @@ describe('rename', () => {
         renameVisualization(UPDATED_AO_NAME)
 
         expectAOTitleToContain(AO_NAME)
+        expectTableToBeVisible()
 
         cy.reload()
 
         expectAOTitleToContain(UPDATED_AO_NAME)
+        expectTableToBeVisible()
 
         deleteVisualization()
     })

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -62,7 +62,7 @@ describe('rename', () => {
         expectTableToBeVisible()
         expectAOTitleToContain(AO_NAME)
 
-        cy.reload()
+        cy.reload(true)
 
         expectTableToBeVisible()
         expectAOTitleToContain(UPDATED_AO_NAME)


### PR DESCRIPTION
Fixes [DHIS2-16154](https://dhis2.atlassian.net/browse/DHIS2-16154)

**Requires https://github.com/dhis2/analytics/pull/1593**

---

### Key features

1. bump analytics dep with the actual fix
2. add some Cypress tests for File Menu rename

---

### Description

The rename feature stopped working when support for deprecated PATCH request format was removed.
`json+patch` format is required for PATCH requests now.
The implementation for File Menu rename and update of custom calculations is in `analytics` (see linked PR).

This PR adds some tests for the File Menu rename feature.

---

### TODO

-   [x] Cypress tests
-   [x] Update docs
-   [x] KFMT
-   [x] update dep once analytics PR [1593](https://github.com/dhis2/analytics/pull/1593) is merged

[DHIS2-16154]: https://dhis2.atlassian.net/browse/DHIS2-16154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ