### PR TITLE
fix: hh:mm time format ambiguous (DHIS2-16717)

### DIFF
--- a/cypress/integration/table.cy.js
+++ b/cypress/integration/table.cy.js
@@ -70,7 +70,7 @@ const previousYear = getPreviousYearStr()
 const mainDimensions = [
     {
         label: trackerProgram[DIMENSION_ID_LAST_UPDATED],
-        value: '2023-01-04 02:04',
+        value: '2023-01-04 14:04',
     },
     { label: 'Created by', value: 'Traore, John (admin)' },
     { label: 'Last updated by', value: 'Traore, John (admin)' },

--- a/src/modules/tableValues.js
+++ b/src/modules/tableValues.js
@@ -34,7 +34,7 @@ const getFormattedCellValue = ({ value, header = {}, visualization = {} }) => {
             moment(value).format(
                 header.name === headersMap[DIMENSION_ID_LAST_UPDATED] ||
                     header.valueType === VALUE_TYPE_DATETIME
-                    ? 'yyyy-MM-DD hh:mm'
+                    ? 'yyyy-MM-DD HH:mm'
                     : 'yyyy-MM-DD'
             )
         )


### PR DESCRIPTION
Implements [DHIS2-16717](https://dhis2.atlassian.net/browse/DHIS2-16717)

---

### Key features

1. Change time format to 24h

---

### Description

Previously the `hh` time format was used in `moment.js`, which is using a 12h clock, causing 11am and 11pm to look identical - `11:00`. 
Switching to the `HH` time format, that uses a 24h clock, means 11pm will be outputted as `23:00` instead.

---

### TODO

-   [x] Cypress tests
-   [ ] Update docs
-   [x] Manual testing

---

### Screenshots

_api docs (https://momentjs.com/docs/)_
![image](https://github.com/dhis2/line-listing-app/assets/12590483/7ad5e290-44e9-4a10-9b3a-d2ae14be99ab)


_before_
![image](https://github.com/dhis2/line-listing-app/assets/12590483/c05b7cc5-ac10-4005-8fb0-b36e0c7a8e4b)


_after_
![image](https://github.com/dhis2/line-listing-app/assets/12590483/c453dbc3-4d06-4d97-95e0-5ceffbf50311)


[DHIS2-16717]: https://dhis2.atlassian.net/browse/DHIS2-16717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ