### PR TITLE
chore: implement handling for DHIS2 core-triggered dispatch events

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -7,6 +7,8 @@ on:
         branches:
             - 'master'
             - 'dev'
+    repository_dispatch:
+        types: [cypress-test-trigger]
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}


### PR DESCRIPTION
### Description:
This PR introduces the capability to trigger Cypress tests in line-listing-app via the **`repository_dispatch`** event from the DHIS2 core repository. It's part of an initiative to enhance our testing processes by allowing on-demand and automated cross-repository testing and enabling the DHIS2 core to directly request Cypress test execution in this app.

### Changes:
Implemented handling for `repository_dispatch` with the event type `cypress-test-trigger`.