### PR TITLE
chore: use enableAutoLogin for handling Cypress login correctly

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,4 +1,7 @@
+import { enableAutoLogin } from '@dhis2/cypress-commands'
 import './commands.js'
+
+enableAutoLogin()
 
 Cypress.on('uncaught:exception', (err) => {
     // This prevents a benign error:
@@ -19,7 +22,6 @@ Cypress.on('uncaught:exception', (err) => {
     }
 })
 
-const LOGIN_ENDPOINT = 'dhis-web-commons-security/login.action'
 const SESSION_COOKIE_NAME = 'JSESSIONID'
 const LOCAL_STORAGE_KEY = 'DHIS2_BASE_URL'
 
@@ -36,24 +38,8 @@ const findSessionCookieForBaseUrl = (baseUrl, cookies) =>
     )
 
 before(() => {
-    const username = Cypress.env('dhis2Username')
-    const password = Cypress.env('dhis2Password')
     const baseUrl = Cypress.env('dhis2BaseUrl')
     const instanceVersion = Cypress.env('dhis2InstanceVersion')
-
-    cy.request({
-        url: `${baseUrl}/${LOGIN_ENDPOINT}`,
-        method: 'POST',
-        form: true,
-        followRedirect: true,
-        body: {
-            j_username: username,
-            j_password: password,
-            '2fa_code': '',
-        },
-    }).should((response) => {
-        expect(response.status).to.eq(200)
-    })
 
     cy.getAllCookies()
         .should((cookies) => {


### PR DESCRIPTION
### Key features

1.use enableAutoLogin for handling login correctly

---

### Description

The .action endpoint has been removed in 42.
The enableAutoLogin function from cypress-commands handles correctly the login for different instance versions.
