### PR TITLE
chore: properly cleanup ResizeObserver when component unmounts

### DIFF
--- a/src/components/Visualization/Visualization.jsx
+++ b/src/components/Visualization/Visualization.jsx
@@ -690,11 +690,11 @@ export const Visualization = ({
 
 Visualization.propTypes = {
     displayProperty: PropTypes.string.isRequired,
-    isVisualizationLoading: PropTypes.bool.isRequired,
     visualization: PropTypes.object.isRequired,
     onResponsesReceived: PropTypes.func.isRequired,
     filters: PropTypes.object,
     forDashboard: PropTypes.bool,
+    isVisualizationLoading: PropTypes.bool,
     onColumnHeaderClick: PropTypes.func,
     onDataSorted: PropTypes.func,
     onError: PropTypes.func,


### PR DESCRIPTION
This PR addresses two developer warnings/errors which could potentially be the source of bugs:
1. Callback refs do not have cleanup effects like useEffect does. Instead of returning a function from the callback ref that does `sizeObserver.unobserve(node)`, we now call sizeObserver..disconnect() in the cleanup function of a `useEffect` hook, so when the component unmounts.
2. When the interpretations modal opens, we got this warning: 
    ```Failed prop type: The prop `isVisualizationLoading` is marked as required in `Visualization`, but its value is `undefined`.```. 
    This was fixed by simply making the prop optional. This is fine since we have a default value for it.
