### PR TITLE
fix: reduce resizehandle interaction area on left side [DHIS2-17923]

### DIFF
--- a/src/components/MainSidebar/MainSidebar.module.css
+++ b/src/components/MainSidebar/MainSidebar.module.css
@@ -42,9 +42,9 @@
 .resizeHandle {
     position: absolute;
     height: 100%;
-    /* Interaction area extends 8px left and
-     * right of the sidebar border */
-    width: 17px;
+    /* Interaction area extends 1px left and
+     * 8px right of the sidebar border */
+    width: 10px;
     right: -8px;
     cursor: col-resize;
 }
@@ -54,9 +54,7 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    /* Blue line extends 1px left and right
-     * from sidebar border */
-    left: 7px;
+    left: 0;
     width: 3px;
     pointer-events: none;
     opacity: 0;

--- a/src/components/MainSidebar/useResizableAccessorySidebar.js
+++ b/src/components/MainSidebar/useResizableAccessorySidebar.js
@@ -18,8 +18,9 @@ const createWidthWithinBoundsCalculator = (event, startWidth) => {
     const isKeyboardMode = event.type === 'focus'
     const rect = element.getBoundingClientRect()
     const minWidth = ACCESSORY_PANEL_MIN_WIDTH
-    // Take center of draghandle on X-axis as starting point
-    const startPageX = Math.ceil(rect.left + rect.width / 2)
+    /* This needs to correspond with right edge of the accessory sidebar
+     * which is 2px right of the left edge of the resize handle */
+    const startPageX = Math.ceil(rect.left + 2)
     const maxPageX = window.innerWidth - ACCESSORY_PANEL_MIN_PX_AT_END
     const maxDeltaX = maxPageX - startPageX
     const maxWidth = startWidth + maxDeltaX


### PR DESCRIPTION
Implements [DHIS2-17923](https://dhis2.atlassian.net/browse/DHIS2-17923)

---

### Key features

1. allow grabbing the drag handle besides the resize handle

---

### Description

I've reduced the space on the left of the resize-handle. Before I used to have some transparent pixels there that would also trigger the interaction, as per the specs. Since those made the drag handle inaccessible with the mouse, I've had to remove most of it. Since the border is 1px and the resize-handle is 3 px, the resize-handle still "sticks out" by 1 px on the left. I've kept the 8 px on the right, so the interaction is still 10px wide. I think this is enough for users to trigger the interaction without too much effort. This does mean that the interaction area is now asymmetrical, which is probably  slightly odd, but still better than having a very narrow symmetrical interaction area.

---

### Screenshots

Mouse can now grab the scrollbar:
<img width="977" alt="draghandle_draggable" src="https://github.com/user-attachments/assets/4abb03b6-c20d-42d0-bcd1-9d6e77920908">

[DHIS2-17923]: https://dhis2.atlassian.net/browse/DHIS2-17923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ