### PR TITLE
fix:  restore navigation between line lists using the browser address bar [DHIS2-19387]

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -84,7 +84,7 @@ import StartScreen from './Visualization/StartScreen.js'
 import { Visualization } from './Visualization/Visualization.js'
 
 // Used to avoid repeating `history` listener calls -- see below
-let lastLocationKey
+let lastLocation
 
 const dimensionFields = () =>
     'dimension,dimensionType,filter,program[id],programStage[id],optionSet[id],valueType,legendSet[id],repetition,items[dimensionItem~rename(id)]'
@@ -335,10 +335,15 @@ const App = () => {
             // Avoid duplicate actions for the same update object. This also
             // avoids a loop, because dispatching a pop state effect below also
             // triggers listeners again (but with the same location object key)
-            if (location.key === lastLocationKey) {
+            const { key, pathname, search } = location
+            if (
+                key === lastLocation?.key &&
+                pathname === lastLocation?.pathname &&
+                search === lastLocation?.search
+            ) {
                 return
             }
-            lastLocationKey = location.key
+            lastLocation = location
             // Dispatch this event for external routing listeners to observe,
             // e.g. global shell
             const popStateEvent = new PopStateEvent('popstate', {


### PR DESCRIPTION
Related to [DHIS2-19381](https://dhis2.atlassian.net/browse/DHIS2-19381) and [DHIS2-19387](https://dhis2.atlassian.net/browse/DHIS2-19387)

Pretty much the same changes for DV and maps:
https://github.com/dhis2/maps-app/pull/3508
https://github.com/dhis2/data-visualizer-app/pull/3375

### Screenshots


https://github.com/user-attachments/assets/17ce549f-0fb8-4072-9dcb-f0033e4bd66b




[DHIS2-19381]: https://dhis2.atlassian.net/browse/DHIS2-19381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-19387]: https://dhis2.atlassian.net/browse/DHIS2-19387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ