### PR TITLE
chore: add group for security updates to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,10 @@ updates:
                   - minor
                   - patch
               exclude-patterns:
-                  - '@dhis2'
-                  - 'i18next'
+                  - '*@dhis2*'
+                  - '*i18next*'
+          security:
+              applies-to: security-updates
+              update-types:
+                  - minor
+                  - patch


### PR DESCRIPTION
Added a group to group together all security updates. Also, the exclude-pattern was missing wildcards so it didn't work.