### PR TITLE
fix: use correct icon in most viewed list (DHIS2-18470)

### DIFF
--- a/src/components/Visualization/StartScreen.js
+++ b/src/components/Visualization/StartScreen.js
@@ -1,4 +1,8 @@
-import { VisTypeIcon, useCachedDataQuery } from '@dhis2/analytics'
+import {
+    VisTypeIcon,
+    useCachedDataQuery,
+    VIS_TYPE_LINE_LIST,
+} from '@dhis2/analytics'
 import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { colors } from '@dhis2/ui'
@@ -124,7 +128,7 @@ const StartScreen = ({ error, setLoadError }) => {
                                     >
                                         <span className={styles.visIcon}>
                                             <VisTypeIcon
-                                                type={vis.type}
+                                                type={VIS_TYPE_LINE_LIST}
                                                 useSmall
                                                 color={colors.grey600}
                                             />


### PR DESCRIPTION
Implements [DHIS2-18470](https://dhis2.atlassian.net/browse/DHIS2-18470)

---

### Key features

1. use correct icon in Most viewed list

---

### Description

The icon used in the Most viewed list was the default column chart visualization.
The reason was that the visualization objects returned in the most viewed list didn't have the `type` so the icon used was the default fallback icon (colum chart visualization).

---

### TODO

- [ ] Dashboard tested N/A
- [ ] Tests added (Cypress and/or Jest) N/A
- [ ] Docs added N/A
- [ ] i18n strings generated N/A
- [ ] d2-ci dependency replaced N/A
- [x] Tester approved (Jennifer)

---

### Screenshots

Before:
<img width="572" alt="Screenshot 2025-04-22 at 14 51 03" src="https://github.com/user-attachments/assets/a748348e-debe-491d-b731-88a1bf05dde6" />

After:
<img width="572" alt="Screenshot 2025-04-22 at 14 50 56" src="https://github.com/user-attachments/assets/89d33dc4-b03d-4d66-a1b0-e1016fc8566f" />


[DHIS2-18470]: https://dhis2.atlassian.net/browse/DHIS2-18470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ