### PR TITLE
chore: include release notes in slackbot message

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -170,7 +170,7 @@ jobs:
         needs: release
         if: |
             success() &&
-            !cancelled()  &&
+            !cancelled() &&
             github.ref == 'refs/heads/master' &&
             contains(github.event.head_commit.message, 'chore(release)')
         steps:
@@ -188,13 +188,41 @@ jobs:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
                   payload: |
                       {
-                        "text": ":large_green_circle: :line-listing-app: :tada: Line Listing release succeeded for version: ${{ steps.extract_version.outputs.version }}",
+                        "text": "Line Listing app release ${{ steps.extract_version.outputs.version }} succeeded",
                         "blocks": [
+                          {
+                            "type": "header",
+                            "text": {
+                                "type": "plain_text",
+                                "text": ":large_green_circle: :line-listing-app: Line Listing version ${{ steps.extract_version.outputs.version }} released :tada:",
+                                "emoji": true
+                            }
+                          },
+                          {
+                            "type": "divider"
+                          },
                           {
                             "type": "section",
                             "text": {
-                              "type": "mrkdwn",
-                              "text": ":large_green_circle: :line-listing-app: :tada: Line Listing version ${{ steps.extract_version.outputs.version }} released <https://github.com/dhis2/line-listing-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess|successfully>"
+                                "type": "mrkdwn",
+                                "text": "*Release Notes*"
+                            }
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": ${{ toJSON(github.event.head_commit.message) }}
+                            }
+                          },
+                          {
+                            "type": "divider"
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "Link to <https://github.com/dhis2/line-listing-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess|build>"
                             }
                           }
                         ]


### PR DESCRIPTION
It is useful to see the release notes in the slack channel for a quick reference as to what was released.

The commit message in the "chore(release)" commit includes the release notes, so hopefully it will display nicely.

This is an example of what it will look like (except obviously it will say "Line Listing app":

![image](https://github.com/dhis2/line-listing-app/assets/6113918/cc1bd5ba-5488-4bf5-996d-935c509651de)
