### PR TITLE
fix: ensure hyperlinks work when using the upcoming global shell [DHIS2-19274]

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "26.13.3",
+        "@dhis2/analytics": "^26.13.3",
         "@dhis2/app-runtime": "^3.13.2",
         "@dhis2/ui": "^9.15.0",
         "@dnd-kit/core": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf",
+        "@dhis2/analytics": "26.13.3",
         "@dhis2/app-runtime": "^3.13.2",
         "@dhis2/ui": "^9.15.0",
         "@dnd-kit/core": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "cy:run": "start-server-and-test 'yarn start' http://localhost:3000 'yarn cypress run --env networkMode=live'"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^11.8.1",
+        "@dhis2/cli-app-scripts": "^11.8.2",
         "@dhis2/cli-style": "^10.7.3",
         "@dhis2/cypress-commands": "^10.0.6",
         "@dhis2/cypress-plugins": "^10.0.6",
@@ -37,7 +37,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.12.0",
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf",
         "@dhis2/app-runtime": "^3.13.2",
         "@dhis2/ui": "^9.15.0",
         "@dnd-kit/core": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2123,10 +2123,9 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.12.0":
-  version "26.12.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.12.0.tgz#5c153048fcd76fee13bfb297af3d344f4069dc2f"
-  integrity sha512-Ou1lH1iDxnpzOliGu9OkbRKOmxcqsojTa0zq8HlccJbMjtHmpdnp8deWJ7KgQFz+A7dpuHgsPbvcaMROBIxyrg==
+"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf":
+  version "26.13.2"
+  resolved "git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf"
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"
@@ -2144,12 +2143,12 @@
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/app-adapter@11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-11.8.1.tgz#625055ef9a6749da400d51251b7f0883da5fcf4e"
-  integrity sha512-x1gnWMGy3JTU7zx4TWQ5IZ7jbV0cxIxQHqImg35bwe+r/twAq0Q92J9WaVaCce6POaHjgJkiLpgPtZyqsQZyQg==
+"@dhis2/app-adapter@11.8.2":
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-11.8.2.tgz#18538c647358d8450999a2769a39a34e357101c6"
+  integrity sha512-rfZjSXhjLVsfbb2DwHiAqx85/l71ngZIn9CN4jph30mGksCCcNwA9jJx0cW9ZVEK3FfFk18wPo2PKAW2DU6MTg==
   dependencies:
-    "@dhis2/pwa" "11.8.1"
+    "@dhis2/pwa" "11.8.2"
     moment "^2.24.0"
 
 "@dhis2/app-runtime@^3.10.6", "@dhis2/app-runtime@^3.13.2":
@@ -2194,15 +2193,15 @@
   dependencies:
     post-robot "^10.0.46"
 
-"@dhis2/app-shell@11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-11.8.1.tgz#b3b020aa7b9d8e9fb916f74a7340a6e7d82302b5"
-  integrity sha512-PS6XFK/o0lNUKzYDHv5T383MbVH/X8hQG3bYAYd8cmlyuEr8nm1V4Glb4YdHDMbUe+7ErzYk0LqF9/qcP8lXfg==
+"@dhis2/app-shell@11.8.2":
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-11.8.2.tgz#fa05d8964980e45a276a271b54ba2f4e16ef5131"
+  integrity sha512-iGz4p4PY44k8E+HOUpc2kCr9+fk4HNq7dUrD0YsfOpnJfxf1/2aArNSBqz89dDOBzjYaBxrUg8byyrhxbYuI2w==
   dependencies:
-    "@dhis2/app-adapter" "11.8.1"
+    "@dhis2/app-adapter" "11.8.2"
     "@dhis2/app-runtime" "^3.10.6"
     "@dhis2/d2-i18n" "^1.1.1"
-    "@dhis2/pwa" "11.8.1"
+    "@dhis2/pwa" "11.8.2"
     "@dhis2/ui" "^9.8.9"
     classnames "^2.2.6"
     moment "^2.29.1"
@@ -2216,10 +2215,10 @@
     typeface-roboto "^0.0.75"
     typescript "^5.6.3"
 
-"@dhis2/cli-app-scripts@^11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-11.8.1.tgz#136b98401b7d941d5d4dc02b381f4bf21e7ef7be"
-  integrity sha512-8RpxfQfkZuvu/0f7xeDg9CPs2LF0l3VrtR7fLxyy1CX8X699RTp+QyQwgbNyP08jKZh6ZC71hpQFeioXYBIl7Q==
+"@dhis2/cli-app-scripts@^11.8.2":
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-11.8.2.tgz#669f73bdcdb272f0c619f495bced1740dc009093"
+  integrity sha512-rn+vqY9CZqK9bDjO4sEdSbUoI63hsvY8LSehzcvqAgqlM2lXViuYfU2H99b5bCo2WSZiBl5yNYS+pcYwH4/JjA==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -2229,7 +2228,7 @@
     "@babel/preset-env" "^7.14.7"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "11.8.1"
+    "@dhis2/app-shell" "11.8.2"
     "@dhis2/cli-helpers-engine" "^3.2.0"
     "@jest/core" "^27.0.6"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.4"
@@ -2351,10 +2350,10 @@
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-3.1.2.tgz#65b8ad2da8cd2f72bc8b951049a6c9d1b97af3e9"
   integrity sha512-eM0jjLOWvtXWqSFp5YC4DHFpkP8Y1D2eUwGV7MBWjni+o27oesVan+oT7WHeOeLdlAd4acRJrnaaAyB4Ck1wGQ==
 
-"@dhis2/pwa@11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-11.8.1.tgz#d7feef92ac2308a246015628bc67af6c0f8d7b62"
-  integrity sha512-33mtGqCUrSzxT+54ys7JMhk9CQemvxq52S8PYxFqBt2J+j/3xzNeMbIf/MGlQ0IcLrRjkMdzWXBJIhK0EQFM1w==
+"@dhis2/pwa@11.8.2":
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-11.8.2.tgz#9fe027cff6588d73916289843547ecbc42bc8f1a"
+  integrity sha512-3BGCLp42Bt3f/flTt0OU44HL9vMsR9W1mj9MloQRnw0Fos6qibW0hUlyj6dzZhIStCDo90Vebb54cC22Eb6M/A==
   dependencies:
     idb "^6.0.0"
     workbox-core "^6.1.5"
@@ -5898,11 +5897,6 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
 
-ci-info@^3.7.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
-  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
-
 cidr-regex@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/cidr-regex/-/cidr-regex-3.1.1.tgz#ba1972c57c66f61875f18fd7dd487469770b571d"
@@ -8686,13 +8680,6 @@ find-versions@^5.1.0:
   dependencies:
     semver-regex "^4.0.5"
 
-find-yarn-workspace-root@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
-  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
-  dependencies:
-    micromatch "^4.0.2"
-
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -11380,17 +11367,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stable-stringify@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz#addb683c2b78014d0b78d704c2fcbdf0695a60e2"
-  integrity sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==
-  dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    isarray "^2.0.5"
-    jsonify "^0.0.1"
-    object-keys "^1.1.1"
-
 json-stable-stringify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz#611c23e814db375527df851193db59dd2af27f45"
@@ -11436,7 +11412,7 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonify@^0.0.1, jsonify@~0.0.0:
+jsonify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
   integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
@@ -11537,13 +11513,6 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
-
-klaw-sync@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
-  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
-  dependencies:
-    graceful-fs "^4.1.11"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -13212,7 +13181,7 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
-open@^7.3.1, open@^7.4.2:
+open@^7.3.1:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -13568,27 +13537,6 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==
-
-patch-package@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
-  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
-  dependencies:
-    "@yarnpkg/lockfile" "^1.1.0"
-    chalk "^4.1.2"
-    ci-info "^3.7.0"
-    cross-spawn "^7.0.3"
-    find-yarn-workspace-root "^2.0.0"
-    fs-extra "^9.0.0"
-    json-stable-stringify "^1.0.2"
-    klaw-sync "^6.0.0"
-    minimist "^1.2.6"
-    open "^7.4.2"
-    rimraf "^2.6.3"
-    semver "^7.5.3"
-    slash "^2.0.0"
-    tmp "^0.0.33"
-    yaml "^2.2.2"
 
 path-browserify@^1.0.0:
   version "1.0.1"
@@ -14371,11 +14319,6 @@ postcss@^8.3.5, postcss@^8.4.23, postcss@^8.4.33, postcss@^8.4.38, postcss@^8.4.
     nanoid "^3.3.7"
     picocolors "^1.0.1"
     source-map-js "^1.2.0"
-
-postinstall-postinstall@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
-  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -15456,13 +15399,6 @@ rfdc@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -15980,11 +15916,6 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
-
-slash@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
-  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -18527,11 +18458,6 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@^2.2.2:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.0.tgz#aef9bb617a64c937a9a748803786ad8d3ffe1e98"
-  integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==
 
 yaml@^2.3.4:
   version "2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2123,9 +2123,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf":
-  version "26.13.2"
-  resolved "git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf"
+"@dhis2/analytics@26.13.3":
+  version "26.13.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.13.3.tgz#cf887e3f4cd9af7ad8968a9cc4171f95c9980d11"
+  integrity sha512-a11qX7Z/DF71Ac5eZD8+m0Xt1VObA0CBb8efZP4CFslXKkUK0c1WySTYWK86qTGoYNTPCJ6A/GacyZY8o/SsoQ==
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2123,7 +2123,7 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@26.13.3":
+"@dhis2/analytics@^26.13.3":
   version "26.13.3"
   resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.13.3.tgz#cf887e3f4cd9af7ad8968a9cc4171f95c9980d11"
   integrity sha512-a11qX7Z/DF71Ac5eZD8+m0Xt1VObA0CBb8efZP4CFslXKkUK0c1WySTYWK86qTGoYNTPCJ6A/GacyZY8o/SsoQ==


### PR DESCRIPTION
Implements [DHIS2-19274](https://dhis2.atlassian.net/browse/DHIS2-19274)

**Requires https://github.com/dhis2/analytics/pull/1770**

---

### Key features

1. Uses new version of @dhis2/analytics with fixes for hyperlinks in markdown editor and get-link helpers
2. Uses new version of @dhis2/cli-app-scripts to ensure page template has a base target set to `_top`

---

### TODO

- [x] Dashboard tested
- [x] Tested with and without the global shell
- [x] d2-ci dependency replaced


App and plugin can be tested on https://test.e2e.dhis2.org/analytics-42dev


[DHIS2-19274]: https://dhis2.atlassian.net/browse/DHIS2-19274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ