### PR TITLE
chore: skip ReportPortal integration for Dependabot PRs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -36,10 +36,13 @@ const reportPortalConfig = [
     },
 ]
 
+const isDependabotPR = process.env.GITHUB_ACTOR === 'dependabot[bot]'
+
 const isReportPortalSetup =
     process.env.REPORTPORTAL_API_KEY !== undefined &&
     process.env.REPORTPORTAL_ENDPOINT !== undefined &&
-    process.env.REPORTPORTAL_PROJECT !== undefined
+    process.env.REPORTPORTAL_PROJECT !== undefined &&
+    !isDependabotPR
 
 module.exports = {
     transformIgnorePatterns: [


### PR DESCRIPTION
This PR disables ReportPortal integration when a PR is created by Dependabot, preventing 401 errors caused by missing API keys or secrets in these PRs.

