### PR TITLE
fix: avoid arrow function in fields (DHIS2-21914)

### DIFF
--- a/src/api/visualization.js
+++ b/src/api/visualization.js
@@ -1,6 +1,6 @@
 import { getDimensionMetadataFields } from '../modules/visualization.js'
 
-const dimensionFields = () =>
+const dimensionFields =
     'dimension,dimensionType,filter,program[id],programStage[id],optionSet[id],valueType,legendSet[id],repetition,items[dimensionItem~rename(id)]'
 
 export const VISUALIZATION_QUERY = {


### PR DESCRIPTION
Implements [DHIS2-21914](https://dhis2.atlassian.net/browse/DHIS2-21914)

### Description

Clear bug in LL. Adding a function rather than the returned value to the `fields` string. Solved by turning the function into a plain string as it did not take any arguments.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- _N/A_ Dashboard tested
- _N/A_ Cypress and/or Jest tests added/updated
- _N/A_ Docs added
- _N/A_ d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX)
- [x] Tester approved (name)

---

### Screenshots

Before
<img width="2426" height="947" alt="Screenshot_2026-07-30_12-14-42" src="https://github.com/user-attachments/assets/b277f52a-d720-4e01-ac0a-44cc3cd73ca7" />

After
<img width="2426" height="947" alt="Screenshot_2026-07-30_12-27-02" src="https://github.com/user-attachments/assets/37e1cae9-9f3b-4211-98c8-5c9c86d355dc" />

[DHIS2-21914]: https://dhis2.atlassian.net/browse/DHIS2-21914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ