### PR TITLE
chore: fix test visualizations cleanup in Cypress

### DIFF
--- a/cypress/integration/conditions/optionSetCondition.cy.js
+++ b/cypress/integration/conditions/optionSetCondition.cy.js
@@ -263,7 +263,7 @@ describe('Option set condition', () => {
         // Table and tooltips should show the correct labels for option set
         assertTableChipAndTooltip()
 
-        const AO_NAME = `TEST option set ${new Date().toLocaleString()}`
+        const AO_NAME = `OPTION-SET-${Date.now()}`
         saveVisualization(AO_NAME)
 
         expectAOTitleToContain(AO_NAME)

--- a/cypress/integration/fileMenu.cy.js
+++ b/cypress/integration/fileMenu.cy.js
@@ -166,7 +166,7 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        const AO_NAME = `TEST ${new Date().toLocaleString()} - "saved, valid: save" state`
+        const AO_NAME = `TEST-${Date.now()}-valid-save`
 
         saveVisualization(AO_NAME)
 
@@ -204,7 +204,7 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        const AO_NAME = `TEST ${new Date().toLocaleString()} - "saved, valid: data" state`
+        const AO_NAME = `TEST-${Date.now()}-valid-data`
 
         saveVisualization(AO_NAME)
 
@@ -243,7 +243,7 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        const AO_NAME = `TEST ${new Date().toLocaleString()} - "dirty" state`
+        const AO_NAME = `TEST-${Date.now()}-dirty`
 
         saveVisualization(AO_NAME)
 

--- a/cypress/integration/fileMenu.cy.js
+++ b/cypress/integration/fileMenu.cy.js
@@ -166,7 +166,7 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        const AO_NAME = `TEST-${Date.now()}-valid-save`
+        const AO_NAME = `FILE-MENU-${Date.now()}-VALID-SAVE`
 
         saveVisualization(AO_NAME)
 
@@ -204,7 +204,7 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        const AO_NAME = `TEST-${Date.now()}-valid-data`
+        const AO_NAME = `FILE-MENU-${Date.now()}-VALID-DATA`
 
         saveVisualization(AO_NAME)
 
@@ -243,7 +243,7 @@ describe('file menu', () => {
 
         clickMenubarUpdateButton()
 
-        const AO_NAME = `TEST-${Date.now()}-dirty`
+        const AO_NAME = `FILE-MENU-${Date.now()}-DIRTY`
 
         saveVisualization(AO_NAME)
 

--- a/cypress/integration/options.cy.js
+++ b/cypress/integration/options.cy.js
@@ -222,7 +222,7 @@ describe(['>=40'], 'ou hierarchy', () => {
         getTableRows().eq(0).find('td').eq(0).containsExact(NAME_WITH_HIERARCHY)
 
         // save / load - hierarchy is still shown
-        const AO_NAME = `TEST ${new Date().toLocaleString()}`
+        const AO_NAME = `OPTIONS-${Date.now()}`
         saveVisualization(AO_NAME)
         expectAOTitleToContain(AO_NAME)
         expectTableToBeVisible()

--- a/cypress/integration/orgUnitDimension.cy.js
+++ b/cypress/integration/orgUnitDimension.cy.js
@@ -195,7 +195,7 @@ describe(`Org unit dimension`, () => {
         ])
 
         cy.log('saves AO')
-        const AO_NAME = `TEST ${new Date().toLocaleString()}`
+        const AO_NAME = `ORGUNIT-DIMENSION-${Date.now()}`
         saveVisualization(AO_NAME)
         expectAOTitleToContain(AO_NAME)
 

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -70,8 +70,8 @@ const deleteVisualizationWithUid = (uid) =>
 
 describe('rename', () => {
     it('replace existing name works correctly', () => {
-        const AO_NAME = `TEST RENAME ${new Date().toLocaleString()}`
-        const UPDATED_AO_NAME = AO_NAME + ' superduper'
+        const AO_NAME = `RENAME-${Date.now()}`
+        const UPDATED_AO_NAME = AO_NAME + '-superduper'
         setupTable()
 
         // save
@@ -101,9 +101,9 @@ describe('rename', () => {
     })
 
     it('add and change and delete name and description', () => {
-        const AO_NAME = `TEST RENAME ${new Date().toLocaleString()}`
-        const AO_DESC = 'with description'
-        const AO_DESC_UPDATED = AO_DESC + ' edited'
+        const AO_NAME = `RENAME-${Date.now()}`
+        const AO_DESC = 'w/description'
+        const AO_DESC_UPDATED = AO_DESC + '-edited'
         setupTable()
 
         // save
@@ -159,8 +159,8 @@ describe('rename', () => {
     })
 
     it('handles failure when renaming', () => {
-        const AO_NAME = `TEST RENAME ${new Date().toLocaleString()}`
-        const UPDATED_AO_NAME = AO_NAME + ' superduper'
+        const AO_NAME = `RENAME-${Date.now()}`
+        const UPDATED_AO_NAME = AO_NAME + '-superduper'
         setupTable()
 
         // save
@@ -194,8 +194,8 @@ describe('rename', () => {
 
 describe('save', () => {
     it('new AO with name saves correctly (event)', () => {
-        const AO_NAME = `TEST event ${new Date().toLocaleString()}`
-        const UPDATED_AO_NAME = AO_NAME + ' superduper'
+        const AO_NAME = `EVENT-${Date.now()}`
+        const UPDATED_AO_NAME = AO_NAME + '-superduper'
         setupTable()
 
         // save with a name
@@ -239,8 +239,8 @@ describe('save', () => {
     })
 
     it(['>=41'], 'new AO with name saves correctly (TE)', () => {
-        const AO_NAME = `TEST TE ${new Date().toLocaleString()}`
-        const UPDATED_AO_NAME = AO_NAME + ' superduper'
+        const AO_NAME = `TE-${Date.now()}`
+        const UPDATED_AO_NAME = AO_NAME + '-superduper'
 
         // set up a simple TE line list
         goToStartPage()
@@ -299,7 +299,7 @@ describe('save', () => {
     })
 
     it('new AO with sorted table saves correctly', () => {
-        const AO_NAME = `TEST SORTING ${new Date().toLocaleString()}`
+        const AO_NAME = `SORTING-${Date.now()}`
         setupTable()
 
         // save with a name
@@ -349,7 +349,7 @@ describe('save', () => {
     })
 
     it('new AO saves correctly after adding/removing sorting', () => {
-        const AO_NAME = `TEST SORTING TOGGLING ${new Date().toLocaleString()}`
+        const AO_NAME = `SORTING-TOGGLING-${Date.now()}`
         setupTable()
 
         // save with a name
@@ -396,8 +396,8 @@ describe('save', () => {
         const AO_DAY = '29'
         const AO_MONTH = 'Dec'
         const AO_YEAR = '2022'
-        const AO_UNTITLED = 'Untitled Line list'
-        const UPDATED_AO_NAME = `TEST ${new Date().toLocaleString()}`
+        const AO_UNTITLED = 'Untitled'
+        const UPDATED_AO_NAME = `TEST-${Date.now()}`
         setupTable()
 
         cy.log('Save for the first time')
@@ -454,7 +454,7 @@ describe('save', () => {
 
     it('"save" a copied AO created by others works after editing', () => {
         const AO_NAME = 'E2E: Enrollment - Percentage'
-        const COPIED_AO_NAME = `${AO_NAME} - copied ${new Date().toLocaleString()}`
+        const COPIED_AO_NAME = `${AO_NAME}-copied-${Date.now()}`
 
         // opens an AO created by others
         goToAO('MKwZRjXiyAJ')

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -59,7 +59,7 @@ const setupTable = () => {
     expectTableToBeVisible()
 }
 
-const uidRe = /\/[a-zA-Z][a-zA-Z0-9]{10}$/
+const uidRe = /\/([a-zA-Z][a-zA-Z0-9]{10})$/
 
 const deleteVisualizationWithUid = (uid) =>
     cy.request({

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -70,7 +70,7 @@ const deleteVisualizationWithUid = (uid) =>
 
 describe('rename', () => {
     it('replace existing name works correctly', () => {
-        const AO_NAME = `RENAME-${Date.now()}`
+        const AO_NAME = `SAVE-${Date.now()}-RENAME`
         const UPDATED_AO_NAME = AO_NAME + '-superduper'
         setupTable()
 
@@ -101,7 +101,7 @@ describe('rename', () => {
     })
 
     it('add and change and delete name and description', () => {
-        const AO_NAME = `RENAME-${Date.now()}`
+        const AO_NAME = `SAVE-${Date.now()}-RENAME`
         const AO_DESC = 'w/description'
         const AO_DESC_UPDATED = AO_DESC + '-edited'
         setupTable()
@@ -159,7 +159,7 @@ describe('rename', () => {
     })
 
     it('handles failure when renaming', () => {
-        const AO_NAME = `RENAME-${Date.now()}`
+        const AO_NAME = `SAVE-${Date.now()}-RENAME`
         const UPDATED_AO_NAME = AO_NAME + '-superduper'
         setupTable()
 
@@ -194,7 +194,7 @@ describe('rename', () => {
 
 describe('save', () => {
     it('new AO with name saves correctly (event)', () => {
-        const AO_NAME = `EVENT-${Date.now()}`
+        const AO_NAME = `SAVE-${Date.now()}-EVENT`
         const UPDATED_AO_NAME = AO_NAME + '-superduper'
         setupTable()
 
@@ -239,7 +239,7 @@ describe('save', () => {
     })
 
     it(['>=41'], 'new AO with name saves correctly (TE)', () => {
-        const AO_NAME = `TE-${Date.now()}`
+        const AO_NAME = `SAVE-${Date.now()}-TE`
         const UPDATED_AO_NAME = AO_NAME + '-superduper'
 
         // set up a simple TE line list
@@ -299,7 +299,7 @@ describe('save', () => {
     })
 
     it('new AO with sorted table saves correctly', () => {
-        const AO_NAME = `SORTING-${Date.now()}`
+        const AO_NAME = `SAVE-${Date.now()}-SORTING`
         setupTable()
 
         // save with a name
@@ -349,7 +349,7 @@ describe('save', () => {
     })
 
     it('new AO saves correctly after adding/removing sorting', () => {
-        const AO_NAME = `SORTING-TOGGLING-${Date.now()}`
+        const AO_NAME = `SAVE-${Date.now()}-SORTING-TOGGLING`
         setupTable()
 
         // save with a name
@@ -397,7 +397,7 @@ describe('save', () => {
         const AO_MONTH = 'Dec'
         const AO_YEAR = '2022'
         const AO_UNTITLED = 'Untitled'
-        const UPDATED_AO_NAME = `TEST-${Date.now()}`
+        const UPDATED_AO_NAME = `SAVE-${Date.now()}-NONAME`
         setupTable()
 
         cy.log('Save for the first time')


### PR DESCRIPTION
### Description

The previous PR which implemented the cleanup of all created visualization during Cypress test runs had a bug in the extraction of the ids which prevented those visualizations from being deleted.
The regexp is fixed here to correctly extract the id from the URL.

All the names used for the saved visualization have been shortened and they should be unique.
The full date and time is being replaced with the epoch.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [ ] Docs added N/A
- [ ] d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX) N/A
- [ ] Tester approved (name) N/A
