### PR TITLE
fix: system / user setting for display name not respected in Org Unit tree (DHIS2-15000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "999.9.9-ouname-alpha.1",
+        "@dhis2/analytics": "^26.6.9",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^9.4.2",
         "@dnd-kit/core": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.6.5",
+        "@dhis2/analytics": "999.9.9-ouname-alpha.1",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^9.4.2",
         "@dnd-kit/core": "^5.0.3",

--- a/src/components/Dialogs/FixedDimension.js
+++ b/src/components/Dialogs/FixedDimension.js
@@ -21,6 +21,7 @@ import {
     formatDimensionId,
 } from '../../modules/dimensionId.js'
 import { removeLastPathSegment, getOuPath } from '../../modules/orgUnit.js'
+import { DERIVED_USER_SETTINGS_DISPLAY_NAME_PROPERTY } from '../../modules/userSettings.js'
 import {
     STATUS_ACTIVE,
     STATUS_CANCELLED,
@@ -50,7 +51,7 @@ const FixedDimension = ({
     selectedItemsIds,
     inputType,
 }) => {
-    const { rootOrgUnits } = useCachedDataQuery()
+    const { rootOrgUnits, currentUser } = useCachedDataQuery()
     const { serverVersion } = useConfig()
     const statusNames = getStatusNames()
     const { programId, dimensionId } = extractDimensionIdParts(
@@ -244,6 +245,11 @@ const FixedDimension = ({
                             roots={rootOrgUnits.map(
                                 (rootOrgUnit) => rootOrgUnit.id
                             )}
+                            displayNameProp={
+                                currentUser.settings[
+                                    DERIVED_USER_SETTINGS_DISPLAY_NAME_PROPERTY
+                                ]
+                            }
                             {...dimensionProps}
                         />
                     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2034,10 +2034,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@999.9.9-ouname-alpha.1":
-  version "999.9.9-ouname-alpha.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-ouname-alpha.1.tgz#c2a5f27429e02b762f3344fdcbacb985199f30da"
-  integrity sha512-xFHCM2zPSt/eaOdk+V5uE4m2YxdW5Pn3cK0zJVKctS864tLXMNVCORQ+eDYQfl7lwbWm92Ax05z9L4StizEYtw==
+"@dhis2/analytics@^26.6.9":
+  version "26.6.9"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.9.tgz#932847c4bee3dd720d5d0b872c6b11eeae8b260c"
+  integrity sha512-AcU5FKH1Rmi8GdgqdJ1aOPqTKhztLafhzKNvGBdb5rSNR8/KS2djyTxxPhL0fdusu+1Rc04RFSkOLajq3ChVrQ==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2034,10 +2034,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.6.5":
-  version "26.6.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.5.tgz#44ee29a279c37f3969096d859bc0f07d953e3f42"
-  integrity sha512-ob6kNEEkIAC50RtKuUZWi8Y04uwsPHK/EiYhzxZkSOdS5wFm8X+88KZrD//fILXQjwMhJvl/4+F/T0qVxOF/jQ==
+"@dhis2/analytics@999.9.9-ouname-alpha.1":
+  version "999.9.9-ouname-alpha.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-ouname-alpha.1.tgz#c2a5f27429e02b762f3344fdcbacb985199f30da"
+  integrity sha512-xFHCM2zPSt/eaOdk+V5uE4m2YxdW5Pn3cK0zJVKctS864tLXMNVCORQ+eDYQfl7lwbWm92Ax05z9L4StizEYtw==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
Implements [DHIS2-15000](https://jira.dhis2.org/browse/DHIS2-15000)

**Requires https://github.com/dhis2/analytics/pull/1664**

---

### Key features

1. Pass `displayNameProp` to `OrgUnitDimension` to enable short name to work

---

### TODO

-   [ ] Cypress tests
-   [ ] Update docs
-   [ ] Manual testing

[DHIS2-15000]: https://dhis2.atlassian.net/browse/DHIS2-15000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ