### PR TITLE
chore: only upload videos for failing cypress tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const { chromeAllowXSiteCookies } = require('@dhis2/cypress-plugins')
 const { defineConfig } = require('cypress')
 const {
@@ -7,6 +8,28 @@ const {
 async function setupNodeEvents(on, config) {
     chromeAllowXSiteCookies(on, config)
     excludeByVersionTags(on, config)
+
+    // Delete videos for passing tests
+    on('after:spec', (spec, results) => {
+        try {
+            if (results && results.video) {
+                // Do we have failures for any retry attempts?
+                const failures = results.tests.some((test) =>
+                    test.attempts.some((attempt) => attempt.state === 'failed')
+                )
+                if (!failures) {
+                    // delete the video if the spec passed and no tests retried
+                    fs.unlinkSync(results.video)
+                }
+            }
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                console.log('Video already deleted')
+            } else {
+                throw error
+            }
+        }
+    })
 
     if (!config.env.dhis2InstanceVersion) {
         throw new Error(

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -78,10 +78,6 @@ module.exports = defineConfig({
         viewportHeight: 800,
         // Record video
         video: true,
-        /* Only compress and upload videos for failures.
-         * This will save execution time and reduce the risk
-         * out-of-memory issues on the CI machine */
-        videoUploadOnPasses: false,
         // Enabled to reduce the risk of out-of-memory issues
         experimentalMemoryManagement: true,
         // Set to a low number to reduce the risk of out-of-memory issues


### PR DESCRIPTION
Not in JIRA

---

### Key features

1. Stop uploading videos of passing tests

### How to verify this is working correctly

1. The test suite should still pass
2. The test suite should not crash because it is trying to delete a file
3. When reviewing the cypress test run log we should see that no video was upload (unless there was a failing test)