### PR TITLE
chore: remove & pre- and suffixes from modifyDownloadUrl search and replace strings

### DIFF
--- a/public/push-analytics.json
+++ b/public/push-analytics.json
@@ -17,8 +17,8 @@
     "obtainDownloadArtifact": {
         "strategy": "scrapeDownloadPage",
         "modifyDownloadUrl": {
-            "searchValue": "&paging=false&",
-            "replaceValue": "&paging=true&pageSize=50&"
+            "searchValue": "paging=false",
+            "replaceValue": "paging=true&pageSize=50"
         },
         "htmlSelector": "body",
         "cssSelector": "style"


### PR DESCRIPTION
### Description

This PR removes `&` pre- and suffixes from `modifyDownloadUrl` search and replace strings in the push-analytics.json instructions file. These `&`s are problematic when the query parameter being replaced is the first or last query parameter present.

Push analytics now sanitises the search and replace strings, so the previous push-analytics file will work correctly as well. As such there is no rush to merge in this PR.