### PR TITLE
fix: bump analytics with period selector validation fix (DHIS2-17707)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.7.5",
+        "@dhis2/analytics": "^26.8.1",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/ui": "^9.4.2",
         "@dnd-kit/core": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,10 +2038,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.7.5":
-  version "26.7.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.7.5.tgz#b85a35ba0adb971b237c814d1d384e10e3ec5ca1"
-  integrity sha512-YLkCOXWGm8JFlpq0AZhWsMxA6lJeRTixHDeMqdyZQeYPYCvZJiUAp0TtC+uSRK1uV1yIHRj4OjQytMWTsvUUnQ==
+"@dhis2/analytics@^26.8.1":
+  version "26.8.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.8.1.tgz#ad72b326e92f0440a0280fc223ff0b85483eac5f"
+  integrity sha512-0y2RMlP1VucSaKCSGIsY4EwYmg6dg3ig765j7StOhbgT6wbRnE32VrQibG/sElGN3jwGf58frIGntEXdqGbjuw==
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
Fixes [DHIS2-17707](https://dhis2.atlassian.net/browse/DHIS2-17707)

**Requires https://github.com/dhis2/analytics/pull/1690**

---

### Key features

1. update `analytics` dependency with fix for period selector validation

---

### Description

See https://github.com/dhis2/analytics/pull/1690 for a detailed description.

---

### TODO

-   [x] Manual testing

[DHIS2-17707]: https://dhis2.atlassian.net/browse/DHIS2-17707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ