### PR TITLE
fix: remove CSS that prevents LL from showing in dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "cy:run": "start-server-and-test 'yarn start' http://localhost:3000 'yarn cypress run --env networkMode=live'"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^11.2.2",
+        "@dhis2/cli-app-scripts": "^11.4.2",
         "@dhis2/cli-style": "^10.4.3",
         "@dhis2/cypress-commands": "^10.0.3",
         "@dhis2/cypress-plugins": "^10.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,12 +2145,12 @@
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/app-adapter@11.2.2":
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-11.2.2.tgz#0e5a8525c6c8adb11a8e33d33bfba78eb7731d62"
-  integrity sha512-T7kownygvtl/9brKr39xojv4UXAvlvZaBLwkKAoSt1XcDAYpw97vcxs8K5RG00cbLV91I194jVfnKTg2bjuajw==
+"@dhis2/app-adapter@11.4.2":
+  version "11.4.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-11.4.2.tgz#a588ac696fd1c38873359f16a03c0be237b3c4de"
+  integrity sha512-AKlgpLNxChQxfZV4Ji6GeQv1k3N5AkymcedAMCPbR6wjVhskyE0l4a/9HdMBQh+vFlVOtE5fC/NBRifQjlE8Kw==
   dependencies:
-    "@dhis2/pwa" "11.2.2"
+    "@dhis2/pwa" "11.4.2"
     moment "^2.24.0"
 
 "@dhis2/app-runtime@^3.10.4", "@dhis2/app-runtime@^3.4.4":
@@ -2195,15 +2195,15 @@
   dependencies:
     post-robot "^10.0.46"
 
-"@dhis2/app-shell@11.2.2":
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-11.2.2.tgz#43e849eff4e3238edccf41d55b2ad71b29c4c80d"
-  integrity sha512-TK4V+LmcvQfFAZZloKPDMKAa/d7jUEl7eXopYyJYscCeImNuMufz3+6WgeOC6xQe9nHC36I8/d7NuSpPiEoQUw==
+"@dhis2/app-shell@11.4.2":
+  version "11.4.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-11.4.2.tgz#66ce1cdb666c22b3b530d4c052a72305b5571700"
+  integrity sha512-R8oKl9Zoby7uK3emdmtRqTyoOR/UjraBP7Xq+OkoKSHrt77HVQElsVpfSrLvz+p7VuNEhIMtZCW2xwS4MK07uw==
   dependencies:
-    "@dhis2/app-adapter" "11.2.2"
+    "@dhis2/app-adapter" "11.4.2"
     "@dhis2/app-runtime" "^3.10.4"
     "@dhis2/d2-i18n" "^1.1.1"
-    "@dhis2/pwa" "11.2.2"
+    "@dhis2/pwa" "11.4.2"
     "@dhis2/ui" "^9.4.4"
     classnames "^2.2.6"
     moment "^2.29.1"
@@ -2217,10 +2217,10 @@
     typeface-roboto "^0.0.75"
     typescript "^3.6.3"
 
-"@dhis2/cli-app-scripts@^11.2.2":
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-11.2.2.tgz#fb7d3d487fb8c0d1e690f8f91fc0d3d884dccd35"
-  integrity sha512-muCg1UjCIN2WZ5FoVJwhdD+SBNO8NYvwZiUoltoHZ244L1v8pfPJifr7zgMLKp+1AsO4DB4nq3ne6qR3elZgiQ==
+"@dhis2/cli-app-scripts@^11.4.2":
+  version "11.4.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-11.4.2.tgz#5842ee8032ef021321d063204b34b853b879c6c0"
+  integrity sha512-H2dHcnFGSOaqKFrbLXYauYcBOoalnhFnJJSYZXpBbhX83JCbwLDhIopDUYssb948n9xhq0DMMFnMCbKFdHIOZQ==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -2229,7 +2229,7 @@
     "@babel/preset-env" "^7.14.7"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "11.2.2"
+    "@dhis2/app-shell" "11.4.2"
     "@dhis2/cli-helpers-engine" "^3.2.0"
     "@jest/core" "^27.0.6"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.4"
@@ -2351,10 +2351,10 @@
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-3.1.2.tgz#65b8ad2da8cd2f72bc8b951049a6c9d1b97af3e9"
   integrity sha512-eM0jjLOWvtXWqSFp5YC4DHFpkP8Y1D2eUwGV7MBWjni+o27oesVan+oT7WHeOeLdlAd4acRJrnaaAyB4Ck1wGQ==
 
-"@dhis2/pwa@11.2.2":
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-11.2.2.tgz#fec40b4022d6e0133e4f1a6910919088e6d0392c"
-  integrity sha512-WdcH1UwoaFas4voScQ5zwfsTlYGJlo6eFgR991efAytEUGce4UsKFtS+KvtSBNMmQp+9F09tq+BDV52gPv/mdA==
+"@dhis2/pwa@11.4.2":
+  version "11.4.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-11.4.2.tgz#19d6936f7134613c187666f55dbf8596aeefbb8e"
+  integrity sha512-6QXEiDTfOFnOKxWipT2FH6MpbaEUw4Y6oKz6KK7SkqQKNV40NFBIvh93RXGpq06IupzK1cfnNltTDPdG0tPKsQ==
   dependencies:
     idb "^6.0.0"
     workbox-core "^6.1.5"


### PR DESCRIPTION
Implements [DHIS2-XXXX](https://dhis2.atlassian.net/browse/DHIS2-XXXX)

---

### Key features

1. fix bug that prevents LL to show in dashboard

---

### Description

Originally reported by Yuri.
The issue was introduced in version 101.0.4 where `cli-app-scripts` was updated to version 11.2.2.
The issue is related to some CSS rule which causes the LL table to be hidden when used in a dashboard item.
The fix is in cli-app-scripts where the plugin shell is built.

---

### TODO

-   [ ] Cypress tests
-   [x] Manual testing

---

### Screenshots

Before:
<img width="574" alt="Screenshot 2024-06-24 at 09 15 46" src="https://github.com/dhis2/line-listing-app/assets/150978/a6e1297c-7608-4989-8fe0-9a02fba8ff2b">


After:
<img width="567" alt="Screenshot 2024-06-24 at 09 15 58" src="https://github.com/dhis2/line-listing-app/assets/150978/37398bc7-9d7f-41fb-8553-574dc1db2beb">
