### PR TITLE
fix: favourite link is missing the app name (DHIS2-16018)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.6.9",
+        "@dhis2/analytics": "999.9.9-ll-link-alpha.1",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^9.4.2",
         "@dnd-kit/core": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "999.9.9-ll-link-alpha.1",
+        "@dhis2/analytics": "^26.6.13",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^9.4.2",
         "@dnd-kit/core": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2034,10 +2034,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@999.9.9-ll-link-alpha.1":
-  version "999.9.9-ll-link-alpha.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-ll-link-alpha.1.tgz#0e5493ef7095f49c76d78288ba5dd9a57f355670"
-  integrity sha512-Awh5KUKVzk4X8QMTTwMTW1c0XOMLC08bHu7V4v61Z3Uv6i0h0sgpn+CI4+1spvdtV36evn/r5rEcEjuD8VbKqw==
+"@dhis2/analytics@^26.6.13":
+  version "26.6.13"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.13.tgz#1951d31ba74947ee848c1aa20b5e9b361d527de0"
+  integrity sha512-xBNJrevU0pc9Ucv3Zcj0uHi8NdNpcetyyKdub7NziRnuMQRvPlBu8jezAjzc2Rjf+Q0sDnCBXJLa2oOjpLbNNQ==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2034,10 +2034,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.6.9":
-  version "26.6.9"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.9.tgz#932847c4bee3dd720d5d0b872c6b11eeae8b260c"
-  integrity sha512-AcU5FKH1Rmi8GdgqdJ1aOPqTKhztLafhzKNvGBdb5rSNR8/KS2djyTxxPhL0fdusu+1Rc04RFSkOLajq3ChVrQ==
+"@dhis2/analytics@999.9.9-ll-link-alpha.1":
+  version "999.9.9-ll-link-alpha.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-ll-link-alpha.1.tgz#0e5493ef7095f49c76d78288ba5dd9a57f355670"
+  integrity sha512-Awh5KUKVzk4X8QMTTwMTW1c0XOMLC08bHu7V4v61Z3Uv6i0h0sgpn+CI4+1spvdtV36evn/r5rEcEjuD8VbKqw==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
Implements [DHIS2-16018](https://dhis2.atlassian.net/browse/DHIS2-16018)

**Requires https://github.com/dhis2/analytics/pull/1669**

---

### Key features

1. Bumps Analytics to the version that contains the fix

---

### TODO

-   [x] Manual testing

---

### Known issues / Screenshots

Note that the url is missing the instance name when used on Netlify:
![image](https://github.com/dhis2/line-listing-app/assets/12590483/0dfd599c-c465-43fa-a0af-e3d298aa25c4)

When uploaded as a custom version to the instance directly it works as expected though, as seen below: 
![image](https://github.com/dhis2/line-listing-app/assets/12590483/66b95406-df79-43a2-b864-544de7b35c4d)


[DHIS2-16018]: https://dhis2.atlassian.net/browse/DHIS2-16018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ