### PR TITLE
test: dynamic offset for years

### DIFF
--- a/cypress/helpers/period.js
+++ b/cypress/helpers/period.js
@@ -59,10 +59,14 @@ const getPreviousYearStr = () => (new Date().getFullYear() - 1).toString()
 
 const getCurrentYearStr = () => new Date().getFullYear().toString()
 
+const getOffsetYearStr = (offset) =>
+    (new Date().getFullYear() - offset).toString()
+
 export {
     selectFixedPeriod,
     selectRelativePeriod,
     unselectAllPeriods,
     getPreviousYearStr,
     getCurrentYearStr,
+    getOffsetYearStr,
 }

--- a/cypress/integration/conditions/dateConditions.cy.js
+++ b/cypress/integration/conditions/dateConditions.cy.js
@@ -23,6 +23,7 @@ import {
     getPreviousYearStr,
     unselectAllPeriods,
     selectFixedPeriod,
+    getOffsetYearStr,
 } from '../../helpers/period.js'
 import { goToStartPage } from '../../helpers/startScreen.js'
 import {
@@ -78,7 +79,7 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
     })
 
     it('exactly', () => {
-        const TEST_DATE = '1991-05-21'
+        const TEST_DATE = `${getOffsetYearStr(32)}-05-21`
 
         addConditions([
             {
@@ -95,7 +96,7 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
     })
 
     it('is not', () => {
-        const TEST_DATE = '1991-05-20'
+        const TEST_DATE = `${getOffsetYearStr(32)}-05-20`
 
         addConditions([
             {
@@ -104,7 +105,11 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
             },
         ])
 
-        expectTableToMatchRows(['1991-05-21', '1991-12-01', '1991-12-02'])
+        expectTableToMatchRows([
+            `${getOffsetYearStr(32)}-05-21`,
+            `${getOffsetYearStr(32)}-12-01`,
+            `${getOffsetYearStr(32)}-12-02`,
+        ])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -112,7 +117,7 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
     })
 
     it('after', () => {
-        const TEST_DATE = '1991-05-21'
+        const TEST_DATE = `${getOffsetYearStr(32)}-05-21`
 
         addConditions([
             {
@@ -121,7 +126,10 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
             },
         ])
 
-        expectTableToMatchRows(['1991-12-01', '1991-12-02'])
+        expectTableToMatchRows([
+            `${getOffsetYearStr(32)}-12-01`,
+            `${getOffsetYearStr(32)}-12-02`,
+        ])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -129,7 +137,7 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
     })
 
     it('after or including', () => {
-        const TEST_DATE = '1991-05-21'
+        const TEST_DATE = `${getOffsetYearStr(32)}-05-21`
 
         addConditions([
             {
@@ -138,7 +146,11 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
             },
         ])
 
-        expectTableToMatchRows(['1991-05-21', '1991-12-01', '1991-12-02'])
+        expectTableToMatchRows([
+            `${getOffsetYearStr(32)}-05-21`,
+            `${getOffsetYearStr(32)}-12-01`,
+            `${getOffsetYearStr(32)}-12-02`,
+        ])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -149,7 +161,7 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
     })
 
     it('before', () => {
-        const TEST_DATE = '1991-12-02'
+        const TEST_DATE = `${getOffsetYearStr(32)}-12-02`
 
         addConditions([
             {
@@ -158,7 +170,11 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
             },
         ])
 
-        expectTableToMatchRows(['1991-05-20', '1991-05-21', '1991-12-01'])
+        expectTableToMatchRows([
+            `${getOffsetYearStr(32)}-05-20`,
+            `${getOffsetYearStr(32)}-05-21`,
+            `${getOffsetYearStr(32)}-12-01`,
+        ])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -166,7 +182,7 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
     })
 
     it('before or including', () => {
-        const TEST_DATE = '1991-05-21'
+        const TEST_DATE = `${getOffsetYearStr(32)}-05-21`
 
         addConditions([
             {
@@ -175,7 +191,10 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
             },
         ])
 
-        expectTableToMatchRows(['1991-05-20', '1991-05-21'])
+        expectTableToMatchRows([
+            `${getOffsetYearStr(32)}-05-20`,
+            `${getOffsetYearStr(32)}-05-21`,
+        ])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
 
@@ -229,12 +248,12 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
         ])
 
         expectTableToMatchRows([
-            '1990-07-17',
-            '1990-11-12',
-            '1991-12-01',
-            '1991-12-02',
-            '1991-05-20',
-            '1991-05-21',
+            `${getOffsetYearStr(33)}-07-17`,
+            `${getOffsetYearStr(33)}-11-12`,
+            `${getOffsetYearStr(32)}-12-01`,
+            `${getOffsetYearStr(32)}-12-02`,
+            `${getOffsetYearStr(32)}-05-20`,
+            `${getOffsetYearStr(32)}-05-21`,
         ])
 
         assertChipContainsText(`${dimensionName}: 1 condition`)
@@ -243,8 +262,8 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
     })
 
     it('2 conditions: after + before or including', () => {
-        const TEST_DATE_AFT = '1991-05-20'
-        const TEST_DATE_BFI = '1991-12-01'
+        const TEST_DATE_AFT = `${getOffsetYearStr(32)}-05-20`
+        const TEST_DATE_BFI = `${getOffsetYearStr(32)}-12-01`
 
         addConditions([
             {
@@ -257,7 +276,10 @@ describe('date conditions (Date)', { testIsolation: false }, () => {
             },
         ])
 
-        expectTableToMatchRows(['1991-05-21', '1991-12-01'])
+        expectTableToMatchRows([
+            `${getOffsetYearStr(32)}-05-21`,
+            `${getOffsetYearStr(32)}-12-01`,
+        ])
 
         assertChipContainsText(`${dimensionName}: 2 conditions`)
 

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -50,6 +50,7 @@ import {
     selectRelativePeriod,
     getPreviousYearStr,
     getCurrentYearStr,
+    getOffsetYearStr,
 } from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import {
@@ -94,7 +95,7 @@ const programDimensions = [
 const programDataDimensions = [
     { label: TEST_DIM_AGE, value: '1991-01-01' },
     { label: TEST_DIM_COORDINATE, value: '[-0.090380,51.538034]' },
-    { label: TEST_DIM_DATE, value: '1991-12-01' },
+    { label: TEST_DIM_DATE, value: `${getOffsetYearStr(32)}-12-01` },
     { label: TEST_DIM_DATETIME, value: '1991-12-01 12:00' },
     { label: TEST_DIM_EMAIL, value: 'email@address.com' },
     { label: TEST_DIM_INTEGER, value: '10' },

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -12,7 +12,7 @@ import {
     selectEventWithProgram,
 } from '../helpers/dimensions.js'
 import { clickMenubarUpdateButton } from '../helpers/menubar.js'
-import { selectRelativePeriod } from '../helpers/period.js'
+import { selectFixedPeriod, selectRelativePeriod } from '../helpers/period.js'
 import { goToStartPage } from '../helpers/startScreen.js'
 import {
     getTableRows,
@@ -27,7 +27,18 @@ const assertTimeDimension = (dimension) => {
         selectEventWithProgram(trackerProgram)
         openProgramDimensionsSidebar()
         const label = trackerProgram[dimension.id]
-        selectRelativePeriod({ label, period: TEST_REL_PE_THIS_YEAR })
+        if (dimension.id === DIMENSION_ID_LAST_UPDATED) {
+            // last updated doesn't seem to get bumped yearly in the SL DB so we need to select a fixed period
+            selectFixedPeriod({
+                label,
+                period: {
+                    year: '2023',
+                    name: '2023',
+                },
+            })
+        } else {
+            selectRelativePeriod({ label, period: TEST_REL_PE_THIS_YEAR })
+        }
 
         clickMenubarUpdateButton()
 


### PR DESCRIPTION
No JIRA

Fixes issues related to the yearly bump in the database.
Basically turns things like `1991` to "this year minus 33" (i.e. 2024-33=1991) for data that was unexpectedly bumped in the demo db.