### PR TITLE
fix: adjust input option design

### DIFF
--- a/src/components/MainSidebar/InputPanel/InputOption.js
+++ b/src/components/MainSidebar/InputPanel/InputOption.js
@@ -17,9 +17,11 @@ const InputOption = ({
         onClick={onClick}
         data-test={dataTest}
     >
-        <Radio checked={selected} />
         <div className={styles.label}>
-            <div className={styles.header}>{header}</div>
+            <div className={styles.header}>
+                <Radio dense checked={selected} />
+                <span>{header}</span>
+            </div>
             <div className={styles.description}>{description}</div>
             {children}
         </div>

--- a/src/components/MainSidebar/InputPanel/InputOption.module.css
+++ b/src/components/MainSidebar/InputPanel/InputOption.module.css
@@ -31,8 +31,11 @@
     font-weight: medium;
     font-size: 14px;
     line-height: 16px;
+    font-weight: 500;
     color: var(--colors-grey900);
     user-select: none;
+    display: flex;
+    align-items: center;
 }
 .description {
     font-size: 13px;

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramSelect.module.css
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramSelect.module.css
@@ -12,5 +12,12 @@
     flex-grow: 1;
 }
 .stage {
-    margin-left: var(--spacers-dp8);
+    margin-left: var(--spacers-dp4);
+}
+
+.label {
+    color: var(--colors-grey700);
+    font-size: 12px;
+    font-weight: 500;
+    margin-top: 2px;
 }

--- a/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
@@ -25,10 +25,10 @@ const StageSelect = ({ stages }) => {
 
     return (
         <div className={cx(styles.rows, styles.stage)}>
+            <span className={styles.label}>{i18n.t('Stage')}</span>
             <div className={styles.columns}>
                 <div className={styles.stretch}>
                     <SingleSelect
-                        prefix={i18n.t('Stage')}
                         dense
                         selected={selectedStageId}
                         onChange={onChange}


### PR DESCRIPTION
### Description

This PR adjusts the design of the input option component:
- moves `radio` to share line with header text, to reduce indent
- use custom ultra-dense `label` for stage selector, removing use of `prefix` and allowing more horizontal space.

---

### Screenshots

Before:
![image](https://github.com/dhis2/line-listing-app/assets/33054985/64b41e7d-6dd2-477e-bbb5-f53c62cdb704)


After:
![image](https://github.com/dhis2/line-listing-app/assets/33054985/3086f75b-09a2-415b-8523-b396ccc47431)

