### PR TITLE
fix: extract the start-end-date part of the item id

### DIFF
--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -167,15 +167,6 @@ export const PeriodDimension = ({ dimension, onClose }) => {
         updatePeriodDimensionItems([])
     }
 
-    const selectedPeriods = selectedIds.map((id) => ({
-        id,
-        name: getNameFromMetadata(id),
-    }))
-
-    const { dimensionId: selectedStartEndDate } = extractDimensionIdParts(
-        selectedIds[0] || ''
-    )
-
     return dimension ? (
         <DimensionModal
             dataTest={'period-dimension-modal'}
@@ -200,7 +191,10 @@ export const PeriodDimension = ({ dimension, onClose }) => {
             <div className={styles.entry}>
                 {entryMethod === OPTION_PRESETS && (
                     <BasePeriodDimension
-                        selectedPeriods={selectedPeriods}
+                        selectedPeriods={selectedIds.map((id) => ({
+                            id,
+                            name: getNameFromMetadata(id),
+                        }))}
                         onSelect={({ items }) =>
                             updatePeriodDimensionItems(items)
                         }
@@ -209,7 +203,7 @@ export const PeriodDimension = ({ dimension, onClose }) => {
                 )}
                 {entryMethod === OPTION_START_END_DATES && (
                     <StartEndDate
-                        value={selectedStartEndDate}
+                        value={getStartEndDate(selectedIds[0] || '')}
                         setValue={(value) => {
                             if (!value && selectedIds.length) {
                                 updatePeriodDimensionItems([])

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -4,8 +4,10 @@ import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import styles from './StartEndDate.module.css'
 
-export const StartEndDate = ({ value, setValue }) => {
-    const [startDateStr, endDateStr] = value ? value.split('_') : []
+export const StartEndDate = ({
+    value: [startDateStr, endDateStr],
+    setValue,
+}) => {
     const [startDate, setStartDate] = useState(startDateStr)
     const [endDate, setEndDate] = useState(endDateStr)
 
@@ -54,5 +56,5 @@ export const StartEndDate = ({ value, setValue }) => {
 }
 StartEndDate.propTypes = {
     setValue: PropTypes.func.isRequired,
-    value: PropTypes.string.isRequired,
+    value: PropTypes.array.isRequired,
 }


### PR DESCRIPTION
Fixes bug where Period Dimension doesn't recognize the start/end date that has been selected for a time dimension

Perhaps the `extractDimensionIdParts` should be renamed, since it is also used to get the selected item for the dimension?