### PR TITLE
chore: remove numTestsKeptInMemory from cypress config because default behaviour is better

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -80,8 +80,6 @@ module.exports = defineConfig({
         video: true,
         // Enabled to reduce the risk of out-of-memory issues
         experimentalMemoryManagement: true,
-        // Set to a low number to reduce the risk of out-of-memory issues
-        numTestsKeptInMemory: 5,
         /* When allowing 1 retry on CI, the test suite will pass if
          * it's flaky. And/but we also get to identify flaky tests on the
          * Cypress Dashboard. */


### PR DESCRIPTION
No JIRA issue available, 

Having `numTestsKeptInMemory` set to a low number can make local debugging using `cy:open`difficult. Normally you can hover over steps to see the state of the DOM in each one. However, when the number of tests in the current test file exceed the value of `numTestsKeptInMemory`, you well start seeing message saying `The snapshot is missing. Displaying current state of the DOM` for the first tests in the file.

After inspecting [the Cypress docs](https://docs.cypress.io/guides/references/configuration#Global), it turns out that the default behaviour is actually what we want:
> The number of tests for which snapshots and command data are kept in memory. `numTestsKeptInMemory` is set to `50` by default during `cypress open` and set to `0` by default during `cypress run`. Reduce this number if you are experiencing high memory consumption in your browser during a test run.

This way we should not encounter out-of-memory errors on CI (which uses `cypress run`), and we should be able to visually debug tests locally using `cypress open`.

Also see [this Slack thread](https://dhis2.slack.com/archives/G3TL0J145/p1729152230795329)