### PR TITLE
chore: remove use of deprecated cache package in GHA

### DIFF
--- a/.github/workflows/dhis2-preview-pr.yml
+++ b/.github/workflows/dhis2-preview-pr.yml
@@ -26,8 +26,8 @@ jobs:
               with:
                   node-version: 18.x
 
-            - uses: c-hive/gha-yarn-cache@v2
-            - run: yarn install --frozen-lockfile
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
 
             - name: Build
               run: yarn d2-app-scripts build --standalone

--- a/.github/workflows/dhis2-verify-commits.yml
+++ b/.github/workflows/dhis2-verify-commits.yml
@@ -9,7 +9,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: c-hive/gha-yarn-cache@v2
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
@@ -23,7 +22,6 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-            - uses: c-hive/gha-yarn-cache@v2
             - run: yarn install --frozen-lockfile
             - id: commitlint
               # This will return a config file with a .js extensions for @dhis2/cli-style ^10.4.3


### PR DESCRIPTION
### Key features

1. remove deprecated package used in GHA

---

### Description

See: 
https://github.com/c-hive/gha-yarn-cache?tab=readme-ov-file#deprecated
https://github.com/actions/toolkit/blob/main/packages/cache/README.md
