### PR TITLE
chore: release workflow fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,9 @@ jobs:
         runs-on: ubuntu-latest
         if: >
             ${{ !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]' &&
-            !contains(github.event.head_commit.message, '[skip ci]') &&
-            !contains(github.event.head_commit.message, '[skip release]') &&
-            !startsWith(github.event.head_commit.message, 'chore') }}
+            github.actor != 'dependabot[bot]' }}
+        outputs:
+            build_exists: ${{ steps.check_build.outputs.build_exists }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -40,33 +39,39 @@ jobs:
               run: npx semantic-release
               env:
                   GITHUB_TOKEN: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
-                  DEBUG: '@semantic-release/commit-analyzer'
+
+            - name: Set build_exists output
+              id: check_build
+              run: |
+                  if ls build/bundle/line-listing-*.zip 1> /dev/null 2>&1; then
+                      echo "build_exists=yes" >> $GITHUB_OUTPUT
+                  else
+                      echo "build_exists=no" >> $GITHUB_OUTPUT
+                  fi
 
             - name: Publish to AppHub
+              if: ${{ steps.check_build.outputs.build_exists == 'yes' }}
               run: yarn run d2-app-scripts publish
 
     report-release-result:
         runs-on: ubuntu-latest
         needs: release
-        if: >
-            ${{ !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]' &&
-            !contains(github.event.head_commit.message, '[skip ci]') &&
-            !contains(github.event.head_commit.message, '[skip release]') }}
+        if: ${{ always() }}
         steps:
             - name: Checkout code
+              if: ${{ needs.release.outputs.build_exists == 'yes' && success() }}
               uses: actions/checkout@v4
               with:
                   ref: master
                   fetch-depth: 0
 
             - name: Extract version
-              if: success()
+              if: ${{ needs.release.outputs.build_exists == 'yes' && success() }}
               id: extract_version
               uses: Saionaro/extract-package-version@v1.3.0
 
             - name: Send success message to analytics-internal-bot slack channel
-              if: success()
+              if: ${{ needs.release.outputs.build_exists == 'yes' && success() }}
               id: slack_success
               uses: slackapi/slack-github-action@v1.27.0
               with:


### PR DESCRIPTION
There are 3 main improvements to the workflow to help solve all the failing builds:

1. Instead of complex if statements in the gh workflow file (they aren't even working anyway!),
use commit_analyzer config to prevent release for our [skip release] and [skip ci] PRs.

2. Publishing to AppHub fails if there is no build file, which there won't be in the
case of chores and [skip release]. So add an if statement that checks that a build
was made. The output gets set to "yes" if there is a build.

3. The report-release-result job should always run. But it should only report a success
message if there is a build and the release step was successful (which is not only
the build file but also whether it was published to apphub)


Here's some workflow outputs from an example app that demonstrate the above changes in a test repo:
build_exists has been set to true and Publish AppHub runs: https://github.com/jenniferarnesen/dhis2-ci-demo/actions/runs/11667460947/job/32484827377

Skip publishing to App hub when [skip release] (even when the commit was a fix or feature): https://github.com/jenniferarnesen/dhis2-ci-demo/actions/runs/11681915720/job/32527955692#step:5:55