### PR TITLE
fix(push-analytics): add push analytics instructions

### DIFF
--- a/public/push-analytics.json
+++ b/public/push-analytics.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.0.1",
+    "showVisualization": {
+        "strategy": "navigateToUrl",
+        "steps": [
+            { "goto": "{{appUrl}}/#/{{id}}" },
+            { "waitForSelector": ".push-analytics-linelist-table" }
+        ]
+    },
+    "triggerDownload": {
+        "strategy": "useUiElements",
+        "steps": [
+            { "click": ".push-analytics-download-dropdown-menu-button" },
+            { "click": ".push-analytics-download-as-html-css-menu-item" }
+        ]
+    },
+    "obtainDownloadArtifact": {
+        "strategy": "scrapeDownloadPage",
+        "modifyDownloadUrl": {
+            "searchValue": "&paging=false&",
+            "replaceValue": "&paging=true&pageSize=50&"
+        },
+        "htmlSelector": "body",
+        "cssSelector": "style"
+    },
+    "clearVisualization": {
+        "strategy": "navigateToUrl",
+        "steps": [{ "goto": "{{appUrl}}/#/new" }]
+    }
+}


### PR DESCRIPTION
Related to [DHIS2-15367](https://dhis2.atlassian.net/browse/DHIS2-15367) in JIRA and push-analytics [PR#10](https://github.com/dhis2/push-analytics/pull/10)

---

### Key features

1. Adds a JSON file with scrape instructions which push-analytics can use to convert a dashboard item for this app.

---



[DHIS2-15367]: https://dhis2.atlassian.net/browse/DHIS2-15367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ