### PR TITLE
chore: remove 39 support and use anly-e2e-4x format for cypress test instances

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -83,7 +83,7 @@ jobs:
     call-workflow-e2e-prod:
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
         needs: [build, lint, test, setup-matrix]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/support-hardcoded-dev-version
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/hardcoded-dev-version-minor
         with:
             should_record: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record')}}
             spec-group: ${{ needs.setup-matrix.outputs.matrix }}

--- a/cypress/integration/options.cy.js
+++ b/cypress/integration/options.cy.js
@@ -183,7 +183,7 @@ describe('options', () => {
     })
 })
 
-describe(['>=40'], 'ou hierarchy', () => {
+describe('ou hierarchy', () => {
     it('sets organisation unit hierarchy', () => {
         const NAME_WITHOUT_HIERARCHY = 'Ngelehun CHC'
         const NAME_WITH_HIERARCHY = 'Sierra Leone / Bo / Badjia / Ngelehun CHC'
@@ -223,6 +223,7 @@ describe(['>=40'], 'ou hierarchy', () => {
 
         // save / load - hierarchy is still shown
         const AO_NAME = `OPTIONS-${Date.now()}`
+
         saveVisualization(AO_NAME)
         expectAOTitleToContain(AO_NAME)
         expectTableToBeVisible()
@@ -309,14 +310,16 @@ describe('skip rounding', () => {
     it('sets skip rounding for event', () => {
         testSkipRoundingForEvent('3.12')
     })
-    /* Skip rounding for enrollment is implemented in v39 and v40.
-     * However, in our v39/40 test instances the data we use for this
+    /* Skip rounding for enrollment is implemented in v40.
+     * However, in our v40 test instance the data we use for this
      * test is missing, which makes this test fail.
      * Until https://dhis2.atlassian.net/browse/DHIS2-17884 is resolved,
      * we will have to disable tests for these versions. */
+    // VERSION-TOGGLE
     it(['>=41'], 'sets skip rounding for enrollment (41 and above)', () => {
         testSkipRoundingForEnrollment('3.12')
     })
+    // VERSION-TOGGLE
     it(['>=41'], 'sets skip rounding for tracked entity (41 and above)', () => {
         goToStartPage()
 

--- a/src/__tests__/cypressGetExcludedTags.spec.js
+++ b/src/__tests__/cypressGetExcludedTags.spec.js
@@ -1,94 +1,70 @@
 import { getExcludedTags } from '../../cypress/plugins/excludeByVersionTags.js'
 
 describe('get excluded Cypress tags', () => {
-    test('instanceVersion 2.39', () => {
-        expect(getExcludedTags('2.39')).toEqual([
-            '<39',
-            '>39',
-            '>=40',
-            '>40',
-            '>=41',
-            '>41',
-            '>=42',
-        ])
-    })
-
     test('instanceVersion 2.40', () => {
         expect(getExcludedTags('2.40')).toEqual([
-            '<=39',
-            '<39',
             '<40',
             '>40',
             '>=41',
             '>41',
             '>=42',
+            '>42',
+            '>=43',
         ])
     })
 
     test('instanceVersion 2.41-SNAPSHOT', () => {
         expect(getExcludedTags('2.41-SNAPSHOT')).toEqual([
-            '<=39',
-            '<39',
             '<=40',
             '<40',
             '<41',
             '>41',
             '>=42',
+            '>42',
+            '>=43',
         ])
     })
 
     test('instanceVersion dev', () => {
         expect(getExcludedTags('dev')).toEqual([
-            '<=39',
-            '<39',
             '<=40',
             '<40',
-            '<41',
             '<=41',
+            '<41',
             '<42',
+            '<=42',
+            '<43',
         ])
     })
 
     // unexpected argument forms
-    test('instanceVersion 39', () => {
-        expect(getExcludedTags('39')).toEqual([
-            '<39',
-            '>39',
-            '>=40',
+    test('instanceVersion 40-SNAPSHOT.2', () => {
+        expect(getExcludedTags('40-SNAPSHOT.2')).toEqual([
+            '<40',
             '>40',
             '>=41',
             '>41',
             '>=42',
-        ])
-    })
-
-    test('instanceVersion 39-SNAPSHOT.2', () => {
-        expect(getExcludedTags('39-SNAPSHOT.2')).toEqual([
-            '<39',
-            '>39',
-            '>=40',
-            '>40',
-            '>=41',
-            '>41',
-            '>=42',
+            '>42',
+            '>=43',
         ])
     })
 
     test('instanceVersion Dev', () => {
         expect(getExcludedTags('Dev')).toEqual([
-            '<=39',
-            '<39',
             '<=40',
             '<40',
-            '<41',
             '<=41',
+            '<41',
             '<42',
+            '<=42',
+            '<43',
         ])
     })
 
-    test('instanceVersion 2.38', () => {
+    test('instanceVersion 2.39', () => {
         expect(() => {
-            getExcludedTags('2.38')
+            getExcludedTags('2.39')
         }).toThrow()
     })
 })

--- a/src/components/VisualizationOptions/VisualizationOptionsManager.js
+++ b/src/components/VisualizationOptions/VisualizationOptionsManager.js
@@ -4,7 +4,6 @@ import {
     HoverMenuList,
     HoverMenuListItem,
 } from '@dhis2/analytics'
-import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import React, { useState } from 'react'
 import { getOptionsByType } from '../../modules/options/config.js'
@@ -12,14 +11,13 @@ import UpdateVisualizationContainer from '../UpdateButton/UpdateVisualizationCon
 
 const VisualizationOptionsManager = () => {
     const [selectedOptionConfigKey, setSelectedOptionConfigKey] = useState(null)
-    const { serverVersion } = useConfig()
 
     const onOptionsUpdate = (handler) => {
         handler()
         setSelectedOptionConfigKey(null)
     }
 
-    const optionsConfig = getOptionsByType({ serverVersion })
+    const optionsConfig = getOptionsByType()
 
     return (
         <>

--- a/src/modules/options/config.js
+++ b/src/modules/options/config.js
@@ -2,11 +2,11 @@ import { VIS_TYPE_PIVOT_TABLE } from '@dhis2/analytics'
 import lineListConfig from './lineListConfig.js'
 import pivotTableConfig from './pivotTableConfig.js'
 
-export const getOptionsByType = ({ type, serverVersion }) => {
+export const getOptionsByType = (type) => {
     switch (type) {
         case VIS_TYPE_PIVOT_TABLE:
             return pivotTableConfig()
         default:
-            return lineListConfig(serverVersion)
+            return lineListConfig()
     }
 }

--- a/src/modules/options/lineListConfig.js
+++ b/src/modules/options/lineListConfig.js
@@ -9,11 +9,7 @@ import getDataTab from './tabs/data.js'
 import getLegendTab from './tabs/legend.js'
 import getStyleTab from './tabs/style.js'
 
-export default (serverVersion) => {
-    const currentVersion = `${serverVersion.major}.${serverVersion.minor}.${
-        serverVersion.patch || 0
-    }`
-
+export default () => {
     const optionsConfig = [
         getDataTab([
             getDisplayTemplate({
@@ -28,7 +24,7 @@ export default (serverVersion) => {
                     <DisplayDensity />,
                     <FontSize />,
                     <DigitGroupSeparator />,
-                    currentVersion >= '2.40.0' ? <ShowHierarchy /> : null,
+                    <ShowHierarchy />,
                 ]),
             },
         ]),


### PR DESCRIPTION
Implements [DHIS2-19609](https://dhis2.atlassian.net/browse/DHIS2-19609)
and [DHIS2-19574](https://dhis2.atlassian.net/browse/DHIS2-19574)

### Description

1. Remove version toggles in tests and code for 2.39 support
2. Use the branch of the `workflow` repo with the gh action that runs the cypress tests that uses format `anly-e2e-4x`

---

### Quality checklist

- [ ] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [ ] Docs added N/A
- [ ] d2-ci dependency replaced N/A
- [x] Tester approved (Jennifer)


[DHIS2-19609]: https://dhis2.atlassian.net/browse/DHIS2-19609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-19574]: https://dhis2.atlassian.net/browse/DHIS2-19574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ