### PR TITLE
chore: clear visualization by going to base route instead of new

### DIFF
--- a/public/push-analytics.json
+++ b/public/push-analytics.json
@@ -25,6 +25,6 @@
     },
     "clearVisualization": {
         "strategy": "navigateToUrl",
-        "steps": [{ "goto": "{{appUrl}}/#/new" }]
+        "steps": [{ "goto": "{{appUrl}}/#/" }]
     }
 }


### PR DESCRIPTION
I found out that there was a small mistake in the push-analytics instructions. Visiting `/#/new` would show an error view instead of a the "Getting started" view. And while this technically still "clears the visualization" (the chart is no longer in the DOM), it's better to change the route to the home path which does show the "Getting started" view to avoid confusion when debugging issues in push-analytics.