### PR TITLE
fix: interpretations paragraph new lines were not rendering correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.2.0",
+        "@dhis2/analytics": "999.9.9-loadflash-alpha.1",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^8.14.5",
         "@dnd-kit/core": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,10 +2041,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.2.0":
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.2.0.tgz#36a7f258ac96ddab90f4001e62257e2cc64f202e"
-  integrity sha512-YcJu6EHnor6pbHmwXKYumLRVy/9TxuLtBDv9JIzjt9/APZa8kbak6sT2/53pnWDnbUjzDwR8EV1UIz24vAX+ig==
+"@dhis2/analytics@999.9.9-loadflash-alpha.1":
+  version "999.9.9-loadflash-alpha.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-loadflash-alpha.1.tgz#3da151ed31cc349255233769a072b124007895e4"
+  integrity sha512-+/6BHGLlj9tRpomwtFa2ozRquGE+9F1R9JLqIQ4rBpk6dzYHTEoDYGEXb25I1qXtGFeNRiDLDZRYctDQf6zFrw==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
This analytics upgrade fixes 2 bugs:

* Interpretations panel flashes when liking/unliking an interpretation ([DHIS2-16392](https://dhis2.atlassian.net/browse/DHIS2-16392))
* Interpretations and replies don't respect new lines ([DHIS2-16365](https://dhis2.atlassian.net/browse/DHIS2-16365))

[DHIS2-16392]: https://dhis2.atlassian.net/browse/DHIS2-16392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-16365]: https://dhis2.atlassian.net/browse/DHIS2-16365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ