### PR TITLE
fix: always show unformatted date

### DIFF
--- a/cypress/integration/period.cy.js
+++ b/cypress/integration/period.cy.js
@@ -100,7 +100,7 @@ describe('period dimension', { testIsolation: false }, () => {
             .trigger('mouseover')
 
         cy.getBySelLike('tooltip-content').contains(
-            `January 1, ${previousYear} - December 31, ${currentYear}`
+            `${previousYear}-01-01 - ${currentYear}-12-31`
         )
     })
     it('the custom period persists when reopening the modal', () => {
@@ -145,7 +145,7 @@ describe('period dimension', { testIsolation: false }, () => {
             .trigger('mouseover')
 
         cy.getBySelLike('tooltip-content').contains(
-            `January 1, ${previousYear} - December 31, ${currentYear}`
+            `${previousYear}-01-01 - ${currentYear}-12-31`
         )
 
         openModal(TEST_DIM_ID)

--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -24,7 +24,6 @@ import {
     SYSTEM_SETTINGS_HIDE_MONTHLY_PERIODS,
     SYSTEM_SETTINGS_HIDE_BIMONTHLY_PERIODS,
 } from '../../../modules/systemSettings.js'
-import { USER_SETTINGS_UI_LOCALE } from '../../../modules/userSettings.js'
 import {
     sGetDimensionIdsFromLayout,
     sGetUiItemsByDimension,
@@ -51,26 +50,6 @@ const useIsInLayout = (dimensionId) => {
         () => !!dimensionId && allDimensionIds.includes(dimensionId),
         [dimensionId, allDimensionIds]
     )
-}
-
-const useLocalizedStartEndDateFormatter = () => {
-    const { currentUser } = useCachedDataQuery()
-    const formatter = new Intl.DateTimeFormat(
-        currentUser.settings[USER_SETTINGS_UI_LOCALE],
-        {
-            dateStyle: 'long',
-        }
-    )
-    return (startEndDate) => {
-        if (isStartEndDate(startEndDate)) {
-            return startEndDate
-                .split('_')
-                .map((dateStr) => formatter.format(new Date(dateStr)))
-                .join(' - ')
-        } else {
-            return ''
-        }
-    }
 }
 
 const useMetadataNameGetter = () => {
@@ -104,7 +83,6 @@ const useExcludedPeriods = () => {
 }
 
 export const PeriodDimension = ({ dimension, onClose }) => {
-    const formatStartEndDate = useLocalizedStartEndDateFormatter()
     const getNameFromMetadata = useMetadataNameGetter()
     const dispatch = useDispatch()
     const isInLayout = useIsInLayout(dimension?.id)
@@ -126,7 +104,7 @@ export const PeriodDimension = ({ dimension, onClose }) => {
                 if (isStartEndDate(item.id)) {
                     acc.metadata[item.id] = {
                         id: item.id,
-                        name: formatStartEndDate(item.id),
+                        name: item.id.replace('_', ' - '),
                     }
                 } else {
                     acc.metadata[item.id] = item


### PR DESCRIPTION
No JIRA ticket avaiable

---

### Key features

1. Consistent custom date range strings in tooltip

---

### Description

Before, when setting a custom date range / defining a start and end date, after the first edit you would see a "pretty date" in the tooltip, but after each subsequent error, an unformatted date would show in that same tooltip. This PR makes the tooltip behaviour consistent by always showing an unformastted date. See [this Slack thread](https://dhis2.slack.com/archives/G3TL0J145/p1700493355195899) for a full discussion.

|  | Before fix | After fix |
| ------------- | ------------- | ------------- |
| After first selection  | <img width="272" alt="inital_pre_fix" src="https://github.com/dhis2/line-listing-app/assets/353236/dea18f79-caee-4ed4-acd5-511055a17901"> |  <img width="275" alt="initial_post_fix" src="https://github.com/dhis2/line-listing-app/assets/353236/1144bbe4-8e2d-4270-8021-6be632f61e61"> |
| After subsequent selections  |  <img width="272" alt="subsequent" src="https://github.com/dhis2/line-listing-app/assets/353236/6ab02a1e-a496-40c2-8ede-5107a4b8249b"> | <img width="272" alt="subsequent" src="https://github.com/dhis2/line-listing-app/assets/353236/6ab02a1e-a496-40c2-8ede-5107a4b8249b">  |


