### PR TITLE
feat: bump Line Listing to mininum version 2.39 (DHIS2-17209)

### DIFF
--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -28,7 +28,7 @@ jobs:
               id: instance-version
               uses: dhis2/action-instance-version@v1
               with:
-                  instance-url: https://test.e2e.dhis2.org/analytics-2.41d
+                  instance-url: https://test.e2e.dhis2.org/analytics-dev
                   username: ${{ secrets.username }}
                   password: ${{ secrets.password }}
 
@@ -62,7 +62,7 @@ jobs:
               env:
                   BROWSER: none
                   CYPRESS_RECORD_KEY: ${{ secrets.recordkey }}
-                  CYPRESS_dhis2BaseUrl: https://test.e2e.dhis2.org/analytics-2.41d
+                  CYPRESS_dhis2BaseUrl: https://test.e2e.dhis2.org/analytics-dev
                   CYPRESS_dhis2InstanceVersion: ${{ needs.compute-dev-version.outputs.version }}
                   CYPRESS_dhis2Username: ${{ secrets.username }}
                   CYPRESS_dhis2Password: ${{ secrets.password }}

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This setup helps in managing Cypress Cloud credits more efficiently, ensuring re
 
 #### Configure Cypress tests to run only on certain versions
 
-Some tests may only be applicable to some supported versions of DHIS2 (DHIS2 officially supports the latest 3 released versions). For instance, if you add a feature to 2.42 that would not work on 2.41, then a test for that feature should only run on instances >=2.42, and should not run on instances <2.41. To configure a test to only run on certain versions, add a tag array as the first argument to the test's `describe` or `it`. You can add multiple tags to the array if that is relevant. Tags must be in the form of < <= > >= otherwise they will be ignored. In addition, the tags contain only the minor version, i.e., "41", not "2.41". Here are some tag examples, given a minimum supported version of 2.39:
+Some tests may only be applicable to some supported versions of DHIS2 (DHIS2 officially supports the latest 3 released versions). For instance, if you add a feature to 2.42 that would not work on 2.41, then a test for that feature should only run on instances >=2.42, and should not run on instances <2.41. To configure a test to only run on certain versions, add a tag array as the first argument to the test's `describe` or `it`. You can add multiple tags to the array if that is relevant. Tags must be in the form of < <= > >= otherwise they will be ignored. In addition, the tags contain only the minor version, i.e., "41", not "2.41". Here are some tag examples, given the minimum supported version of 2.39:
 
 ```
 it(['<40'], 'runs on 39 only', () => { test implementation })

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ In order to run the cypress tests locally make sure you have configured your git
 
 Make sure that the `dhis2InstanceVersion` matches the version that is running at the dhis2BaseUrl. You can use 'dev' if the instance is dev, or else get the running instance version from this endpoint: `/api/system/info?fields=version` (which might return something like this: `2.40-SNAPSHOT`)
 
-Here is an example configuration for running tests against 2.38:
+Here is an example configuration for running tests against 2.39:
 
 ```
 {
-    "dhis2BaseUrl": "https://test.e2e.dhis2.org/2.38lytics/",
+    "dhis2BaseUrl": "https://test.e2e.dhis2.org/analytics-2.39/",
     "dhis2Username": ...,
     "dhis2Password": ...
-    "dhis2InstanceVersion": "2.38"
+    "dhis2InstanceVersion": "2.39"
 }
 ```
 
@@ -91,13 +91,13 @@ This setup helps in managing Cypress Cloud credits more efficiently, ensuring re
 
 #### Configure Cypress tests to run only on certain versions
 
-Some tests may only be applicable to some supported versions of DHIS2 (DHIS2 officially supports the latest 3 released versions). For instance, if you add a feature to 2.39 that would not work on 2.38, then a test for that feature should only run on instances >=2.39, and should not run on instances <2.39. To configure a test to only run on certain versions, add a tag array as the first argument to the test's `describe` or `it`. You can add multiple tags to the array if that is relevant. Tags must be in the form of < <= > >= otherwise they will be ignored. In addition, the tags contain only the minor version, i.e., "39", not "2.39". Here are some tag examples, given a minimum supported version of 2.38:
+Some tests may only be applicable to some supported versions of DHIS2 (DHIS2 officially supports the latest 3 released versions). For instance, if you add a feature to 2.42 that would not work on 2.41, then a test for that feature should only run on instances >=2.42, and should not run on instances <2.41. To configure a test to only run on certain versions, add a tag array as the first argument to the test's `describe` or `it`. You can add multiple tags to the array if that is relevant. Tags must be in the form of < <= > >= otherwise they will be ignored. In addition, the tags contain only the minor version, i.e., "41", not "2.41". Here are some tag examples, given a minimum supported version of 2.39:
 
 ```
-it(['<39'], 'runs on 38 only', () => { test implementation })
-it(['<=39'], 'runs on 38 and 39', () => { test implementation })
-it(['>39'], 'runs on 40 and dev', () => { test implementation })
-it(['>=39'], 'runs on 39, 40 and dev', () => { test implementation })
+it(['<40'], 'runs on 39 only', () => { test implementation })
+it(['<=40'], 'runs on 39 and 40', () => { test implementation })
+it(['>40'], 'runs on 41 and dev', () => { test implementation })
+it(['>=40'], 'runs on 40, 41 and dev', () => { test implementation })
 ```
 
 Tests without tags will run on all supported versions plus dev.

--- a/cypress/integration/createEvent.cy.js
+++ b/cypress/integration/createEvent.cy.js
@@ -23,7 +23,11 @@ import {
 } from '../helpers/table.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
-const runTests = ({ scheduledDateIsSupported } = {}) => {
+describe('event', () => {
+    beforeEach(() => {
+        goToStartPage()
+        cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
+    })
     it('creates an event line list (tracker program)', () => {
         const eventProgram = E2E_PROGRAM
         const dimensionName = TEST_DIM_TEXT
@@ -47,11 +51,9 @@ const runTests = ({ scheduledDateIsSupported } = {}) => {
         cy.getBySel('dimension-item-enrollmentDate').contains(
             eventProgram[DIMENSION_ID_ENROLLMENT_DATE]
         )
-        if (scheduledDateIsSupported) {
-            cy.getBySel('dimension-item-scheduledDate').contains(
-                eventProgram[DIMENSION_ID_SCHEDULED_DATE]
-            )
-        }
+        cy.getBySel('dimension-item-scheduledDate').contains(
+            eventProgram[DIMENSION_ID_SCHEDULED_DATE]
+        )
 
         cy.getBySel('dimension-item-incidentDate').contains(
             eventProgram[DIMENSION_ID_INCIDENT_DATE]
@@ -94,9 +96,7 @@ const runTests = ({ scheduledDateIsSupported } = {}) => {
             programName: 'Inpatient morbidity and mortality',
             [DIMENSION_ID_EVENT_DATE]: 'Report date',
             [DIMENSION_ID_ENROLLMENT_DATE]: 'Enrollment date',
-            ...(scheduledDateIsSupported
-                ? { [DIMENSION_ID_SCHEDULED_DATE]: 'Scheduled date' }
-                : {}),
+            [DIMENSION_ID_SCHEDULED_DATE]: 'Scheduled date',
             [DIMENSION_ID_INCIDENT_DATE]: 'Date of Discharge',
             [DIMENSION_ID_LAST_UPDATED]: 'Last updated on',
         }
@@ -119,9 +119,7 @@ const runTests = ({ scheduledDateIsSupported } = {}) => {
 
         cy.getBySel('dimension-item-enrollmentDate').should('not.exist')
 
-        if (scheduledDateIsSupported) {
-            cy.getBySel('dimension-item-scheduledDate').should('not.exist')
-        }
+        cy.getBySel('dimension-item-scheduledDate').should('not.exist')
 
         cy.getBySel('dimension-item-incidentDate').should('not.exist')
 
@@ -202,20 +200,4 @@ const runTests = ({ scheduledDateIsSupported } = {}) => {
         assertChipContainsText(dimensionName, 'all')
         assertChipContainsText(periodLabel, 1)
     })
-}
-
-describe(['>=39'], 'event', () => {
-    beforeEach(() => {
-        goToStartPage()
-        cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
-    })
-    runTests({ scheduledDateIsSupported: true })
-})
-
-describe(['<39'], 'event', () => {
-    beforeEach(() => {
-        goToStartPage()
-        cy.getBySel('main-sidebar', EXTENDED_TIMEOUT)
-    })
-    runTests()
 })

--- a/cypress/integration/eventStatus.cy.js
+++ b/cypress/integration/eventStatus.cy.js
@@ -37,7 +37,7 @@ describe('event status (event)', () => {
         clickAddRemoveProgramDimension(dimensionName)
     }
 
-    it(['>=39'], 'can be filtered by status SCHEDULED', () => {
+    it('can be filtered by status SCHEDULED', () => {
         setUpTable()
 
         selectFixedPeriod({

--- a/cypress/integration/eventStatus.cy.js
+++ b/cypress/integration/eventStatus.cy.js
@@ -170,9 +170,6 @@ describe('event status (event)', () => {
             `${currentYear}-01-01`,
         ])
 
-        // TODO: determine expected once 2.38analytics_dev is available
-        // expectTableToMatchRows(['Active', 'Completed', 'Completed'])
-
         getTableHeaderCells().contains(dimensionName).should('be.visible')
 
         assertChipContainsText(dimensionName, 'all')

--- a/cypress/integration/legendSet.cy.js
+++ b/cypress/integration/legendSet.cy.js
@@ -65,7 +65,7 @@ describe('Options - Legend', () => {
                     .should('have.css', 'color', defaultTextColor)
             })
 
-    it(['>=39'], 'apples legend correctly (event)', () => {
+    it('apples legend correctly (event)', () => {
         const TEST_LEGEND_AGE = {
             name: 'Age 10y interval',
             cells: [

--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -29,7 +29,6 @@ const assertDimensionsForEventWithoutProgramSelected = () => {
 
 const assertDimensionsForEventWithProgramSelected = (
     program,
-    scheduledDateIsSupported,
     showIncidentDate
 ) => {
     cy.getBySel('dimension-item-ou').contains('Organisation unit')
@@ -50,13 +49,9 @@ const assertDimensionsForEventWithProgramSelected = (
         program[DIMENSION_ID_ENROLLMENT_DATE]
     )
 
-    if (scheduledDateIsSupported) {
-        cy.getBySel('dimension-item-scheduledDate').contains(
-            program[DIMENSION_ID_SCHEDULED_DATE]
-        )
-    } else {
-        cy.getBySel('dimension-item-scheduledDate').should('not.exist')
-    }
+    cy.getBySel('dimension-item-scheduledDate').contains(
+        program[DIMENSION_ID_SCHEDULED_DATE]
+    )
 
     if (showIncidentDate) {
         cy.getBySel('dimension-item-incidentDate').contains(
@@ -110,7 +105,12 @@ export const programDimensionsIsDisabled = () =>
         .and('have.css', 'user-select', 'none')
         .and('have.css', 'cursor', 'not-allowed')
 
-const runTests = ({ scheduledDateIsSupported } = {}) => {
+describe('program dimensions', () => {
+    beforeEach(() => {
+        goToStartPage()
+        cy.getBySel('main-sidebar', EXTENDED_TIMEOUT).should('be.visible')
+    })
+
     /*
 Test data used:
     E2E program
@@ -167,11 +167,7 @@ I.e. Scheduled date works like this:
 
             openProgramDimensionsSidebar()
 
-            assertDimensionsForEventWithProgramSelected(
-                program,
-                scheduledDateIsSupported,
-                true
-            )
+            assertDimensionsForEventWithProgramSelected(program, true)
 
             // add main and time dimensions
 
@@ -188,11 +184,9 @@ I.e. Scheduled date works like this:
                 program[DIMENSION_ID_ENROLLMENT_DATE],
                 program[DIMENSION_ID_INCIDENT_DATE],
             ]
-            if (scheduledDateIsSupported) {
-                expectedUnselectedDimensions.push(
-                    program[DIMENSION_ID_SCHEDULED_DATE]
-                )
-            }
+            expectedUnselectedDimensions.push(
+                program[DIMENSION_ID_SCHEDULED_DATE]
+            )
 
             expectedSelectedDimensions.forEach((dimension) =>
                 clickAddRemoveMainDimension(dimension)
@@ -260,10 +254,7 @@ I.e. Scheduled date works like this:
                 .its('length')
                 .should('be.gte', 1)
 
-            assertDimensionsForEventWithProgramSelected(
-                program.defaultStage,
-                scheduledDateIsSupported
-            )
+            assertDimensionsForEventWithProgramSelected(program.defaultStage)
 
             // add a data element
 
@@ -293,11 +284,9 @@ I.e. Scheduled date works like this:
                 program.defaultStage[DIMENSION_ID_EVENT_DATE],
             ]
 
-            if (scheduledDateIsSupported) {
-                expectedUnselectedDimensions.push(
-                    program.defaultStage[DIMENSION_ID_SCHEDULED_DATE]
-                )
-            }
+            expectedUnselectedDimensions.push(
+                program.defaultStage[DIMENSION_ID_SCHEDULED_DATE]
+            )
 
             expectedSelectedMainDimensions.forEach((dimension) =>
                 clickAddRemoveMainDimension(dimension)
@@ -320,10 +309,7 @@ I.e. Scheduled date works like this:
 
             openProgramDimensionsSidebar()
 
-            assertDimensionsForEventWithProgramSelected(
-                TEST_PROGRAM.stage,
-                scheduledDateIsSupported
-            )
+            assertDimensionsForEventWithProgramSelected(TEST_PROGRAM.stage)
 
             // assert that the DE was removed but the PA remained
 
@@ -499,24 +485,6 @@ I.e. Scheduled date works like this:
             getListChildren().should('have.length', 106)
         })
     })
-}
-
-describe(['>=39'], 'program dimensions', () => {
-    beforeEach(() => {
-        goToStartPage()
-        cy.getBySel('main-sidebar', EXTENDED_TIMEOUT).should('be.visible')
-    })
-
-    runTests({ scheduledDateIsSupported: true })
-})
-
-describe(['<39'], 'program dimensions', () => {
-    beforeEach(() => {
-        goToStartPage()
-        cy.getBySel('main-sidebar', EXTENDED_TIMEOUT).should('be.visible')
-    })
-
-    runTests()
 })
 
 describe('counting selection', () => {

--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -117,217 +117,6 @@ const programDataDimensions = [
     { label: TEST_DIM_YESNO, value: 'Yes' },
 ]
 
-const assertColumnHeaders = () => {
-    const dimensionName = TEST_DIM_TEXT
-
-    selectEventWithProgramDimensions({
-        ...trackerProgram,
-        dimensions: [dimensionName],
-    })
-
-    const testMainDimensions = mainDimensions.map(
-        (dimension) => dimension.label
-    )
-
-    const testProgramDimensions = programDimensions.map(
-        (dimension) => dimension.label
-    )
-
-    // add main and time dimensions
-    testMainDimensions.forEach((label) => clickAddRemoveMainDimension(label))
-    testProgramDimensions.forEach((label) =>
-        clickAddRemoveProgramDimension(label)
-    )
-
-    selectFixedPeriod({
-        label: periodLabel,
-        period: {
-            type: 'Daily',
-            year: `${getPreviousYearStr()}`,
-            name: `${getPreviousYearStr()}-12-10`,
-        },
-    })
-
-    clickMenubarUpdateButton()
-
-    expectTableToBeVisible()
-
-    const labels = [
-        dimensionName,
-        ...testMainDimensions,
-        ...testProgramDimensions,
-    ]
-
-    // check the correct number of columns
-    getTableHeaderCells().its('length').should('equal', labels.length)
-
-    // check the column headers in the table
-    labels.forEach((label) => {
-        getTableHeaderCells()
-            .contains(label)
-            .scrollIntoView()
-            .should('be.visible')
-            .click()
-        cy.getBySelLike('modal-title').contains(label)
-        cy.getBySelLike('modal-action-cancel').click()
-    })
-}
-
-const assertDimensions = () => {
-    selectEventWithProgram(trackerProgram)
-
-    openProgramDimensionsSidebar()
-
-    mainDimensions.forEach(({ label }) => clickAddRemoveMainDimension(label))
-
-    programDimensions.forEach(({ label }) =>
-        clickAddRemoveProgramDimension(label)
-    )
-
-    programDataDimensions.forEach(({ label }) =>
-        clickAddRemoveProgramDataDimension(label)
-    )
-
-    selectFixedPeriod({
-        label: periodLabel,
-        period: {
-            type: 'Daily',
-            year: `${getPreviousYearStr()}`,
-            name: `${getPreviousYearStr()}-12-10`,
-        },
-    })
-
-    clickMenubarUpdateButton()
-
-    expectTableToBeVisible()
-
-    const allDimensions = [
-        ...mainDimensions,
-        ...programDimensions,
-        ...programDataDimensions,
-    ]
-
-    getTableHeaderCells().its('length').should('eq', allDimensions.length)
-
-    getTableRows().its('length').should('eq', 1)
-
-    // assert the values of the dimensions
-    allDimensions.forEach(({ value }, index) => {
-        getTableDataCells().eq(index).invoke('text').should('eq', value)
-    })
-
-    // check that the URL dimension is wrapped in a link
-    if (
-        allDimensions.includes((dimension) => dimension.label === TEST_DIM_URL)
-    ) {
-        getTableDataCells()
-            .eq(
-                allDimensions.findIndex(
-                    (dimension) => dimension.label === TEST_DIM_URL
-                )
-            )
-            .find('a')
-            .should(
-                'have.attr',
-                'href',
-                allDimensions.find(
-                    (dimension) => dimension.label === TEST_DIM_URL
-                ).value
-            )
-    }
-}
-
-const assertSorting = () => {
-    // remove any DGS to allow numeric value comparison
-    openStyleOptionsModal()
-
-    cy.getBySel('dgs-select-content')
-        .findBySel('dhis2-uicore-select-input')
-        .click()
-    cy.contains('None').click()
-    clickOptionsModalUpdateButton()
-
-    selectEventWithProgramDimensions({
-        ...trackerProgram,
-        dimensions: [TEST_DIM_INTEGER],
-    })
-
-    // filter empty/null values on E2E - Integer dimension
-    // this helps with the value comparison when sorting
-    cy.getBySelLike('layout-chip').contains(TEST_DIM_INTEGER).click()
-    cy.getBySel('button-add-condition').click()
-    cy.contains('Choose a condition type').click()
-    cy.contains('is not empty / not null').click()
-    cy.getBySel('conditions-modal').contains('Update').click()
-
-    programDimensions
-        .filter((dimension) => dimension.label === 'Organisation unit')
-        .forEach(({ label }) => clickAddRemoveProgramDimension(label))
-
-    selectRelativePeriod({
-        label: periodLabel,
-        period: TEST_REL_PE_THIS_YEAR,
-    })
-
-    clickMenubarUpdateButton()
-
-    expectTableToBeVisible()
-
-    cy.intercept(/api\/\d+\/analytics(\S)*asc=/).as('getAnalyticsSortAsc')
-
-    getTableHeaderCells().find(`button[title*="${TEST_DIM_INTEGER}"]`).click()
-
-    // wait for table to be sorted
-    cy.wait('@getAnalyticsSortAsc')
-
-    expectTableToBeUpdated()
-
-    getTableRows()
-        .eq(0)
-        .find('td')
-        .eq(0)
-        .invoke('text')
-        .then(parseInt)
-        .then(($cell0Value) =>
-            getTableRows()
-                .eq(1)
-                .find('td')
-                .eq(0)
-                .invoke('text')
-                .then(parseInt)
-                .then(($cell1Value) =>
-                    expect($cell0Value).to.be.lessThan($cell1Value)
-                )
-        )
-
-    cy.intercept(/api\/(\d+)\/analytics(\S)*desc=/).as('getAnalyticsSortDesc')
-
-    getTableHeaderCells().find(`button[title*="${TEST_DIM_INTEGER}"]`).click()
-
-    // wait for table to be sorted
-    cy.wait('@getAnalyticsSortDesc')
-
-    expectTableToBeUpdated()
-
-    getTableRows()
-        .eq(0)
-        .find('td')
-        .eq(0)
-        .invoke('text')
-        .then(parseInt)
-        .then(($cell0Value) =>
-            getTableRows()
-                .eq(1)
-                .find('td')
-                .eq(0)
-                .invoke('text')
-                .then(parseInt)
-                .then(($cell1Value) =>
-                    expect($cell0Value).to.be.greaterThan($cell1Value)
-                )
-        )
-}
-
 const init = () => {
     goToStartPage()
 
@@ -338,42 +127,235 @@ const init = () => {
     cy.containsExact('Remove').click()
 }
 
-describe(['>=38', '<39'], 'table', () => {
+describe('table', () => {
     beforeEach(init)
-    it('click on column header opens the dimension dialog (2.38)', () => {
-        assertColumnHeaders()
-    })
-
-    it('dimensions display correct values in the visualization (2.38)', () => {
-        programDataDimensions.push({
-            label: TEST_DIM_NUMBER_OPTIONSET,
-            value: 'One',
-        })
-        assertDimensions()
-    })
-    it('data can be sorted', () => {
-        assertSorting()
-    })
-})
-
-describe(['>=39'], 'table', () => {
-    beforeEach(init)
-    it('click on column header opens the dimension dialog (>=2.39)', () => {
+    it('click on column header opens the dimension dialog', () => {
         // feat: https://dhis2.atlassian.net/browse/DHIS2-11192
         programDimensions.push({
             label: trackerProgram[DIMENSION_ID_SCHEDULED_DATE],
             value: `${previousYear}-12-10`,
         })
-        assertColumnHeaders()
+        const dimensionName = TEST_DIM_TEXT
+
+        selectEventWithProgramDimensions({
+            ...trackerProgram,
+            dimensions: [dimensionName],
+        })
+
+        const testMainDimensions = mainDimensions.map(
+            (dimension) => dimension.label
+        )
+
+        const testProgramDimensions = programDimensions.map(
+            (dimension) => dimension.label
+        )
+
+        // add main and time dimensions
+        testMainDimensions.forEach((label) =>
+            clickAddRemoveMainDimension(label)
+        )
+        testProgramDimensions.forEach((label) =>
+            clickAddRemoveProgramDimension(label)
+        )
+
+        selectFixedPeriod({
+            label: periodLabel,
+            period: {
+                type: 'Daily',
+                year: `${getPreviousYearStr()}`,
+                name: `${getPreviousYearStr()}-12-10`,
+            },
+        })
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        const labels = [
+            dimensionName,
+            ...testMainDimensions,
+            ...testProgramDimensions,
+        ]
+
+        // check the correct number of columns
+        getTableHeaderCells().its('length').should('equal', labels.length)
+
+        // check the column headers in the table
+        labels.forEach((label) => {
+            getTableHeaderCells()
+                .contains(label)
+                .scrollIntoView()
+                .should('be.visible')
+                .click()
+            cy.getBySelLike('modal-title').contains(label)
+            cy.getBySelLike('modal-action-cancel').click()
+        })
     })
-    it('dimensions display correct values in the visualization (>=2.39)', () => {
+    it('dimensions display correct values in the visualization', () => {
         programDataDimensions.push({
             label: TEST_DIM_NUMBER_OPTIONSET,
             value: 'One',
         })
-        assertDimensions()
+        selectEventWithProgram(trackerProgram)
+
+        openProgramDimensionsSidebar()
+
+        mainDimensions.forEach(({ label }) =>
+            clickAddRemoveMainDimension(label)
+        )
+
+        programDimensions.forEach(({ label }) =>
+            clickAddRemoveProgramDimension(label)
+        )
+
+        programDataDimensions.forEach(({ label }) =>
+            clickAddRemoveProgramDataDimension(label)
+        )
+
+        selectFixedPeriod({
+            label: periodLabel,
+            period: {
+                type: 'Daily',
+                year: `${getPreviousYearStr()}`,
+                name: `${getPreviousYearStr()}-12-10`,
+            },
+        })
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        const allDimensions = [
+            ...mainDimensions,
+            ...programDimensions,
+            ...programDataDimensions,
+        ]
+
+        getTableHeaderCells().its('length').should('eq', allDimensions.length)
+
+        getTableRows().its('length').should('eq', 1)
+
+        // assert the values of the dimensions
+        allDimensions.forEach(({ value }, index) => {
+            getTableDataCells().eq(index).invoke('text').should('eq', value)
+        })
+
+        // check that the URL dimension is wrapped in a link
+        if (
+            allDimensions.includes(
+                (dimension) => dimension.label === TEST_DIM_URL
+            )
+        ) {
+            getTableDataCells()
+                .eq(
+                    allDimensions.findIndex(
+                        (dimension) => dimension.label === TEST_DIM_URL
+                    )
+                )
+                .find('a')
+                .should(
+                    'have.attr',
+                    'href',
+                    allDimensions.find(
+                        (dimension) => dimension.label === TEST_DIM_URL
+                    ).value
+                )
+        }
     })
-    it('data can be sorted (>=2.39)', () => {
-        assertSorting()
+    it('data can be sorted', () => {
+        // remove any DGS to allow numeric value comparison
+        openStyleOptionsModal()
+
+        cy.getBySel('dgs-select-content')
+            .findBySel('dhis2-uicore-select-input')
+            .click()
+        cy.contains('None').click()
+        clickOptionsModalUpdateButton()
+
+        selectEventWithProgramDimensions({
+            ...trackerProgram,
+            dimensions: [TEST_DIM_INTEGER],
+        })
+
+        // filter empty/null values on E2E - Integer dimension
+        // this helps with the value comparison when sorting
+        cy.getBySelLike('layout-chip').contains(TEST_DIM_INTEGER).click()
+        cy.getBySel('button-add-condition').click()
+        cy.contains('Choose a condition type').click()
+        cy.contains('is not empty / not null').click()
+        cy.getBySel('conditions-modal').contains('Update').click()
+
+        programDimensions
+            .filter((dimension) => dimension.label === 'Organisation unit')
+            .forEach(({ label }) => clickAddRemoveProgramDimension(label))
+
+        selectRelativePeriod({
+            label: periodLabel,
+            period: TEST_REL_PE_THIS_YEAR,
+        })
+
+        clickMenubarUpdateButton()
+
+        expectTableToBeVisible()
+
+        cy.intercept(/api\/\d+\/analytics(\S)*asc=/).as('getAnalyticsSortAsc')
+
+        getTableHeaderCells()
+            .find(`button[title*="${TEST_DIM_INTEGER}"]`)
+            .click()
+
+        // wait for table to be sorted
+        cy.wait('@getAnalyticsSortAsc')
+
+        expectTableToBeUpdated()
+
+        getTableRows()
+            .eq(0)
+            .find('td')
+            .eq(0)
+            .invoke('text')
+            .then(parseInt)
+            .then(($cell0Value) =>
+                getTableRows()
+                    .eq(1)
+                    .find('td')
+                    .eq(0)
+                    .invoke('text')
+                    .then(parseInt)
+                    .then(($cell1Value) =>
+                        expect($cell0Value).to.be.lessThan($cell1Value)
+                    )
+            )
+
+        cy.intercept(/api\/(\d+)\/analytics(\S)*desc=/).as(
+            'getAnalyticsSortDesc'
+        )
+
+        getTableHeaderCells()
+            .find(`button[title*="${TEST_DIM_INTEGER}"]`)
+            .click()
+
+        // wait for table to be sorted
+        cy.wait('@getAnalyticsSortDesc')
+
+        expectTableToBeUpdated()
+
+        getTableRows()
+            .eq(0)
+            .find('td')
+            .eq(0)
+            .invoke('text')
+            .then(parseInt)
+            .then(($cell0Value) =>
+                getTableRows()
+                    .eq(1)
+                    .find('td')
+                    .eq(0)
+                    .invoke('text')
+                    .then(parseInt)
+                    .then(($cell1Value) =>
+                        expect($cell0Value).to.be.greaterThan($cell1Value)
+                    )
+            )
     })
 })

--- a/cypress/integration/timeDimensions.cy.js
+++ b/cypress/integration/timeDimensions.cy.js
@@ -60,25 +60,7 @@ const assertTimeDimension = (dimension) => {
     })
 }
 
-describe(['>37', '<39'], 'time dimensions', () => {
-    beforeEach(() => {
-        goToStartPage()
-    })
-
-    // Note: The rowsLengths needs to be updated when events are changed or added to the database
-    const timeDimensions = [
-        { id: DIMENSION_ID_EVENT_DATE, rowsLength: 7 },
-        { id: DIMENSION_ID_ENROLLMENT_DATE, rowsLength: 12 },
-        { id: DIMENSION_ID_INCIDENT_DATE, rowsLength: 12 },
-        { id: DIMENSION_ID_LAST_UPDATED, rowsLength: 10 },
-    ]
-
-    timeDimensions.forEach((dimension) => {
-        assertTimeDimension(dimension)
-    })
-})
-
-describe(['>=39'], 'time dimensions', () => {
+describe('time dimensions', () => {
     beforeEach(() => {
         goToStartPage()
     })

--- a/cypress/plugins/excludeByVersionTags.js
+++ b/cypress/plugins/excludeByVersionTags.js
@@ -5,9 +5,9 @@ The list of excluded tags returned by getExcludedTags are the tags that cypress 
 
 Using excluded tags (instead of included tags) allows for most of the tests to remain untagged and be run against all supported versions of DHIS2.
 
-DHIS2 officially supports the latest 3 released versions of DHIS2. For example: 2.38, 2.39 and 2.40. Dev would then have version 2.41-SNAPSHOT. Therefore, the getExcludedTags calculates the range of tags based on minimum supported version + 3 (2.38, 2.39, 2.40, 2.41-SNAPSHOT)
+DHIS2 officially supports the latest 3 released versions of DHIS2. For example: 2.39, 2.40 and 2.41. Dev would then have version 2.41-SNAPSHOT. Therefore, the getExcludedTags calculates the range of tags based on minimum supported version + 3 (2.39, 2.40, 2.41, 2.42)
 
-With the minimum supported version of 2.38, the tags will always contain "38", "39", "40" and "41", but the comparison symbols will depend on the current instance version.
+With the minimum supported version of 2.39, the tags will always contain "39", "40" and "41", but the comparison symbols will depend on the current instance version.
 
 Allowed tag comparisons are ">", ">=", "<", "<="
 */
@@ -40,7 +40,7 @@ const getExcludedTags = (v) => {
 
     let excludeTags = []
     if (currentInstanceVersion === MIN_DHIS2_VERSION) {
-        // For example instance = 2.38, MIN = 2.38
+        // For example instance = 2.39, MIN = 2.39
         excludeTags = [
             `<${currentInstanceVersion}`,
             `>${currentInstanceVersion}`,
@@ -51,7 +51,7 @@ const getExcludedTags = (v) => {
             `>=${currentInstanceVersion + 3}`,
         ]
     } else if (currentInstanceVersion === MIN_DHIS2_VERSION + 1) {
-        // For example instance = 2.39, MIN = 2.38
+        // For example instance = 2.40, MIN = 2.39
         excludeTags = [
             `<=${currentInstanceVersion - 1}`,
             `<${currentInstanceVersion - 1}`,
@@ -62,7 +62,7 @@ const getExcludedTags = (v) => {
             `>=${currentInstanceVersion + 2}`,
         ]
     } else if (currentInstanceVersion === MIN_DHIS2_VERSION + 2) {
-        // For example instance = 2.40, MIN = 2.38
+        // For example instance = 2.41, MIN = 2.39
         excludeTags = [
             `<=${currentInstanceVersion - 2}`,
             `<${currentInstanceVersion - 2}`,
@@ -73,7 +73,7 @@ const getExcludedTags = (v) => {
             `>=${currentInstanceVersion + 1}`,
         ]
     } else {
-        // For example instance = 2.41, MIN = 2.38
+        // For example instance = 2.42, MIN = 2.39
         excludeTags = [
             `<=${currentInstanceVersion - 3}`,
             `<${currentInstanceVersion - 3}`,

--- a/d2.config.js
+++ b/d2.config.js
@@ -4,7 +4,7 @@ const config = {
     id: 'a4cd3827-e717-4e09-965d-ab05df2591e5',
     title: 'Line Listing',
 
-    minDHIS2Version: '2.38',
+    minDHIS2Version: '2.39',
 
     pwa: {
         enabled: true,

--- a/src/__tests__/cypressGetExcludedTags.spec.js
+++ b/src/__tests__/cypressGetExcludedTags.spec.js
@@ -1,18 +1,6 @@
 import { getExcludedTags } from '../../cypress/plugins/excludeByVersionTags.js'
 
 describe('get excluded Cypress tags', () => {
-    test('instanceVersion 2.38', () => {
-        expect(getExcludedTags('2.38')).toEqual([
-            '<38',
-            '>38',
-            '>=39',
-            '>39',
-            '>=40',
-            '>40',
-            '>=41',
-        ])
-    })
-
     test('instanceVersion 2.39', () => {
         expect(getExcludedTags('2.39')).toEqual([
             '<=38',
@@ -61,21 +49,9 @@ describe('get excluded Cypress tags', () => {
         ])
     })
 
-    test('instanceVersion number 2.38', () => {
-        expect(getExcludedTags(2.38)).toEqual([
-            '<38',
-            '>38',
-            '>=39',
-            '>39',
-            '>=40',
-            '>40',
-            '>=41',
-        ])
-    })
-
     // unexpected argument forms
-    test('instanceVersion 38', () => {
-        expect(getExcludedTags('38')).toEqual([
+    test('instanceVersion 39', () => {
+        expect(getExcludedTags('39')).toEqual([
             '<38',
             '>38',
             '>=39',
@@ -86,8 +62,8 @@ describe('get excluded Cypress tags', () => {
         ])
     })
 
-    test('instanceVersion 38-SNAPSHOT.2', () => {
-        expect(getExcludedTags('38-SNAPSHOT.2')).toEqual([
+    test('instanceVersion 39-SNAPSHOT.2', () => {
+        expect(getExcludedTags('39-SNAPSHOT.2')).toEqual([
             '<38',
             '>38',
             '>=39',
@@ -110,9 +86,9 @@ describe('get excluded Cypress tags', () => {
         ])
     })
 
-    test('instanceVersion 2.37', () => {
+    test('instanceVersion 2.38', () => {
         expect(() => {
-            getExcludedTags('2.37')
+            getExcludedTags('2.38')
         }).toThrow()
     })
 })

--- a/src/__tests__/cypressGetExcludedTags.spec.js
+++ b/src/__tests__/cypressGetExcludedTags.spec.js
@@ -3,86 +3,86 @@ import { getExcludedTags } from '../../cypress/plugins/excludeByVersionTags.js'
 describe('get excluded Cypress tags', () => {
     test('instanceVersion 2.39', () => {
         expect(getExcludedTags('2.39')).toEqual([
-            '<=38',
-            '<38',
             '<39',
             '>39',
             '>=40',
             '>40',
             '>=41',
+            '>41',
+            '>=42',
         ])
     })
 
     test('instanceVersion 2.40', () => {
         expect(getExcludedTags('2.40')).toEqual([
-            '<=38',
-            '<38',
             '<=39',
             '<39',
             '<40',
             '>40',
             '>=41',
+            '>41',
+            '>=42',
         ])
     })
 
     test('instanceVersion 2.41-SNAPSHOT', () => {
         expect(getExcludedTags('2.41-SNAPSHOT')).toEqual([
-            '<=38',
-            '<38',
             '<=39',
             '<39',
-            '<40',
             '<=40',
+            '<40',
             '<41',
+            '>41',
+            '>=42',
         ])
     })
 
     test('instanceVersion dev', () => {
         expect(getExcludedTags('dev')).toEqual([
-            '<=38',
-            '<38',
             '<=39',
             '<39',
-            '<40',
             '<=40',
+            '<40',
             '<41',
+            '<=41',
+            '<42',
         ])
     })
 
     // unexpected argument forms
     test('instanceVersion 39', () => {
         expect(getExcludedTags('39')).toEqual([
-            '<38',
-            '>38',
-            '>=39',
+            '<39',
             '>39',
             '>=40',
             '>40',
             '>=41',
+            '>41',
+            '>=42',
         ])
     })
 
     test('instanceVersion 39-SNAPSHOT.2', () => {
         expect(getExcludedTags('39-SNAPSHOT.2')).toEqual([
-            '<38',
-            '>38',
-            '>=39',
+            '<39',
             '>39',
             '>=40',
             '>40',
             '>=41',
+            '>41',
+            '>=42',
         ])
     })
 
     test('instanceVersion Dev', () => {
         expect(getExcludedTags('Dev')).toEqual([
-            '<=38',
-            '<38',
             '<=39',
             '<39',
-            '<40',
             '<=40',
+            '<40',
             '<41',
+            '<=41',
+            '<42',
         ])
     })
 

--- a/src/components/Dialogs/FixedDimension.js
+++ b/src/components/Dialogs/FixedDimension.js
@@ -4,7 +4,6 @@ import {
     DIMENSION_ID_ORGUNIT,
     useCachedDataQuery,
 } from '@dhis2/analytics'
-import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { Checkbox } from '@dhis2/ui'
 import PropTypes from 'prop-types'
@@ -52,7 +51,6 @@ const FixedDimension = ({
     inputType,
 }) => {
     const { rootOrgUnits, currentUser } = useCachedDataQuery()
-    const { serverVersion } = useConfig()
     const statusNames = getStatusNames()
     const { programId, dimensionId } = extractDimensionIdParts(
         dimension.id,
@@ -169,18 +167,11 @@ const FixedDimension = ({
         const ALL_STATUSES = [
             { id: STATUS_ACTIVE, name: statusNames[STATUS_ACTIVE] },
             { id: STATUS_COMPLETED, name: statusNames[STATUS_COMPLETED] },
-        ]
-
-        if (
-            `${serverVersion.major}.${serverVersion.minor}.${
-                serverVersion.patch || 0
-            }` >= '2.39.0'
-        ) {
-            ALL_STATUSES.push({
+            {
                 id: STATUS_SCHEDULED,
                 name: statusNames[STATUS_SCHEDULED],
-            })
-        }
+            },
+        ]
 
         return (
             <>

--- a/src/components/MainSidebar/YourDimensionsPanel/useYourDimensions.js
+++ b/src/components/MainSidebar/YourDimensionsPanel/useYourDimensions.js
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { DIMENSION_LIST_FIELDS } from '../DimensionsList/index.js'
 
 const YOUR_DIMENSIONS_RESOURCE = 'dimensions'
-// Fixed filter on org units for 2.38 ?
+// Fixed filter on org units for 2.38 ? // TODO: remove with min version bump?
 const YOUR_DIMENSIONS_FILTER = 'dimensionType:eq:ORGANISATION_UNIT_GROUP_SET'
 
 const query = {

--- a/src/components/MainSidebar/YourDimensionsPanel/useYourDimensions.js
+++ b/src/components/MainSidebar/YourDimensionsPanel/useYourDimensions.js
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react'
 import { DIMENSION_LIST_FIELDS } from '../DimensionsList/index.js'
 
 const YOUR_DIMENSIONS_RESOURCE = 'dimensions'
-// Fixed filter on org units for 2.38 ? // TODO: remove with min version bump?
 const YOUR_DIMENSIONS_FILTER = 'dimensionType:eq:ORGANISATION_UNIT_GROUP_SET'
 
 const query = {

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -146,7 +146,6 @@ const fetchAnalyticsData = async ({
 
     const analyticsApiEndpoint = getAnalyticsEndpoint(visualization.outputType)
 
-    // for 2.38 only /query is used (since only Line List is enabled) // TODO: remove with min version bump?
     const rawResponse = await analyticsEngine[analyticsApiEndpoint].getQuery(
         req
     )

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -146,7 +146,7 @@ const fetchAnalyticsData = async ({
 
     const analyticsApiEndpoint = getAnalyticsEndpoint(visualization.outputType)
 
-    // for 2.38 only /query is used (since only Line List is enabled)
+    // for 2.38 only /query is used (since only Line List is enabled) // TODO: remove with min version bump?
     const rawResponse = await analyticsEngine[analyticsApiEndpoint].getQuery(
         req
     )

--- a/src/modules/options/lineListConfig.js
+++ b/src/modules/options/lineListConfig.js
@@ -34,9 +34,7 @@ export default (serverVersion) => {
         ]),
     ]
 
-    if (currentVersion >= '2.39.0') {
-        optionsConfig.push(getLegendTab())
-    }
+    optionsConfig.push(getLegendTab())
 
     return optionsConfig
 }

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -4,7 +4,6 @@ import {
     USER_ORG_UNIT,
     VIS_TYPE_LINE_LIST,
 } from '@dhis2/analytics'
-import { useConfig } from '@dhis2/app-runtime'
 import { useMemo } from 'react'
 import { useStore, useSelector } from 'react-redux'
 import { createSelector } from 'reselect'
@@ -495,7 +494,6 @@ export const useMainDimensions = () => {
 }
 
 export const useProgramDimensions = () => {
-    const { serverVersion } = useConfig()
     const store = useStore()
     const inputType = useSelector(sGetUiInputType)
     const programId = useSelector(sGetUiProgramId)
@@ -533,11 +531,7 @@ export const useProgramDimensions = () => {
         const timeDimensions = [
             eventDateDim,
             enrollmentDateDim,
-            ...(`${serverVersion.major}.${serverVersion.minor}.${
-                serverVersion.patch || 0
-            }` >= '2.39.0'
-                ? [scheduledDateDim]
-                : []),
+            scheduledDateDim,
             incidentDateDim,
         ].filter((dimension) => {
             if (!dimension) {


### PR DESCRIPTION
Implements [DHIS2-17209](https://dhis2.atlassian.net/browse/DHIS2-17209)

---

### Key features

1. Bumps the min version to `2.39` and removes all corresponding toggles, tests and references to `2.38`

---

### Description

The PR removes all references to 2.38 and sets the min version to 2.39. It was decided in a recent meeting that this should bump the major version.

---

### BREAKING CHANGE

Only supported on 2.39 and above

---

### TODO

-   [x] Figure out what type of release this should be (major, minor, patch)



[DHIS2-17209]: https://dhis2.atlassian.net/browse/DHIS2-17209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ