### PR TITLE
test: first test regex path that was filtering out component jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -50,7 +50,7 @@ module.exports = {
         '\\.(css)$': 'identity-obj-proxy',
     },
     testRunner: 'jest-circus/runner',
-    testRegex: ['/src/modules/__tests__/.*.spec.js?$'],
+    testRegex: ['/src/(.*/)?__tests__/.*.spec.js?$'],
     reporters: [
         'default',
         ...(isReportPortalSetup ? [reportPortalConfig] : []),

--- a/src/components/Layout/__tests__/__snapshots__/ChipBase.spec.js.snap
+++ b/src/components/Layout/__tests__/__snapshots__/ChipBase.spec.js.snap
@@ -31,6 +31,7 @@ exports[`ChipBase Data element: 2 conditions 1`] = `
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       2
     </span>
@@ -69,6 +70,7 @@ exports[`ChipBase Data element: TRUE_ONLY 1 condition 1`] = `
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       1
     </span>
@@ -107,6 +109,7 @@ exports[`ChipBase Data element: TRUE_ONLY both selected 1`] = `
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       all
     </span>
@@ -145,6 +148,7 @@ exports[`ChipBase Data element: TRUE_ONLY no conditions 1`] = `
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       all
     </span>
@@ -180,6 +184,9 @@ exports[`ChipBase Data element: in stage with option set and 2 options chosen 1`
       >
         My data element
       </span>
+      <span>
+        ,
+      </span>
       <span
         class="secondary"
       >
@@ -188,6 +195,7 @@ exports[`ChipBase Data element: in stage with option set and 2 options chosen 1`
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       2
     </span>
@@ -226,6 +234,7 @@ exports[`ChipBase Data element: no conditions 1`] = `
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       all
     </span>
@@ -264,6 +273,7 @@ exports[`ChipBase Data element: option set and 2 options chosen 1`] = `
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       2
     </span>
@@ -302,6 +312,7 @@ exports[`ChipBase OU: 2 selected 1`] = `
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       2
     </span>
@@ -338,7 +349,6 @@ exports[`ChipBase OU: none selected 1`] = `
         Organsiation unit
       </span>
     </span>
-    
   </div>
 </div>
 `;
@@ -374,6 +384,7 @@ exports[`ChipBase Period: 1 selected 1`] = `
     </span>
     <span
       class="suffix"
+      data-test="chip-suffix"
     >
       1
     </span>
@@ -410,7 +421,6 @@ exports[`ChipBase Period: none selected 1`] = `
         Event date (e2e)
       </span>
     </span>
-    
   </div>
 </div>
 `;


### PR DESCRIPTION
A recent change to the jest configuration caused only the tests in src/modules to be run.

As a result of this, some component test snapshots were no longer valid when the new chip design was released.