### PR TITLE
fix: enrollment line list filter for program stage not working (DHIS2-17412)

### DIFF
--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -14,6 +14,8 @@ import {
     openProgramDimensionsSidebar,
     selectEnrollmentWithProgramDimensions,
     selectEventWithProgram,
+    selectProgramForTE,
+    selectTrackedEntityWithType,
 } from '../helpers/dimensions.js'
 import { expectAxisToHaveDimension } from '../helpers/layout.js'
 import { goToStartPage } from '../helpers/startScreen.js'
@@ -230,6 +232,51 @@ I.e. Scheduled date works like this:
                     .contains(dimension)
                     .should('not.exist')
             })
+        })
+
+        it('stage can be selected, dimension list reflects the selection', () => {
+            // select program
+            cy.getBySel('accessory-sidebar')
+                .contains('Choose a program')
+                .click()
+            cy.contains('Child Programme').click()
+
+            // select data element
+            cy.getBySel('program-dimensions-button').click()
+            cy.getBySel('accessory-sidebar').contains('All types').click()
+            cy.getBySel('dhis2-uicore-popper')
+                .containsExact('Data element')
+                .click()
+
+            // items from the selected stage are shown
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH ARV at birth')
+                .should('be.visible')
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH DPT dose')
+                .should('not.exist')
+
+            // select a different stage
+            cy.getBySel('input-panel-button').click()
+            cy.getBySel('stage-select').click()
+            cy.contains('Baby Postnatal').click()
+
+            // items from the selected stage are shown
+            cy.getBySel('program-dimensions-button').click()
+            cy.getBySel('accessory-sidebar').contains('All types').click()
+            cy.getBySel('dhis2-uicore-popper')
+                .containsExact('Data element')
+                .click()
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH ARV at birth')
+                .should('not.exist')
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH DPT dose')
+                .should('be.visible')
         })
 
         it('stage can be selected, dimensions are removed when stage and program are changed', () => {
@@ -461,6 +508,84 @@ I.e. Scheduled date works like this:
                     .contains(dimension)
                     .should('not.exist')
             })
+        })
+
+        it('stage can be selected, dimension list reflects the selection', () => {
+            // select Child programme
+            cy.getBySel('accessory-sidebar')
+                .contains('Choose a program')
+                .click()
+            cy.contains('Child Programme').click()
+
+            // select data element
+            cy.getBySel('program-dimensions-button').click()
+            cy.getBySel('accessory-sidebar').contains('All types').click()
+            cy.getBySel('dhis2-uicore-popper')
+                .containsExact('Data element')
+                .click()
+
+            // items from multiple stages are shown
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH ARV at birth')
+                .should('be.visible')
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH DPT dose')
+                .should('be.visible')
+
+            // select a specific stage
+            cy.getBySel('stage-select').click()
+            cy.getBySel('dhis2-uicore-popper').containsExact('Birth').click()
+
+            // only items from the selected stage are shown
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH ARV at birth')
+                .should('be.visible')
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH DPT dose')
+                .should('not.exist')
+        })
+    })
+    describe('tracked entity', () => {
+        it('stage can be selected, dimension list reflects the selection', () => {
+            selectTrackedEntityWithType('Person')
+
+            // select child programme
+            openProgramDimensionsSidebar()
+            selectProgramForTE('Child Programme')
+
+            // select data element
+            cy.getBySel('accessory-sidebar').contains('All types').click()
+            cy.getBySel('dhis2-uicore-popper')
+                .containsExact('Data element')
+                .click()
+
+            // items from multiple stages are shown
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH ARV at birth')
+                .should('be.visible')
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH DPT dose')
+                .should('be.visible')
+
+            // select a specific stage
+            cy.getBySel('stage-select').click()
+            cy.getBySel('dhis2-uicore-popper').containsExact('Birth').click()
+
+            // only items from the selected stage are shown
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH ARV at birth')
+                .should('be.visible')
+            cy.getBySel('program-dimensions-list')
+                .findBySelLike('dimension-item')
+                .contains('MCH DPT dose')
+                .should('not.exist')
         })
     })
     describe('lazy loading', () => {

--- a/cypress/integration/programDimensions.cy.js
+++ b/cypress/integration/programDimensions.cy.js
@@ -549,7 +549,7 @@ I.e. Scheduled date works like this:
                 .should('not.exist')
         })
     })
-    describe('tracked entity', () => {
+    describe(['>=41'], 'tracked entity', () => {
         it('stage can be selected, dimension list reflects the selection', () => {
             selectTrackedEntityWithType('Person')
 

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -143,15 +143,9 @@ const ProgramDimensionsPanel = ({ visible }) => {
                                     dimensionType={dimensionType}
                                     searchTerm={debouncedSearchTerm}
                                     stageId={
-                                        [
-                                            OUTPUT_TYPE_ENROLLMENT,
-                                            OUTPUT_TYPE_TRACKED_ENTITY,
-                                        ].includes(inputType) &&
                                         dimensionType ===
-                                            DIMENSION_TYPE_DATA_ELEMENT
+                                        DIMENSION_TYPE_DATA_ELEMENT
                                             ? stageFilter
-                                            : inputType === OUTPUT_TYPE_EVENT
-                                            ? selectedStageId
                                             : undefined
                                     }
                                     trackedEntityTypeId={

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -61,6 +61,15 @@ const ProgramDimensionsPanel = ({ visible }) => {
     }
 
     if ([OUTPUT_TYPE_EVENT, OUTPUT_TYPE_ENROLLMENT].includes(inputType)) {
+        let stageId
+        if (
+            inputType === OUTPUT_TYPE_ENROLLMENT &&
+            dimensionType === DIMENSION_TYPE_DATA_ELEMENT
+        ) {
+            stageId = stageFilter
+        } else if (inputType === OUTPUT_TYPE_EVENT) {
+            stageId = selectedStageId
+        }
         return (
             <div className={styles.container}>
                 {isProgramSelectionComplete() ? (
@@ -89,18 +98,7 @@ const ProgramDimensionsPanel = ({ visible }) => {
                             program={selectedProgram}
                             dimensionType={dimensionType}
                             searchTerm={debouncedSearchTerm}
-                            stageId={
-                                [
-                                    OUTPUT_TYPE_ENROLLMENT,
-                                    OUTPUT_TYPE_TRACKED_ENTITY,
-                                ].includes(inputType) ===
-                                    OUTPUT_TYPE_ENROLLMENT &&
-                                dimensionType === DIMENSION_TYPE_DATA_ELEMENT
-                                    ? stageFilter
-                                    : inputType === OUTPUT_TYPE_EVENT
-                                    ? selectedStageId
-                                    : undefined
-                            }
+                            stageId={stageId}
                         />
                     </>
                 ) : (


### PR DESCRIPTION
Implements [DHIS2-17412](https://dhis2.atlassian.net/browse/DHIS2-17412)

---

### Key features

1. Clean up code for determining how/when to use `stageId`

---

### Description

There seems to have been either a copy/paste error or a conflict resolution slip up in a previous PR for determining how/when to use ’stageId’ in the ’StageFilter’. 
There are two separate flows - event/enrollment and TE. However there was code referencing e.g. event with in the TE flow, which is obviously incorrect. This has now been cleaned up so the stage filter works as expected.

---

### TODO

-   [x] Cypress tests
-   [x] Update docs
-   [x] Manual testing

---

### Screenshots

_event_

![image](https://github.com/dhis2/line-listing-app/assets/12590483/eb19fd50-f7ae-4882-82e9-fe39f67a6441)


_enrollment_

![image](https://github.com/dhis2/line-listing-app/assets/12590483/21fdec15-b245-4cbb-a54b-c4d16cfa97f1)



_tracked entity_

![image](https://github.com/dhis2/line-listing-app/assets/12590483/534d5d10-85a7-49dc-9cb7-b402740c841c)


[DHIS2-17412]: https://dhis2.atlassian.net/browse/DHIS2-17412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ