### PR TITLE
chore: add support for unversioned href in translations (DHIS2-19539)

### DIFF
--- a/config/testSetup.js
+++ b/config/testSetup.js
@@ -1,0 +1,1 @@
+import 'jest-webgl-canvas-mock'

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
     moduleNameMapper: {
         '\\.(css)$': 'identity-obj-proxy',
     },
+    setupFilesAfterEnv: ['<rootDir>/config/testSetup.js'],
     testRunner: 'jest-circus/runner',
     testMatch: [
         '**/src/**/__tests__/**/*.spec.[jt]s?(x)',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "cypress-tags": "^1.2.2",
         "eslint-plugin-cypress": "^2.12.1",
         "identity-obj-proxy": "^3.0.0",
+        "jest-webgl-canvas-mock": "^2.5.3",
         "redux-mock-store": "^1.5.4",
         "semantic-release": "^20",
         "start-server-and-test": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6132,7 +6132,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -6751,6 +6751,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==
 
 cssnano-preset-default@^5.2.14:
   version "5.2.14"
@@ -11173,6 +11178,14 @@ jest-watcher@^28.0.0:
     jest-util "^28.1.3"
     string-length "^4.0.1"
 
+jest-webgl-canvas-mock@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/jest-webgl-canvas-mock/-/jest-webgl-canvas-mock-2.5.3.tgz#22f6c6b27ccb54a0fa49ae24dfdaf144d211ffc7"
+  integrity sha512-aE5ym/VV8hpJgsu/zzmvJ/bhD4vnfAM9TY6TRQxQAy9lo3hxtNfa2rbLFt3Qx31spQd5fhlQHO58Aey6oFDxAA==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-worker@^26.2.1:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
@@ -12574,6 +12587,13 @@ moment@^2.24.0, moment@^2.29.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
+moo-color@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"
+  integrity sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==
+  dependencies:
+    color-name "^1.1.4"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes an issue caused by [DHIS2-19539](https://dhis2.atlassian.net/browse/DHIS2-19539)

### Description

The fix is in the [analytics PR](https://github.com/dhis2/analytics/pull/1779).

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested N/A
- [ ] Cypress and/or Jest tests added/updated N/A
- [ ] Docs added N/A
- [x] d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/1779)
- [x] Tester approved (JJA)

---

### Screenshots

Before:
![Screenshot 2025-05-26 at 15 28 18](https://github.com/user-attachments/assets/c9744e35-f328-41d4-b573-f19ed4b35042)

After:
![Screenshot 2025-05-26 at 15 27 44](https://github.com/user-attachments/assets/429537c6-36cd-44a3-8b74-318b7e2a0a9b)



[DHIS2-19539]: https://dhis2.atlassian.net/browse/DHIS2-19539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ