### PR TITLE
fix: sanitize width before reading and writing to local storage

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -42,34 +42,34 @@ async function setupNodeEvents(on, config) {
 
 module.exports = defineConfig({
     projectId: 'm5qvjx',
-    // reporter: '@reportportal/agent-js-cypress',
-    // reporterOptions: {
-    //     endpoint: process.env.REPORTPORTAL_ENDPOINT,
-    //     apiKey: process.env.REPORTPORTAL_API_KEY,
-    //     launch: 'line_listing_app',
-    //     project: process.env.REPORTPORTAL_PROJECT,
-    //     description: '',
-    //     autoMerge: true,
-    //     parallel: true,
-    //     debug: false,
-    //     restClientConfig: {
-    //         timeout: 660000,
-    //     },
-    //     attributes: [
-    //         {
-    //             key: 'dhis2_version',
-    //             value: process.env.DHIS2_VERSION,
-    //         },
-    //         {
-    //             key: 'app_name',
-    //             value: 'line-listing-app',
-    //         },
-    //         {
-    //             key: 'test_level',
-    //             value: 'e2e',
-    //         },
-    //     ],
-    // },
+    reporter: '@reportportal/agent-js-cypress',
+    reporterOptions: {
+        endpoint: process.env.REPORTPORTAL_ENDPOINT,
+        apiKey: process.env.REPORTPORTAL_API_KEY,
+        launch: 'line_listing_app',
+        project: process.env.REPORTPORTAL_PROJECT,
+        description: '',
+        autoMerge: true,
+        parallel: true,
+        debug: false,
+        restClientConfig: {
+            timeout: 660000,
+        },
+        attributes: [
+            {
+                key: 'dhis2_version',
+                value: process.env.DHIS2_VERSION,
+            },
+            {
+                key: 'app_name',
+                value: 'line-listing-app',
+            },
+            {
+                key: 'test_level',
+                value: 'e2e',
+            },
+        ],
+    },
     e2e: {
         setupNodeEvents,
         baseUrl: 'http://localhost:3000',

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -42,34 +42,34 @@ async function setupNodeEvents(on, config) {
 
 module.exports = defineConfig({
     projectId: 'm5qvjx',
-    reporter: '@reportportal/agent-js-cypress',
-    reporterOptions: {
-        endpoint: process.env.REPORTPORTAL_ENDPOINT,
-        apiKey: process.env.REPORTPORTAL_API_KEY,
-        launch: 'line_listing_app',
-        project: process.env.REPORTPORTAL_PROJECT,
-        description: '',
-        autoMerge: true,
-        parallel: true,
-        debug: false,
-        restClientConfig: {
-            timeout: 660000,
-        },
-        attributes: [
-            {
-                key: 'dhis2_version',
-                value: process.env.DHIS2_VERSION,
-            },
-            {
-                key: 'app_name',
-                value: 'line-listing-app',
-            },
-            {
-                key: 'test_level',
-                value: 'e2e',
-            },
-        ],
-    },
+    // reporter: '@reportportal/agent-js-cypress',
+    // reporterOptions: {
+    //     endpoint: process.env.REPORTPORTAL_ENDPOINT,
+    //     apiKey: process.env.REPORTPORTAL_API_KEY,
+    //     launch: 'line_listing_app',
+    //     project: process.env.REPORTPORTAL_PROJECT,
+    //     description: '',
+    //     autoMerge: true,
+    //     parallel: true,
+    //     debug: false,
+    //     restClientConfig: {
+    //         timeout: 660000,
+    //     },
+    //     attributes: [
+    //         {
+    //             key: 'dhis2_version',
+    //             value: process.env.DHIS2_VERSION,
+    //         },
+    //         {
+    //             key: 'app_name',
+    //             value: 'line-listing-app',
+    //         },
+    //         {
+    //             key: 'test_level',
+    //             value: 'e2e',
+    //         },
+    //     ],
+    // },
     e2e: {
         setupNodeEvents,
         baseUrl: 'http://localhost:3000',

--- a/cypress/integration/mainSidebar.cy.js
+++ b/cypress/integration/mainSidebar.cy.js
@@ -220,7 +220,7 @@ describe('accessory sidebar panel', () => {
 
         cy.getBySel('accessory-panel-resize-handle').trigger('mouseup')
     })
-    it.only('ignores out-of-bounds mouse movements past the max-width edge', () => {
+    it('ignores out-of-bounds mouse movements past the max-width edge', () => {
         const movementX = DRAGHANDLE_PAGE_X_MAX - DRAGHANDLE_PAGE_X_INITIAL
         const pageXAtMaxWidth = getMouseMoveOptions(movementX).pageX
         const expectedWidth =
@@ -396,6 +396,14 @@ describe('accessory sidebar panel', () => {
         cy.getBySel('accessory-sidebar')
             .invoke('outerWidth')
             .should('eq', increasedWidth - viewportDecrease)
+    })
+    it('does not decrease the panel width past its min-width on window resize', () => {
+        goToStartPage()
+        cy.viewport(300, Cypress.config().viewportHeight)
+
+        cy.getBySel('accessory-sidebar')
+            .invoke('outerWidth')
+            .should('eq', ACCESSORY_PANEL_MIN_WIDTH)
     })
     it('mouse resizing works after keyboard resize without blurring the resize handle', () => {
         const keyboardMovementX = 100

--- a/src/components/MainSidebar/MainSidebar.module.css
+++ b/src/components/MainSidebar/MainSidebar.module.css
@@ -65,7 +65,7 @@
 }
 .resizeHandle:hover::before {
     opacity: 1;
-    /* Show with a 500ms delay */
+    /* Show with a 200ms delay */
     transition: opacity 150ms 200ms;
 }
 .container.resizing .accessory,

--- a/src/components/MainSidebar/MainSidebar.module.css
+++ b/src/components/MainSidebar/MainSidebar.module.css
@@ -66,7 +66,7 @@
 .resizeHandle:hover::before {
     opacity: 1;
     /* Show with a 500ms delay */
-    transition: opacity 150ms 500ms;
+    transition: opacity 150ms 200ms;
 }
 .container.resizing .accessory,
 .container.resizing .accessoryInner {

--- a/src/modules/localStorage.js
+++ b/src/modules/localStorage.js
@@ -1,12 +1,33 @@
-import { ACCESSORY_PANEL_DEFAULT_WIDTH } from './accessoryPanelConstants.js'
+import {
+    ACCESSORY_PANEL_DEFAULT_WIDTH,
+    ACCESSORY_PANEL_MIN_PX_AT_END,
+    ACCESSORY_PANEL_MIN_WIDTH,
+    PRIMARY_PANEL_WIDTH,
+} from './accessoryPanelConstants.js'
 
 export const STORAGE_KEY = 'dhis2.line-listing.accessoryPanelWidth'
 
 const sanitizeWidth = (width) => {
-    const parsedWidth = parseInt(width)
-    return Number.isInteger(parsedWidth)
-        ? parsedWidth
-        : ACCESSORY_PANEL_DEFAULT_WIDTH
+    const maxAvailableWidth =
+        window.innerWidth -
+        (PRIMARY_PANEL_WIDTH + ACCESSORY_PANEL_MIN_PX_AT_END)
+    let sanitizedWidth = parseInt(width)
+
+    if (!Number.isInteger(sanitizedWidth)) {
+        sanitizedWidth = ACCESSORY_PANEL_DEFAULT_WIDTH
+    }
+
+    // First enforce upper bound
+    if (sanitizedWidth > maxAvailableWidth) {
+        sanitizedWidth = maxAvailableWidth
+    }
+
+    // Then enforce lower bound, so lower bound takes precedence
+    if (sanitizedWidth < ACCESSORY_PANEL_MIN_WIDTH) {
+        sanitizedWidth = ACCESSORY_PANEL_MIN_WIDTH
+    }
+
+    return sanitizedWidth
 }
 
 export const getUserSidebarWidthFromLocalStorage = () =>

--- a/src/modules/localStorage.js
+++ b/src/modules/localStorage.js
@@ -2,12 +2,16 @@ import { ACCESSORY_PANEL_DEFAULT_WIDTH } from './accessoryPanelConstants.js'
 
 export const STORAGE_KEY = 'dhis2.line-listing.accessoryPanelWidth'
 
+const sanitizeWidth = (width) => {
+    const parsedWidth = parseInt(width)
+    return Number.isInteger(parsedWidth)
+        ? parsedWidth
+        : ACCESSORY_PANEL_DEFAULT_WIDTH
+}
+
 export const getUserSidebarWidthFromLocalStorage = () =>
-    parseInt(
-        window.localStorage.getItem(STORAGE_KEY) ??
-            ACCESSORY_PANEL_DEFAULT_WIDTH
-    )
+    sanitizeWidth(window.localStorage.getItem(STORAGE_KEY))
 
 export const setUserSidebarWidthToLocalStorage = (width) => {
-    window.localStorage.setItem(STORAGE_KEY, width)
+    window.localStorage.setItem(STORAGE_KEY, sanitizeWidth(width))
 }

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -4,10 +4,6 @@ import {
     VIS_TYPE_LINE_LIST,
     VIS_TYPE_PIVOT_TABLE,
 } from '@dhis2/analytics'
-import {
-    PRIMARY_PANEL_WIDTH,
-    ACCESSORY_PANEL_MIN_PX_AT_END,
-} from './accessoryPanelConstants.js'
 import { getConditionsFromVisualization } from './conditions.js'
 import { getRequestOptions } from './getRequestOptions.js'
 import { getAdaptedUiLayoutByType } from './layout.js'
@@ -74,9 +70,4 @@ export const getDefaultSorting = () => ({
     direction: 'default',
 })
 
-export const getUserSidebarWidth = () =>
-    Math.min(
-        getUserSidebarWidthFromLocalStorage(),
-        window.innerWidth -
-            (PRIMARY_PANEL_WIDTH + ACCESSORY_PANEL_MIN_PX_AT_END)
-    )
+export const getUserSidebarWidth = getUserSidebarWidthFromLocalStorage


### PR DESCRIPTION
No JIRA ticket

---

### Key features

1. Ensures the width written to local storage is always an integer

---

### Description

I opted to sanitise both on read and write. This covers an edge case for users who have a broken app already, with an invalid width in local storage.

---

### TODO

-   [x] Manual testing

---
